### PR TITLE
feat(ui): add config to turn off hints popup

### DIFF
--- a/README.md
+++ b/README.md
@@ -138,6 +138,10 @@ _See [config.lua#L9](./lua/avante/config.lua) for the full config_
     ---@type string | fun(): any
     list_opener = "copen",
   },
+  --- @class AvanteHintsConfig
+  hints = {
+    enbaled = true,
+  }
 }
 ```
 

--- a/lua/avante/config.lua
+++ b/lua/avante/config.lua
@@ -78,6 +78,10 @@ M.defaults = {
     ---@type string | fun(): any
     list_opener = "copen",
   },
+  --- @class AvanteHintsConfig
+  hints = {
+    enbaled = true,
+  },
 }
 
 ---@type avante.Config
@@ -87,6 +91,10 @@ M.options = {}
 ---@field mappings AvanteConflictMappings
 ---@field highlights AvanteConflictHighlights
 M.diff = {}
+
+---@class AvanteHintsConfig
+---@field enabled boolean
+M.hints = {}
 
 ---@param opts? avante.Config
 function M.setup(opts)

--- a/lua/avante/selection.lua
+++ b/lua/avante/selection.lua
@@ -62,6 +62,9 @@ end
 
 function Selection:setup_autocmds()
   Selection.did_setup = true
+  if Config.hints.enabled == false then
+    return self
+  end
   api.nvim_create_autocmd({ "ModeChanged" }, {
     group = self.augroup,
     pattern = { "n:v", "n:V", "n:" }, -- Entering Visual mode from Normal mode


### PR DESCRIPTION
The default hints popup is displayed every time, which is quite annoying. 
Add a new config 'hints.enabled' to control its display.