### PR TITLE
refactor(config): allow prompt overriding in opts

### DIFF
--- a/lua/avante/config.lua
+++ b/lua/avante/config.lua
@@ -152,6 +152,12 @@ M.defaults = {
   hints = {
     enabled = true,
   },
+  ---@class AvanteLLMConfig
+  llm = {
+    system_prompt = "",
+    planning_mode_system_prompt_tpl = "",
+    editing_mode_system_prompt_tpl = "",
+  },
 }
 
 ---@type avante.Config
@@ -165,6 +171,12 @@ M.diff = {}
 ---@class AvanteHintsConfig
 ---@field enabled boolean
 M.hints = {}
+
+---@class AvanteLLMConfig
+---@field system_prompt string
+---@field planning_mode_user_prompt_tpl string
+---@field editing_mode_user_prompt_tpl string
+M.llm = {}
 
 ---@param opts? avante.Config
 function M.setup(opts)

--- a/lua/avante/llm.lua
+++ b/lua/avante/llm.lua
@@ -14,7 +14,7 @@ M.CANCEL_PATTERN = "AvanteLLMEscape"
 ------------------------------Prompt and type------------------------------
 
 ---@alias AvanteSystemPrompt string
-local system_prompt = [[
+local default_system_prompt = [[
 You are an excellent programming expert.
 ]]
 
@@ -108,7 +108,10 @@ M.stream = function(opts)
   local mode = opts.mode or "planning"
   local provider = Config.provider
 
-  local user_prompt_tpl = mode == "planning" and planning_mode_user_prompt_tpl or editing_mode_user_prompt_tpl
+  local system_prompt = Config.llm.system_prompt or default_system_prompt
+  local user_prompt_tpl = mode == "planning"
+      and (Config.llm.planning_mode_user_prompt_tpl or planning_mode_user_prompt_tpl)
+    or (Config.llm.editing_mode_user_prompt_tpl or editing_mode_user_prompt_tpl)
 
   -- Check if the instructions contains an image path
   local image_paths = {}


### PR DESCRIPTION
## Motivation

Given that the README clearly states “avante.nvim only recommends using the claude-3.5-sonnet model” and “We do not accept changes to the code or prompts to accommodate other models”, is it possible to provide an option allowing users to override the default prompts with those suitable for their specific models?

## Modification

- Add `llm` config section to Avante setup
Introduce `planning_mode_user_prompt_tpl`, `editing_mode_user_prompt_tpl` and `system_prompt` fields
- Update LLM prompt logic to use custom config options if available

