### PR TITLE
fix: don't automatically setup openai when its not the configured provider

### DIFF
--- a/lua/avante/providers/init.lua
+++ b/lua/avante/providers/init.lua
@@ -251,7 +251,9 @@ M = setmetatable(M, {
       end
     end
 
-    t[k].setup()
+    if k == Config.provider then
+      t[k].setup()
+    end
 
     return t[k]
   end,


### PR DESCRIPTION
When it configured with copilot only, nvim shows `Failed to setup openai. Avante won't work as expected` at start. The related code is here 
https://github.com/yetone/avante.nvim/blob/8cd87ac5de3c7e82fb39d7ab619ef9c5bb26a280/lua/avante/providers/init.lua#L254
and because copilot is [sharing some code from openai](https://github.com/yetone/avante.nvim/blob/8cd87ac5de3c7e82fb39d7ab619ef9c5bb26a280/lua/avante/providers/copilot.lua#L8), so the `setup()` for openai is called and the [`has()`](https://github.com/yetone/avante.nvim/blob/8cd87ac5de3c7e82fb39d7ab619ef9c5bb26a280/lua/avante/providers/init.lua#L240) method may report warnings if it lacks of env vars.

Therefore, a quick fix here is to call the `setup()` only when it was configured, or better to share the openai functions at a lower level?

---

avante version: 8cd87ac5de3c7e82fb39d7ab619ef9c5bb26a280