### PR TITLE
feat: add support of light theme

### DIFF
--- a/lua/avante/config.lua
+++ b/lua/avante/config.lua
@@ -119,6 +119,10 @@ M.defaults = {
   hints = {
     enabled = true,
   },
+  --- @class AvanteThemeConfig
+  --- @field theme "light" | "dark"
+  --- @type string
+  theme = "dark",
 }
 
 ---@type avante.Config

--- a/lua/avante/highlights.lua
+++ b/lua/avante/highlights.lua
@@ -1,12 +1,13 @@
 local api = vim.api
+local Config = require("avante.config")
 
 local M = {
   TITLE = "AvanteTitle",
   REVERSED_TITLE = "AvanteReversedTitle",
   SUBTITLE = "AvanteSubtitle",
   REVERSED_SUBTITLE = "AvanteReversedSubtitle",
-  THRIDTITLE = "AvanteThirdTitle",
-  REVERSED_THRIDTITLE = "AvanteReversedThirdTitle",
+  THIRDTITLE = "AvanteThirdTitle",
+  REVERSED_THIRDTITLE = "AvanteReversedThirdTitle",
   REVERSED_NORMAL = "AvanteReversedNormal",
 }
 
@@ -18,12 +19,22 @@ M.setup = function()
   local normal_float = api.nvim_get_hl(0, { name = "NormalFloat" })
 
   api.nvim_set_hl(0, M.REVERSED_NORMAL, { fg = normal.bg })
-  api.nvim_set_hl(0, M.TITLE, { fg = "#1e222a", bg = "#98c379" })
-  api.nvim_set_hl(0, M.REVERSED_TITLE, { fg = "#98c379" })
-  api.nvim_set_hl(0, M.SUBTITLE, { fg = "#1e222a", bg = "#56b6c2" })
-  api.nvim_set_hl(0, M.REVERSED_SUBTITLE, { fg = "#56b6c2" })
-  api.nvim_set_hl(0, M.THRIDTITLE, { fg = "#ABB2BF", bg = "#353B45" })
-  api.nvim_set_hl(0, M.REVERSED_THRIDTITLE, { fg = "#353B45" })
+
+  if Config.defaults.theme == "light" then
+    api.nvim_set_hl(0, M.TITLE, { fg = "#1e222a", bg = "#98c379" })
+    api.nvim_set_hl(0, M.REVERSED_TITLE, { fg = "#98c379" })
+    api.nvim_set_hl(0, M.SUBTITLE, { fg = "#1e222a", bg = "#7998c3" })
+    api.nvim_set_hl(0, M.REVERSED_SUBTITLE, { fg = "#7998c3" })
+    api.nvim_set_hl(0, M.THIRDTITLE, { fg = "#1e222a", bg = "#a479c3" })
+    api.nvim_set_hl(0, M.REVERSED_THIRDTITLE, { fg = "#a479c3" })
+  else
+    api.nvim_set_hl(0, M.TITLE, { fg = "#1e222a", bg = "#98c379" })
+    api.nvim_set_hl(0, M.REVERSED_TITLE, { fg = "#98c379" })
+    api.nvim_set_hl(0, M.SUBTITLE, { fg = "#1e222a", bg = "#56b6c2" })
+    api.nvim_set_hl(0, M.REVERSED_SUBTITLE, { fg = "#56b6c2" })
+    api.nvim_set_hl(0, M.THIRDTITLE, { fg = "#ABB2BF", bg = "#353B45" })
+    api.nvim_set_hl(0, M.REVERSED_THIRDTITLE, { fg = "#353B45" })
+  end
 
   api.nvim_set_hl(M.hint_ns, "NormalFloat", { fg = normal_float.fg, bg = normal_float.bg })
 

--- a/lua/avante/sidebar.lua
+++ b/lua/avante/sidebar.lua
@@ -431,8 +431,8 @@ function Sidebar:render_input_container()
     self.input_container.winid,
     self.input_container.bufnr,
     header_text,
-    Highlights.THRIDTITLE,
-    Highlights.REVERSED_THRIDTITLE
+    Highlights.THIRDTITLE,
+    Highlights.REVERSED_THIRDTITLE
   )
 end
 


### PR DESCRIPTION
Users can set a light theme by adjusting the config. This allows Avante to better match their setup if they're using a light theme, like I do. :)
Below is a preview from my own nvim
![20240825_00h28m16s_grim](https://github.com/user-attachments/assets/03c36ae9-ca49-406b-a96b-86264c75876a)
