### PR TITLE
feat: update max_tokens for anthropic api (3.5 sonnet)

### DIFF
--- a/lua/avante/config.lua
+++ b/lua/avante/config.lua
@@ -43,7 +43,7 @@ M.defaults = {
     endpoint = "https://api.anthropic.com",
     model = "claude-3-5-sonnet-20240620",
     temperature = 0,
-    max_tokens = 4096,
+    max_tokens = 8192, -- per anthropic august 19 update : https://docs.anthropic.com/en/release-notes/api#august-19th-2024
     ["local"] = false,
   },
   ---@type AvanteGeminiProvider


### PR DESCRIPTION
updating max_tokens for anthropic from 4096 to 8192 per the august 19th update from anthropic raising the max_tokens cap for general availability: https://docs.anthropic.com/en/release-notes/api#august-19th-2024

```
August 19th, 2024

We’ve moved 8,192 token outputs from beta to general availability for Claude 3.5 Sonnet.
```