### PR TITLE
Include ARCH in asset name

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -28,7 +28,7 @@ define build_from_source
 endef
 
 define download_release
-	curl -L https://github.com/gptlang/lua-tiktoken/releases/latest/download/tiktoken_core-$1-$2.$(EXT) -o $(BUILD_DIR)/tiktoken_core.$(EXT)
+	curl -L https://github.com/gptlang/lua-tiktoken/releases/latest/download/tiktoken_core-$1-$(ARCH)-$2.$(EXT) -o $(BUILD_DIR)/tiktoken_core.$(EXT)
 endef
 
 ifeq ($(BUILD_FROM_SOURCE), true)


### PR DESCRIPTION
Currently, the makefile tries to cURL an asset that is no longer part of the latest releases.
- For example, previously the release had the file `tiktoken_core-linux-luajit.so`. 
- Now, the CPU arch is part of the release asset. See https://github.com/gptlang/lua-tiktoken/releases/tag/v0.2.2

This change adds `ARCH` so that we fetch an existing asset. 

I tested this by telling `lazy` to use my own branch and the file downloaded is correct

```
➜  build git:(84fa8df) ls -lh
Permissions Size User Date Modified Name
.rw-r--r--  3.1M rkk  25 Aug 15:50  tiktoken_core.so
```