### PR TITLE
config.lua: improve check for `img-clip`

### DIFF
--- a/lua/avante/config.lua
+++ b/lua/avante/config.lua
@@ -187,7 +187,7 @@ function M.setup(opts)
 end
 
 M.support_paste_image = function()
-  local supported = Utils.has("img-clip.nvim")
+  local supported = Utils.has("img-clip.nvim") or Utils.has("img-clip")
   if not supported then
     Utils.warn("img-clip.nvim is not installed. Pasting image will be disabled.", { once = true })
   end


### PR DESCRIPTION
If img clip is installed not by lazy, it is checked agains `package.loaded` in `Util.has`. But the correct key to check there is `img-clip`, not `img-clip.nvim`.

Tested.