### PR TITLE
fix: escape original_content

### DIFF
--- a/lua/avante/init.lua
+++ b/lua/avante/init.lua
@@ -314,6 +314,7 @@ local function call_openai_api_stream(prompt, original_content, on_chunk, on_com
 end
 
 local function call_ai_api_stream(prompt, original_content, on_chunk, on_complete)
+  original_content = utils.escape(original_content)
   if M.config.provider == "openai" or M.config.provider == "azure" then
     call_openai_api_stream(prompt, original_content, on_chunk, on_complete)
   elseif M.config.provider == "claude" then

--- a/lua/avante/utils.lua
+++ b/lua/avante/utils.lua
@@ -4,4 +4,8 @@ function M.trim_suffix(str, suffix)
   return string.gsub(str, suffix .. "$", "")
 end
 
+function M.escape(str)
+  return string.gsub(str, "([%(%)%.%%%+%-%*%?%[%^%$%]])", "%%%1")
+end
+
 return M


### PR DESCRIPTION
`str:gsub` cannot correctly handle `original_content` if it contains certain Lua special symbols.

For example:
```go
package main

import "strings"

func main() {
	strings.Replace("https://login.xxx.com/query?redirect=https%3A%2F%2Fxx.com", "%2F", "/", -1)
}
```
The problematic symbols are `%2` and `%3`.

Let's fix this.