### PR TITLE
fix(sidebar): allow /clear to be run multiple times

### DIFF
--- a/lua/avante/sidebar.lua
+++ b/lua/avante/sidebar.lua
@@ -1093,13 +1093,19 @@ function Sidebar:get_commands()
       if cb then cb(args) end
     end,
     clear = function(args, cb)
-      local chat_history = {}
-      Path.history.save(self.code.bufnr, chat_history)
-      self:update_content("Chat history cleared", { focus = false, scroll = false })
-      vim.defer_fn(function()
-        self:close()
-        if cb then cb(args) end
-      end, 1000)
+      local chat_history = Path.history.load(self.code.bufnr)
+      if next(chat_history) ~= nil then
+        chat_history = {}
+        Path.history.save(self.code.bufnr, chat_history)
+        self:update_content("Chat history cleared", { focus = false, scroll = false })
+        vim.defer_fn(function()
+          self:close()
+          if cb then cb(args) end
+        end, 1000)
+      else
+        self:update_content("Chat history is already empty", { focus = false, scroll = false })
+        vim.defer_fn(function() self:close() end, 1000)
+      end
     end,
     lines = function(args, cb)
       if cb then cb(args) end


### PR DESCRIPTION
**Issue**: Running `/clear` multiple times in the sidebar triggers the following warning message:

```bash
E5108: Error executing lua: ....local/share/nvim/lazy/plenary.nvim/lua/plenary/path.lua:737: ENOENT: no such file or directory: /home/dd/.local/state/nvim/avante/__home__dd__Desktop__curl.c.json
stack traceback:
  [C]: in function 'assert'
  ....local/share/nvim/lazy/plenary.nvim/lua/plenary/path.lua:737: in function 'write'
  ...t/.local/share/nvim/lazy/avante.nvim/lua/avante/path.lua:54: in function 'save'
  ...local/share/nvim/lazy/avante.nvim/lua/avante/sidebar.lua:1111: in function 'callback'
  ...local/share/nvim/lazy/avante.nvim/lua/avante/sidebar.lua:1231: in function 'handle_submit'
  ...local/share/nvim/lazy/avante.nvim/lua/avante/sidebar.lua:1341: in function <...local/share/nvim/lazy/avante.nvim/lua/avante/sidebar.lua:1331>
```

**Fix**: This implementation adds a check to see if the history is empty. If it is, the sidebar will simply close without performing any additional actions, thereby preventing the error.