### PR TITLE
fix: use the original prompts

### DIFF
--- a/README.md
+++ b/README.md
@@ -351,7 +351,6 @@ We would like to express our heartfelt gratitude to the contributors of the foll
 | [ChatGPT.nvim](https://github.com/jackMort/ChatGPT.nvim) | Apache 2.0 License | Calculation of tokens count | https://github.com/yetone/avante.nvim/blob/main/lua/avante/utils/tokens.lua |
 | [img-clip.nvim](https://github.com/HakonHarnes/img-clip.nvim) | MIT License | Clipboard image support | https://github.com/yetone/avante.nvim/blob/main/lua/avante/clipboard.lua |
 | [copilot.lua](https://github.com/zbirenbaum/copilot.lua) | MIT License | Copilot support | https://github.com/yetone/avante.nvim/blob/main/lua/avante/providers/copilot.lua |
-| [Claude Engineer](https://github.com/Doriandarko/claude-engineer) | No License | Some prompts | https://github.com/yetone/avante.nvim/blob/main/lua/avante/llm.lua |
 
 The high quality and ingenuity of these projects' source code have been immensely beneficial throughout our development process. We extend our sincere thanks and respect to the authors and contributors of these projects. It is the selfless dedication of the open-source community that drives projects like avante.nvim forward.
 

--- a/lua/avante/providers/cohere.lua
+++ b/lua/avante/providers/cohere.lua
@@ -31,9 +31,14 @@ local M = {}
 M.api_key_name = "CO_API_KEY"
 
 M.parse_message = function(opts)
+  local user_prompt = ""
+  for _, user_prompt_ in ipairs(opts.user_prompts) do
+    user_prompt = user_prompt .. "\n\n" .. user_prompt_
+  end
+
   return {
     preamble = opts.system_prompt,
-    message = opts.user_prompt,
+    message = user_prompt,
   }
 end
 

--- a/lua/avante/providers/gemini.lua
+++ b/lua/avante/providers/gemini.lua
@@ -24,9 +24,11 @@ M.parse_message = function(opts)
   end
 
   -- insert a part into parts
-  table.insert(message_content, {
-    text = opts.user_prompt,
-  })
+  for _, user_prompt in ipairs(opts.user_prompts) do
+    table.insert(message_content, {
+      text = user_prompt,
+    })
+  end
 
   return {
     systemInstruction = {

--- a/lua/avante/providers/init.lua
+++ b/lua/avante/providers/init.lua
@@ -10,7 +10,7 @@ local Dressing = require("avante.ui.dressing")
 ---
 ---@class AvantePromptOptions: table<[string], string>
 ---@field system_prompt string
----@field user_prompt string
+---@field user_prompts string[]
 ---@field image_paths? string[]
 ---
 ---@class AvanteBaseMessage

--- a/lua/avante/providers/openai.lua
+++ b/lua/avante/providers/openai.lua
@@ -28,6 +28,11 @@ local M = {}
 M.api_key_name = "OPENAI_API_KEY"
 
 M.parse_message = function(opts)
+  local user_prompt = ""
+  for _, user_prompt_ in ipairs(opts.user_prompts) do
+    user_prompt = user_prompt .. "\n\n" .. user_prompt_
+  end
+
   ---@type string | OpenAIMessage[]
   local user_content
   if Config.behaviour.support_paste_from_clipboard and opts.image_paths and #opts.image_paths > 0 then
@@ -40,9 +45,9 @@ M.parse_message = function(opts)
         },
       })
     end
-    table.insert(user_content, { type = "text", text = opts.user_prompt })
+    table.insert(user_content, { type = "text", text = user_prompt })
   else
-    user_content = opts.user_prompt
+    user_content = user_prompt
   end
 
   return {

--- a/lua/avante/selection.lua
+++ b/lua/avante/selection.lua
@@ -407,8 +407,11 @@ function Selection:create_editing_input()
       end, 0)
     end
 
+    local filetype = api.nvim_get_option_value("filetype", { buf = code_bufnr })
+
     Llm.stream({
       file_content = code_content,
+      code_lang = filetype,
       selected_code = self.selection.content,
       instructions = input,
       mode = "editing",


### PR DESCRIPTION
The new prompts do not seem to be very satisfactory, for example, there are issues with the generated code quality and overlapping line numbers. Therefore, the prompts have been rolled back for now, but the contextual functionality is still retained and will be used in the future.