### PR TITLE
Revert "fix: escape original_content"

### DIFF
--- a/lua/avante/init.lua
+++ b/lua/avante/init.lua
@@ -382,7 +382,6 @@ local function call_openai_api_stream(question, code_lang, code_content, on_chun
 end
 
 local function call_ai_api_stream(question, code_lang, code_content, on_chunk, on_complete)
-  code_content = utils.escape(code_content)
   if M.config.provider == "openai" or M.config.provider == "azure" then
     call_openai_api_stream(question, code_lang, code_content, on_chunk, on_complete)
   elseif M.config.provider == "claude" then

--- a/lua/avante/utils.lua
+++ b/lua/avante/utils.lua
@@ -4,8 +4,4 @@ function M.trim_suffix(str, suffix)
   return string.gsub(str, suffix .. "$", "")
 end
 
-function M.escape(str)
-  return string.gsub(str, "([%(%)%.%%%+%-%*%?%[%^%$%]])", "%%%1")
-end
-
 return M


### PR DESCRIPTION
Reverts yetone/avante.nvim#5

@yuchanns Temporarily reverted because there will be this issue:

<img width="740" alt="image" src="https://github.com/user-attachments/assets/7b3b92aa-9c34-4697-b25d-caf8b0967af0">
<img width="662" alt="image" src="https://github.com/user-attachments/assets/d11f2c24-98f5-4df9-9af1-dd701636b3fb">
