### PR TITLE
fix: use `vim.o.lines`/`vim.o.columns` when calculating sidebar height/width

### DIFF
--- a/lua/avante/sidebar.lua
+++ b/lua/avante/sidebar.lua
@@ -1503,17 +1503,13 @@ function Sidebar:render(opts)
   local get_height = function()
     local selected_code_size = self:get_selected_code_size()
 
-    if self:get_layout() == "horizontal" then
-      return math.floor(Config.windows.height / 100 * api.nvim_win_get_height(self.code.winid))
-    end
+    if self:get_layout() == "horizontal" then return math.floor(Config.windows.height / 100 * vim.o.lines) end
 
     return math.max(1, api.nvim_win_get_height(self.code.winid) - selected_code_size - 3 - 8)
   end
 
   local get_width = function()
-    if self:get_layout() == "vertical" then
-      return math.floor(Config.windows.width / 100 * api.nvim_win_get_width(self.code.winid))
-    end
+    if self:get_layout() == "vertical" then return math.floor(Config.windows.width / 100 * vim.o.columns) end
 
     return math.max(1, api.nvim_win_get_width(self.code.winid))
   end


### PR DESCRIPTION
Behavior changed in #420 making the width/height calculated based on the code window, while previously it was based on the overall Neovim editor size. This caused windows to be too small when the user had multiple windows open.

Example behavior, when configured with `windows.width = 30`:

Before fix:

![2024-09-12_00-31-35_region](https://github.com/user-attachments/assets/fc25aa0a-163e-450b-8500-46ad7d3fedd7)

After fix:

![2024-09-12_00-38-02_region](https://github.com/user-attachments/assets/806f5ed7-3cef-4af2-aa78-43769806fd55)

