### PR TITLE
feat/fix: AvanteEdit should immediately switch into insert mode

### DIFF
--- a/lua/avante/selection.lua
+++ b/lua/avante/selection.lua
@@ -318,6 +318,7 @@ function Selection:create_editing_input()
   local winid = api.nvim_open_win(bufnr, true, win_opts)
 
   self.editing_input_winid = winid
+  vim.cmd("startinsert")
 
   api.nvim_set_option_value("wrap", false, { win = winid })
   api.nvim_set_option_value("cursorline", true, { win = winid })


### PR DESCRIPTION
Dear Maintainers,

I suggest that `AvanteEdit` should immediately switch to insert mode, as users most often want to input a prompt.