### PR TITLE
feat: add horizontal layout

### DIFF
--- a/lua/avante/config.lua
+++ b/lua/avante/config.lua
@@ -138,8 +138,8 @@ M.defaults = {
   },
   windows = {
     wrap = true, -- similar to vim.o.wrap
-    width = 30, -- default % based on available width
-    height = 30, -- default % based on available height
+    width = 30, -- default % based on available width in vertical layout
+    height = 30, -- default % based on available height in horizontal layout
     sidebar_header = {
       align = "center", -- left, center, right for title
       rounded = true,

--- a/lua/avante/config.lua
+++ b/lua/avante/config.lua
@@ -18,6 +18,8 @@ M.defaults = {
   -- For most providers that we support we will determine this automatically.
   -- If you wish to use a given implementation, then you can override it here.
   tokenizer = "tiktoken",
+  ---@type "vertical" | "horizontal"
+  layout = "vertical",
   ---@type AvanteSupportedProvider
   openai = {
     endpoint = "https://api.openai.com/v1",
@@ -137,6 +139,7 @@ M.defaults = {
   windows = {
     wrap = true, -- similar to vim.o.wrap
     width = 30, -- default % based on available width
+    height = 30, -- default % based on available height
     sidebar_header = {
       align = "center", -- left, center, right for title
       rounded = true,

--- a/lua/avante/sidebar.lua
+++ b/lua/avante/sidebar.lua
@@ -1374,6 +1374,26 @@ function Sidebar:create_input()
     end
   end
 
+  local get_position = function()
+    if Config.layout == "vertical" then
+      return "bottom"
+    end
+    return "right"
+  end
+
+  local get_size = function()
+    if Config.layout == "vertical" then
+      return {
+        height = 8,
+      }
+    end
+
+    return {
+      width = "40%",
+      height = api.nvim_win_get_height(self.result.winid),
+    }
+  end
+
   self.input = Split({
     enter = false,
     relative = {
@@ -1381,10 +1401,8 @@ function Sidebar:create_input()
       winid = self.result.winid,
     },
     win_options = vim.tbl_deep_extend("force", get_win_options(), { signcolumn = "yes" }),
-    position = "bottom",
-    size = {
-      height = 8,
-    },
+    position = get_position(),
+    size = get_size(),
   })
 
   local function on_submit()
@@ -1567,12 +1585,39 @@ function Sidebar:render()
   local chat_history = History.load(self.code.bufnr)
 
   local sidebar_height = api.nvim_win_get_height(self.code.winid)
-  local selected_code_size = self:get_selected_code_size()
+  local get_position = function()
+    if Config.layout == "vertical" then
+      return "right"
+    end
+    return "bottom"
+  end
+
+  local get_height = function()
+    local selected_code_size = self:get_selected_code_size()
+    vim.print(selected_code_size)
+    if Config.layout == "horizontal" then
+      return math.floor(Config.windows.height / 100 * api.nvim_win_get_height(self.code.winid))
+    end
+
+    if Config.layout == "vertical" then
+      return math.max(1, api.nvim_win_get_height(self.code.winid) - selected_code_size - 3 - 8)
+    end
+  end
+
+  local get_width = function()
+    if Config.layout == "vertical" then
+      return math.floor(Config.windows.width / 100 * api.nvim_win_get_width(self.code.winid))
+    end
+
+    if Config.layout == "horizontal" then
+      return math.max(1, api.nvim_win_get_width(self.code.winid))
+    end
+  end
 
   self.result = Split({
     enter = false,
     relative = "editor",
-    position = "right",
+    position = get_position(),
     buf_options = vim.tbl_deep_extend("force", buf_options, {
       modifiable = false,
       swapfile = false,
@@ -1582,8 +1627,8 @@ function Sidebar:render()
     }),
     win_options = get_win_options(),
     size = {
-      width = string.format("%d%%", Config.windows.width),
-      height = math.max(1, sidebar_height - selected_code_size - 3 - 8),
+      width = get_width(),
+      height = get_height(),
     },
   })
 

--- a/lua/avante/sidebar.lua
+++ b/lua/avante/sidebar.lua
@@ -681,7 +681,7 @@ function Sidebar:render_selected_code()
   end
 
   local selected_code_lines_count = 0
-  local selected_code_max_lines_count = 10
+  local selected_code_max_lines_count = 12
 
   if self.code.selection ~= nil then
     local selected_code_lines = vim.split(self.code.selection.content, "\n")
@@ -1225,6 +1225,9 @@ function Sidebar:create_selected_code()
       },
     })
     self.selected_code:mount()
+    if Config.layout == "horizontal" then
+      api.nvim_win_set_height(self.result.winid, api.nvim_win_get_height(self.result.winid) - selected_code_size - 3)
+    end
   end
 end
 
@@ -1388,9 +1391,11 @@ function Sidebar:create_input()
       }
     end
 
+    local selected_code_size = self:get_selected_code_size()
+
     return {
       width = "40%",
-      height = api.nvim_win_get_height(self.result.winid),
+      height = math.max(1, api.nvim_win_get_height(self.result.winid) - selected_code_size),
     }
   end
 
@@ -1584,7 +1589,6 @@ end
 function Sidebar:render()
   local chat_history = History.load(self.code.bufnr)
 
-  local sidebar_height = api.nvim_win_get_height(self.code.winid)
   local get_position = function()
     if Config.layout == "vertical" then
       return "right"
@@ -1594,7 +1598,7 @@ function Sidebar:render()
 
   local get_height = function()
     local selected_code_size = self:get_selected_code_size()
-    vim.print(selected_code_size)
+
     if Config.layout == "horizontal" then
       return math.floor(Config.windows.height / 100 * api.nvim_win_get_height(self.code.winid))
     end


### PR DESCRIPTION
#123 
Add the support of horizontal layout, you could change layout through setting `layout = "horizontal"` in setup.
example
```
function M.config()
  local avante = require "avante"

  avante.setup({
    -- your configuration comes here
    provider = "copilot",
    layout = "horizontal",
  })

end
``` 
![20240831_19h26m49s_grim](https://github.com/user-attachments/assets/5cea0318-f328-4afc-8ad5-6676a54fa547)


