### PR TITLE
Revert "fix: construct handler opts in the parse function"

### DIFF
--- a/lua/avante/llm.lua
+++ b/lua/avante/llm.lua
@@ -488,6 +488,7 @@ M.stream = function(question, code_lang, code_content, selected_content_content,
     code_content = code_content,
     selected_code_content = selected_content_content,
   }
+  local handler_opts = { on_chunk = on_chunk, on_complete = on_complete, event_state = nil }
 
   ---@type AvanteCurlOutput
   local spec = nil
@@ -509,7 +510,6 @@ M.stream = function(question, code_lang, code_content, selected_content_content,
 
   ---@param line string
   local function parse_and_call(line)
-    local handler_opts = { on_chunk = on_chunk, on_complete = on_complete, event_state = nil }
     local event = line:match("^event: (.+)$")
     if event then
       handler_opts.event_state = event


### PR DESCRIPTION
Reverts yetone/avante.nvim#78