### PR TITLE
remove prefix msg when build because stdout/stderr can be table object

### DIFF
--- a/lua/avante/api.lua
+++ b/lua/avante/api.lua
@@ -73,9 +73,9 @@ M.build = function(opts)
       local output = stdout
       if #output == 0 then
         table.insert(output, "")
-        Utils.info("outputs: " .. output)
+        Utils.info(output)
       else
-        Utils.error("error: " .. stderr)
+        Utils.error(stderr)
       end
     end
   end)


### PR DESCRIPTION
In my case, stderr can be a table value when the build failed. I remove the prefix string because the log level is already set in https://github.com/yetone/avante.nvim/blob/main/lua/avante/utils/init.lua#L301-L315

<img width="1597" alt="img" src="https://github.com/user-attachments/assets/6e95f4dd-00e3-460e-b959-99b23f7c0e65">
