### PR TITLE
feat(mapping): plug and expose API

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,6 +26,11 @@ Install `avante.nvim` using [lazy.nvim](https://github.com/folke/lazy.nvim):
   opts = {
     -- add any opts here
   },
+  keys = { -- See https://github.com/yetone/avante.nvim/wiki#keymaps for more info
+    { "<leader>aa", function() require("avante.api").ask() end, desc = "avante: ask", mode = { "n", "v" } },
+    { "<leader>ar", function() require("avante.api").refresh() end, desc = "avante: refresh", mode = "v" },
+    { "<leader>ae", function() require("avante.api").edit() end, desc = "avante: edit", mode = { "n", "v" } },
+  },
   dependencies = {
     "stevearc/dressing.nvim",
     "nvim-lua/plenary.nvim",
@@ -94,9 +99,6 @@ _See [config.lua#L9](./lua/avante/config.lua) for the full config_
     max_tokens = 4096,
   },
   mappings = {
-    ask = "<leader>aa",
-    edit = "<leader>ae",
-    refresh = "<leader>ar",
     --- @class AvanteConflictMappings
     diff = {
       ours = "co",
@@ -112,10 +114,6 @@ _See [config.lua#L9](./lua/avante/config.lua) for the full config_
     submit = {
       normal = "<CR>",
       insert = "<C-s>",
-    },
-    toggle = {
-      debug = "<leader>ad",
-      hint = "<leader>ah",
     },
   },
   hints = { enabled = true },
@@ -207,6 +205,11 @@ The following key bindings are available for use with `avante.nvim`:
 | <kbd>[</kbd><kbd>x</kbd> | move to next conflict |
 | <kbd>[</kbd><kbd>[</kbd> | jump to previous codeblocks (results window) |
 | <kbd>]</kbd><kbd>]</kbd> | jump to next codeblocks (results windows) |
+
+> [!NOTE]
+>
+> If you are using `lazy.nvim`, then all keymap here will be safely set, meaning if `<leader>aa` is already binded, then avante.nvim won't bind this mapping.
+> In this case, user will be responsible for setting up their own. See [notes on keymaps](https://github.com/yetone/avante.nvim/wiki#keymaps) for more details.
 
 ## Highlight Groups
 

--- a/lua/avante/api.lua
+++ b/lua/avante/api.lua
@@ -1,0 +1,27 @@
+local Utils = require("avante.utils")
+
+---@class avante.ApiToggle
+---@operator call(): boolean
+---@field debug ToggleBind.wrap
+---@field hint ToggleBind.wrap
+---
+---@class avante.Api
+---@field ask fun(): boolean
+---@field edit fun(): nil
+---@field refresh fun(): nil
+---@field toggle avante.ApiToggle
+
+return setmetatable({}, {
+  __index = function(t, k)
+    local module = require("avante")
+    ---@class AvailableApi: ApiCaller
+    ---@field api? boolean
+    local has = module[k]
+    if type(has) ~= "table" or not has.api then
+      Utils.warn(k .. " is not a valid avante's API method", { once = true })
+      return
+    end
+    t[k] = has
+    return t[k]
+  end,
+}) --[[@as avante.Api]]

--- a/lua/avante/config.lua
+++ b/lua/avante/config.lua
@@ -88,10 +88,7 @@ M.defaults = {
     },
   },
   mappings = {
-    ask = "<leader>aa",
-    edit = "<leader>ae",
-    refresh = "<leader>ar",
-    --- @class AvanteConflictMappings
+    ---@class AvanteConflictMappings
     diff = {
       ours = "co",
       theirs = "ct",
@@ -108,6 +105,10 @@ M.defaults = {
       normal = "<CR>",
       insert = "<C-s>",
     },
+    -- NOTE: The following will be safely set by avante.nvim
+    ask = "<leader>aa",
+    edit = "<leader>ae",
+    refresh = "<leader>ar",
     toggle = {
       debug = "<leader>ad",
       hint = "<leader>ah",


### PR DESCRIPTION
By default, avante will safely set certain keymap if lazy is not yet set. 

All documented API, Plug binding as well as exposed API will be link [here](https://github.com/yetone/avante.nvim/wikis#keymaps)

Signed-off-by: Aaron Pham <contact@aarnphm.xyz>
