### PR TITLE
feat: support build tiktoken in Linux aarch64

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -30,7 +30,7 @@ define download_release
 	curl -L https://github.com/gptlang/lua-tiktoken/releases/latest/download/tiktoken_core-$1-$2.$(EXT) -o $(BUILD_DIR)/tiktoken_core.$(EXT)
 endef
 
-ifeq ($(ARCH), arm64)
+ifneq ($(filter arm64 aarch64,$(ARCH)),)
     $(BUILD_DIR)/tiktoken_core.$(EXT): $(BUILD_DIR)
 	$(call build_from_source,luajit)
     $(BUILD_DIR)/tiktoken_core-lua51.$(EXT): $(BUILD_DIR)


### PR DESCRIPTION
In Linux Arm64, we get:

```bash
uname -m
aarch64
```