### PR TITLE
added a check for git root query

### DIFF
--- a/lua/avante/sidebar.lua
+++ b/lua/avante/sidebar.lua
@@ -864,8 +864,8 @@ end
 local function get_project_root()
   local current_file = fn.expand("%:p")
   local current_dir = fn.fnamemodify(current_file, ":h")
-  local git_root = fn.systemlist("git -C " .. fn.shellescape(current_dir) .. " rev-parse --show-toplevel")[1]
-  return git_root or current_dir
+  local git_root = fn.systemlist("git -C " .. fn.shellescape(current_dir) .. " rev-parse --show-toplevel")
+  return (#git_root == 1 and git_root[1]) or current_dir
 end
 
 ---@param sidebar avante.Sidebar


### PR DESCRIPTION
`git -C ...` command produces error on my machine if directory is not a git repository and `.avante_chat_history/` will be created in `fatal: not a git repository` folder.

PS: In my opinion this git command call isn't necessary as the `local current_dir = fn.fnamemodify(current_file, ":h")
` already returns the correct working  directory.