### PR TITLE
fix(windows): check nil

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -32,7 +32,7 @@ else
 endif
 else
 $1:
-	LUA_VERSION=$1 sh ./build.sh
+	LUA_VERSION=$1 bash ./build.sh
 endif
 endef
 

--- a/lua/avante/sidebar.lua
+++ b/lua/avante/sidebar.lua
@@ -1484,7 +1484,9 @@ function Sidebar:render(opts)
   opts = opts or {}
   local chat_history = Path.history.load(self.code.bufnr)
 
-  local get_position = function() return (opts and opts.win and opts.win.position) and opts.win.position or Config.windows.position end
+  local get_position = function()
+    return (opts and opts.win and opts.win.position) and opts.win.position or Config.windows.position
+  end
 
   local get_height = function()
     local selected_code_size = self:get_selected_code_size()

--- a/lua/avante/sidebar.lua
+++ b/lua/avante/sidebar.lua
@@ -1484,7 +1484,7 @@ function Sidebar:render(opts)
   opts = opts or {}
   local chat_history = Path.history.load(self.code.bufnr)
 
-  local get_position = function() return (opts and opts.win.position) and opts.win.position or Config.windows.position end
+  local get_position = function() return (opts and opts.win and opts.win.position) and opts.win.position or Config.windows.position end
 
   local get_height = function()
     local selected_code_size = self:get_selected_code_size()


### PR DESCRIPTION
FIX1 - sidebar was checking `(opts and opts.win.position) ... ~= nil` missing the case where opts.win = nil

FIX2 - Makefile should run the build.sh with bash, not sh, to correspond to the she-bang in `build.sh`
- previously (when bashism `set -eo pipefail` was present in `build.sh`) this was causing issues on POSIX-only shells (such as `dash` which I use for `/bin/sh`)