### PR TITLE
fix(refresh): add additional sidebar.result check

### DIFF
--- a/lua/avante/init.lua
+++ b/lua/avante/init.lua
@@ -192,6 +192,10 @@ M.refresh = function()
   end
   local curbuf = vim.api.nvim_get_current_buf()
 
+  if not sidebar.result then
+    return
+  end
+
   local focused = sidebar.result.bufnr == curbuf or sidebar.input.bufnr == curbuf
   if focused or not sidebar:is_open() then
     return


### PR DESCRIPTION
Opening Neovim and calling ⁠`AvanteRefresh` immediately throws an error:

```
E5108: Error executing lua: ...r/.local/share/nvim/lazy/avante.nvim/lua/avante/init.lua:195: attempt to index field 'result' (a nil value)
stack traceback:
        ...r/.local/share/nvim/lazy/avante.nvim/lua/avante/init.lua:195: in function <...r/.local/share/nvim/lazy/avante.nvim/lua/avante/init.lua:188>
```
This pull request adds an additional check to ensure `⁠sidebar.result` is available.