### PR TITLE
fix: code buffer tab buttons should not be hijacked

### DIFF
--- a/lua/avante/config.lua
+++ b/lua/avante/config.lua
@@ -59,9 +59,7 @@ M.defaults = {
   ---Specify the behaviour of avante.nvim
   ---1. auto_apply_diff_after_generation: Whether to automatically apply diff after LLM response.
   ---                                     This would simulate similar behaviour to cursor. Default to false.
-  ---2. cycle_between_open_buffers      : Enable tab cycling between windows. Default to true
   behaviour = {
-    cycle_between_open_buffers = true,
     auto_apply_diff_after_generation = false,
   },
   highlights = {

--- a/lua/avante/sidebar.lua
+++ b/lua/avante/sidebar.lua
@@ -819,9 +819,6 @@ function Sidebar:refresh_winids()
   if self.winids.input then
     table.insert(winids, self.winids.input)
   end
-  if Config.behaviour.cycle_between_open_buffers and self.code.winid then
-    table.insert(winids, self.code.winid)
-  end
 
   local function switch_windows()
     local current_winid = api.nvim_get_current_win()


### PR DESCRIPTION
@aarnphm 

fix https://github.com/yetone/avante.nvim/issues/168