### PR TITLE
fix(ui): invalid buf id on hide the sidebar during generation

### DIFF
--- a/lua/avante/sidebar.lua
+++ b/lua/avante/sidebar.lua
@@ -224,6 +224,9 @@ end
 function Sidebar:update_content(content, focus, callback)
   focus = focus or false
   vim.defer_fn(function()
+    if not self.view.buf then
+      return
+    end
     api.nvim_set_option_value("modifiable", true, { buf = self.view.buf })
     api.nvim_buf_set_lines(self.view.buf, 0, -1, false, vim.split(content, "\n"))
     api.nvim_set_option_value("modifiable", false, { buf = self.view.buf })


### PR DESCRIPTION
When the AI bot is generating answers and users happen to close the sidebar, it occurs:

```

Error executing vim.schedule lua callback: ...local/share/nvim/lazy/avante.nvim/lua/avante/sidebar.lua:231: Invalid 'buffer': Expected Lua number
stack traceback:
	[C]: in function 'nvim_buf_set_lines'
	...local/share/nvim/lazy/avante.nvim/lua/avante/sidebar.lua:231: in function ''
	vim/_editor.lua: in function ''
	vim/_editor.lua: in function <vim/_editor.lua:0>

```