### PR TITLE
fix: AvanteEdit highlight for visual line mode

### DIFF
--- a/lua/avante/selection.lua
+++ b/lua/avante/selection.lua
@@ -283,22 +283,29 @@ function Selection:create_editing_input()
 
   self.selection = Utils.get_visual_selection_and_range()
 
-  local end_row = self.selection.range.finish.line - 1
-  local end_col = math.min(self.selection.range.finish.col, #code_lines[self.selection.range.finish.line])
+  local start_row
+  local start_col
+  local end_row
+  local end_col
+  if vim.fn.mode() == "V" then
+    start_row = self.selection.range.start.line - 1
+    start_col = 0
+    end_row = self.selection.range.finish.line - 1
+    end_col = #code_lines[self.selection.range.finish.line]
+  else
+    start_row = self.selection.range.start.line - 1
+    start_col = self.selection.range.start.col - 1
+    end_row = self.selection.range.finish.line - 1
+    end_col = math.min(self.selection.range.finish.col, #code_lines[self.selection.range.finish.line])
+  end
 
-  self.selected_code_extmark_id = api.nvim_buf_set_extmark(
-    code_bufnr,
-    SELECTED_CODE_NAMESPACE,
-    self.selection.range.start.line - 1,
-    self.selection.range.start.col - 1,
-    {
-      hl_group = "Visual",
-      hl_mode = "combine",
-      end_row = end_row,
-      end_col = end_col,
-      priority = PRIORITY,
-    }
-  )
+  self.selected_code_extmark_id = api.nvim_buf_set_extmark(code_bufnr, SELECTED_CODE_NAMESPACE, start_row, start_col, {
+    hl_group = "Visual",
+    hl_mode = "combine",
+    end_row = end_row,
+    end_col = end_col,
+    priority = PRIORITY,
+  })
 
   local bufnr = api.nvim_create_buf(false, true)
 


### PR DESCRIPTION
To reproduce: `<Shift-V><Leader>ae`.

Before:

https://github.com/user-attachments/assets/0076f193-5b60-4c23-ab1a-96184d830c06

After:

https://github.com/user-attachments/assets/c237dc4c-d1ef-4820-a9a0-e4ab8e0a4c69

Notes:
- The visual block mode behavior is still wrong, but that seems lower priority.
- It seems like Avante (intentionally?) only supports editing whole lines. So it could also make sense to always use the visual line behavior as an indicator for what's actually being edited.


