### PR TITLE
fix(openai): add support for Cloudflare's AI-Gateway

### DIFF
--- a/lua/avante/config.lua
+++ b/lua/avante/config.lua
@@ -13,7 +13,7 @@ M.defaults = {
   provider = "claude",
   ---@type AvanteSupportedProvider
   openai = {
-    endpoint = "https://api.openai.com",
+    endpoint = "https://api.openai.com/v1",
     model = "gpt-4o",
     temperature = 0,
     max_tokens = 4096,

--- a/lua/avante/providers/openai.lua
+++ b/lua/avante/providers/openai.lua
@@ -95,7 +95,7 @@ M.parse_curl_args = function(provider, code_opts)
   end
 
   return {
-    url = Utils.trim(base.endpoint, { suffix = "/" }) .. "/v1/chat/completions",
+    url = Utils.trim(base.endpoint, { suffix = "/" }) .. "/chat/completions",
     proxy = base.proxy,
     insecure = base.allow_insecure,
     headers = headers,


### PR DESCRIPTION
When making requests to OpenAI, replace https://api.openai.com/v1 in the URL you’re currently using with https://gateway.ai.cloudflare.com/v1/{account_id}/{gateway_id}/openai.