### PR TITLE
Fix list join argument in avante#build function

### DIFF
--- a/autoload/avante.vim
+++ b/autoload/avante.vim
@@ -1,4 +1,4 @@
 function avante#build(...) abort
   let l:source = get(a:, 1, v:false)
-  return join(luaeval("require('avante_lib').load()"),"\n",luaeval("require('avante.api').build(_A)", l:source), "\n")
+  return join([ luaeval("require('avante_lib').load()"), "\n", luaeval("require('avante.api').build(_A)", l:source) ], "\n")
 endfunction


### PR DESCRIPTION
Changes:
- Correct the `join` function arguments to be a list by adding square brackets around them
- This ensures proper concatenation of strings from `luaeval("require('avante_lib').load()")` and `luaeval("require('avante.api').build(_A)", l:source)`

Note that even after this commit is merged, still #453 error exists.