### PR TITLE
Add user option for sidebar window focus mapping

### DIFF
--- a/README.md
+++ b/README.md
@@ -154,12 +154,10 @@ require('avante').setup ({
 
 </details>
 
-
 > [!IMPORTANT]
 >
 > For `avante.tokenizers` and templates to work, make sure to call `require('avante_lib').load()` somewhere when entering the editor.
 > We will leave the users to decide where it fits to do this, as this varies among configurations. (But we do recommend running this after where you set your colorscheme)
-
 
 > [!IMPORTANT]
 >
@@ -230,6 +228,10 @@ _See [config.lua#L9](./lua/avante/config.lua) for the full config_
     submit = {
       normal = "<CR>",
       insert = "<C-s>",
+    },
+    sidebar = {
+      switch_windows = "<Tab>",
+      reverse_switch_windows = "<S-Tab>",
     },
   },
   hints = { enabled = true },
@@ -309,21 +311,21 @@ Given its early stage, `avante.nvim` currently supports the following basic func
 
 The following key bindings are available for use with `avante.nvim`:
 
-| Key Binding | Description |
-|-------------|-------------|
-| <kbd>Leader</kbd><kbd>a</kbd><kbd>a</kbd> | show sidebar |
-| <kbd>Leader</kbd><kbd>a</kbd><kbd>r</kbd> | refresh sidebar |
-| <kbd>Leader</kbd><kbd>a</kbd><kbd>e</kbd> | edit selected blocks |
-| <kbd>c</kbd><kbd>o</kbd> | choose ours |
-| <kbd>c</kbd><kbd>t</kbd> | choose theirs |
-| <kbd>c</kbd><kbd>a</kbd> | choose all theirs |
-| <kbd>c</kbd><kbd>0</kbd> | choose none |
-| <kbd>c</kbd><kbd>b</kbd> | choose both |
-| <kbd>c</kbd><kbd>c</kbd> | choose cursor |
-| <kbd>]</kbd><kbd>x</kbd> | move to previous conflict |
-| <kbd>[</kbd><kbd>x</kbd> | move to next conflict |
-| <kbd>[</kbd><kbd>[</kbd> | jump to previous codeblocks (results window) |
-| <kbd>]</kbd><kbd>]</kbd> | jump to next codeblocks (results windows) |
+| Key Binding                               | Description                                  |
+| ----------------------------------------- | -------------------------------------------- |
+| <kbd>Leader</kbd><kbd>a</kbd><kbd>a</kbd> | show sidebar                                 |
+| <kbd>Leader</kbd><kbd>a</kbd><kbd>r</kbd> | refresh sidebar                              |
+| <kbd>Leader</kbd><kbd>a</kbd><kbd>e</kbd> | edit selected blocks                         |
+| <kbd>c</kbd><kbd>o</kbd>                  | choose ours                                  |
+| <kbd>c</kbd><kbd>t</kbd>                  | choose theirs                                |
+| <kbd>c</kbd><kbd>a</kbd>                  | choose all theirs                            |
+| <kbd>c</kbd><kbd>0</kbd>                  | choose none                                  |
+| <kbd>c</kbd><kbd>b</kbd>                  | choose both                                  |
+| <kbd>c</kbd><kbd>c</kbd>                  | choose cursor                                |
+| <kbd>]</kbd><kbd>x</kbd>                  | move to previous conflict                    |
+| <kbd>[</kbd><kbd>x</kbd>                  | move to next conflict                        |
+| <kbd>[</kbd><kbd>[</kbd>                  | jump to previous codeblocks (results window) |
+| <kbd>]</kbd><kbd>]</kbd>                  | jump to next codeblocks (results windows)    |
 
 > [!NOTE]
 >
@@ -332,18 +334,17 @@ The following key bindings are available for use with `avante.nvim`:
 
 ## Highlight Groups
 
-
-| Highlight Group | Description | Notes |
-|-----------------|-------------|-------|
-| AvanteTitle | Title | |
-| AvanteReversedTitle | Used for rounded border | |
-| AvanteSubtitle | Selected code title | |
-| AvanteReversedSubtitle | Used for rounded border | |
-| AvanteThirdTitle | Prompt title | |
-| AvanteReversedThirdTitle | Used for rounded border | |
-| AvanteConflictCurrent | Current conflict highlight | Default to `Config.highlights.diff.current` |
-| AvanteConflictIncoming | Incoming conflict highlight | Default to `Config.highlights.diff.incoming` |
-| AvanteConflictCurrentLabel | Current conflict label highlight | Default to shade of `AvanteConflictCurrent` |
+| Highlight Group             | Description                       | Notes                                        |
+| --------------------------- | --------------------------------- | -------------------------------------------- |
+| AvanteTitle                 | Title                             |                                              |
+| AvanteReversedTitle         | Used for rounded border           |                                              |
+| AvanteSubtitle              | Selected code title               |                                              |
+| AvanteReversedSubtitle      | Used for rounded border           |                                              |
+| AvanteThirdTitle            | Prompt title                      |                                              |
+| AvanteReversedThirdTitle    | Used for rounded border           |                                              |
+| AvanteConflictCurrent       | Current conflict highlight        | Default to `Config.highlights.diff.current`  |
+| AvanteConflictIncoming      | Incoming conflict highlight       | Default to `Config.highlights.diff.incoming` |
+| AvanteConflictCurrentLabel  | Current conflict label highlight  | Default to shade of `AvanteConflictCurrent`  |
 | AvanteConflictIncomingLabel | Incoming conflict label highlight | Default to shade of `AvanteConflictIncoming` |
 
 See [highlights.lua](./lua/avante/highlights.lua) for more information
@@ -371,6 +372,7 @@ If one wish to custom prompts for each mode, `avante.nvim` will check for projec
 the following patterns: `*.{mode}.avanterules`.
 
 The rules for root hierarchy:
+
 - lsp workspace folders
 - lsp root_dir
 - root pattern of filename of the current buffer
@@ -381,14 +383,15 @@ The rules for root hierarchy:
   <summary>Example folder structure for custom prompt</summary>
 
 If you have the following structure:
-  ```bash
+
+```bash
 .
 ├── .git/
 ├── typescript.planning.avanterules
 ├── snippets.editing.avanterules
 └── src/
 
-  ```
+```
 
 - `typescript.planning.avanterules` will be used for `planning` mode
 - `snippets.editing.avanterules`` will be used for `editing` mode
@@ -399,7 +402,6 @@ If you have the following structure:
 > [!important]
 >
 > `*.avanterules` is a jinja template file, in which will be rendered using [minijinja](https://github.com/mitsuhiko/minijinja). See [templates](https://github.com/yetone/avante.nvim/blob/main/lua/avante/templates) for example on how to extend current templates.
-
 
 ## TODOs
 
@@ -427,14 +429,14 @@ See [wiki](https://github.com/yetone/avante.nvim/wiki) for more recipes and tric
 
 We would like to express our heartfelt gratitude to the contributors of the following open-source projects, whose code has provided invaluable inspiration and reference for the development of avante.nvim:
 
-| Nvim Plugin | License | Functionality | Location |
-| --- | --- | --- | --- |
-| [git-conflict.nvim](https://github.com/akinsho/git-conflict.nvim) | No License | Diff comparison functionality | [lua/avante/diff.lua](https://github.com/yetone/avante.nvim/blob/main/lua/avante/diff.lua) |
-| [ChatGPT.nvim](https://github.com/jackMort/ChatGPT.nvim) | Apache 2.0 License | Calculation of tokens count | [avante/utils/tokens.lua](https://github.com/yetone/avante.nvim/blob/main/lua/avante/utils/tokens.lua) |
-| [img-clip.nvim](https://github.com/HakonHarnes/img-clip.nvim) | MIT License | Clipboard image support | [avante/clipboard.lua](https://github.com/yetone/avante.nvim/blob/main/lua/avante/clipboard.lua) |
-| [copilot.lua](https://github.com/zbirenbaum/copilot.lua) | MIT License | Copilot support | [avante/providers/copilot.lua](https://github.com/yetone/avante.nvim/blob/main/lua/avante/providers/copilot.lua) |
-| [jinja.vim](https://github.com/HiPhish/jinja.vim) | MIT License | Template filetype support | [syntax/jinja.vim](https://github.com/yetone/avante.nvim/blob/main/syntax/jinja.vim) |
-| [codecompanion.nvim](https://github.com/olimorris/codecompanion.nvim) | MIT License | Secrets logic support | [avante/providers/init.lua](https://github.com/yetone/avante.nvim/blob/main/lua/avante/providers/init.lua) |
+| Nvim Plugin                                                           | License            | Functionality                 | Location                                                                                                         |
+| --------------------------------------------------------------------- | ------------------ | ----------------------------- | ---------------------------------------------------------------------------------------------------------------- |
+| [git-conflict.nvim](https://github.com/akinsho/git-conflict.nvim)     | No License         | Diff comparison functionality | [lua/avante/diff.lua](https://github.com/yetone/avante.nvim/blob/main/lua/avante/diff.lua)                       |
+| [ChatGPT.nvim](https://github.com/jackMort/ChatGPT.nvim)              | Apache 2.0 License | Calculation of tokens count   | [avante/utils/tokens.lua](https://github.com/yetone/avante.nvim/blob/main/lua/avante/utils/tokens.lua)           |
+| [img-clip.nvim](https://github.com/HakonHarnes/img-clip.nvim)         | MIT License        | Clipboard image support       | [avante/clipboard.lua](https://github.com/yetone/avante.nvim/blob/main/lua/avante/clipboard.lua)                 |
+| [copilot.lua](https://github.com/zbirenbaum/copilot.lua)              | MIT License        | Copilot support               | [avante/providers/copilot.lua](https://github.com/yetone/avante.nvim/blob/main/lua/avante/providers/copilot.lua) |
+| [jinja.vim](https://github.com/HiPhish/jinja.vim)                     | MIT License        | Template filetype support     | [syntax/jinja.vim](https://github.com/yetone/avante.nvim/blob/main/syntax/jinja.vim)                             |
+| [codecompanion.nvim](https://github.com/olimorris/codecompanion.nvim) | MIT License        | Secrets logic support         | [avante/providers/init.lua](https://github.com/yetone/avante.nvim/blob/main/lua/avante/providers/init.lua)       |
 
 The high quality and ingenuity of these projects' source code have been immensely beneficial throughout our development process. We extend our sincere thanks and respect to the authors and contributors of these projects. It is the selfless dedication of the open-source community that drives projects like avante.nvim forward.
 

--- a/README.md
+++ b/README.md
@@ -154,10 +154,12 @@ require('avante').setup ({
 
 </details>
 
+
 > [!IMPORTANT]
 >
 > For `avante.tokenizers` and templates to work, make sure to call `require('avante_lib').load()` somewhere when entering the editor.
 > We will leave the users to decide where it fits to do this, as this varies among configurations. (But we do recommend running this after where you set your colorscheme)
+
 
 > [!IMPORTANT]
 >
@@ -311,21 +313,21 @@ Given its early stage, `avante.nvim` currently supports the following basic func
 
 The following key bindings are available for use with `avante.nvim`:
 
-| Key Binding                               | Description                                  |
-| ----------------------------------------- | -------------------------------------------- |
-| <kbd>Leader</kbd><kbd>a</kbd><kbd>a</kbd> | show sidebar                                 |
-| <kbd>Leader</kbd><kbd>a</kbd><kbd>r</kbd> | refresh sidebar                              |
-| <kbd>Leader</kbd><kbd>a</kbd><kbd>e</kbd> | edit selected blocks                         |
-| <kbd>c</kbd><kbd>o</kbd>                  | choose ours                                  |
-| <kbd>c</kbd><kbd>t</kbd>                  | choose theirs                                |
-| <kbd>c</kbd><kbd>a</kbd>                  | choose all theirs                            |
-| <kbd>c</kbd><kbd>0</kbd>                  | choose none                                  |
-| <kbd>c</kbd><kbd>b</kbd>                  | choose both                                  |
-| <kbd>c</kbd><kbd>c</kbd>                  | choose cursor                                |
-| <kbd>]</kbd><kbd>x</kbd>                  | move to previous conflict                    |
-| <kbd>[</kbd><kbd>x</kbd>                  | move to next conflict                        |
-| <kbd>[</kbd><kbd>[</kbd>                  | jump to previous codeblocks (results window) |
-| <kbd>]</kbd><kbd>]</kbd>                  | jump to next codeblocks (results windows)    |
+| Key Binding | Description |
+|-------------|-------------|
+| <kbd>Leader</kbd><kbd>a</kbd><kbd>a</kbd> | show sidebar |
+| <kbd>Leader</kbd><kbd>a</kbd><kbd>r</kbd> | refresh sidebar |
+| <kbd>Leader</kbd><kbd>a</kbd><kbd>e</kbd> | edit selected blocks |
+| <kbd>c</kbd><kbd>o</kbd> | choose ours |
+| <kbd>c</kbd><kbd>t</kbd> | choose theirs |
+| <kbd>c</kbd><kbd>a</kbd> | choose all theirs |
+| <kbd>c</kbd><kbd>0</kbd> | choose none |
+| <kbd>c</kbd><kbd>b</kbd> | choose both |
+| <kbd>c</kbd><kbd>c</kbd> | choose cursor |
+| <kbd>]</kbd><kbd>x</kbd> | move to previous conflict |
+| <kbd>[</kbd><kbd>x</kbd> | move to next conflict |
+| <kbd>[</kbd><kbd>[</kbd> | jump to previous codeblocks (results window) |
+| <kbd>]</kbd><kbd>]</kbd> | jump to next codeblocks (results windows) |
 
 > [!NOTE]
 >
@@ -334,17 +336,18 @@ The following key bindings are available for use with `avante.nvim`:
 
 ## Highlight Groups
 
-| Highlight Group             | Description                       | Notes                                        |
-| --------------------------- | --------------------------------- | -------------------------------------------- |
-| AvanteTitle                 | Title                             |                                              |
-| AvanteReversedTitle         | Used for rounded border           |                                              |
-| AvanteSubtitle              | Selected code title               |                                              |
-| AvanteReversedSubtitle      | Used for rounded border           |                                              |
-| AvanteThirdTitle            | Prompt title                      |                                              |
-| AvanteReversedThirdTitle    | Used for rounded border           |                                              |
-| AvanteConflictCurrent       | Current conflict highlight        | Default to `Config.highlights.diff.current`  |
-| AvanteConflictIncoming      | Incoming conflict highlight       | Default to `Config.highlights.diff.incoming` |
-| AvanteConflictCurrentLabel  | Current conflict label highlight  | Default to shade of `AvanteConflictCurrent`  |
+
+| Highlight Group | Description | Notes |
+|-----------------|-------------|-------|
+| AvanteTitle | Title | |
+| AvanteReversedTitle | Used for rounded border | |
+| AvanteSubtitle | Selected code title | |
+| AvanteReversedSubtitle | Used for rounded border | |
+| AvanteThirdTitle | Prompt title | |
+| AvanteReversedThirdTitle | Used for rounded border | |
+| AvanteConflictCurrent | Current conflict highlight | Default to `Config.highlights.diff.current` |
+| AvanteConflictIncoming | Incoming conflict highlight | Default to `Config.highlights.diff.incoming` |
+| AvanteConflictCurrentLabel | Current conflict label highlight | Default to shade of `AvanteConflictCurrent` |
 | AvanteConflictIncomingLabel | Incoming conflict label highlight | Default to shade of `AvanteConflictIncoming` |
 
 See [highlights.lua](./lua/avante/highlights.lua) for more information
@@ -372,7 +375,6 @@ If one wish to custom prompts for each mode, `avante.nvim` will check for projec
 the following patterns: `*.{mode}.avanterules`.
 
 The rules for root hierarchy:
-
 - lsp workspace folders
 - lsp root_dir
 - root pattern of filename of the current buffer
@@ -383,15 +385,14 @@ The rules for root hierarchy:
   <summary>Example folder structure for custom prompt</summary>
 
 If you have the following structure:
-
-```bash
+  ```bash
 .
 ├── .git/
 ├── typescript.planning.avanterules
 ├── snippets.editing.avanterules
 └── src/
 
-```
+  ```
 
 - `typescript.planning.avanterules` will be used for `planning` mode
 - `snippets.editing.avanterules`` will be used for `editing` mode
@@ -402,6 +403,7 @@ If you have the following structure:
 > [!important]
 >
 > `*.avanterules` is a jinja template file, in which will be rendered using [minijinja](https://github.com/mitsuhiko/minijinja). See [templates](https://github.com/yetone/avante.nvim/blob/main/lua/avante/templates) for example on how to extend current templates.
+
 
 ## TODOs
 
@@ -429,14 +431,14 @@ See [wiki](https://github.com/yetone/avante.nvim/wiki) for more recipes and tric
 
 We would like to express our heartfelt gratitude to the contributors of the following open-source projects, whose code has provided invaluable inspiration and reference for the development of avante.nvim:
 
-| Nvim Plugin                                                           | License            | Functionality                 | Location                                                                                                         |
-| --------------------------------------------------------------------- | ------------------ | ----------------------------- | ---------------------------------------------------------------------------------------------------------------- |
-| [git-conflict.nvim](https://github.com/akinsho/git-conflict.nvim)     | No License         | Diff comparison functionality | [lua/avante/diff.lua](https://github.com/yetone/avante.nvim/blob/main/lua/avante/diff.lua)                       |
-| [ChatGPT.nvim](https://github.com/jackMort/ChatGPT.nvim)              | Apache 2.0 License | Calculation of tokens count   | [avante/utils/tokens.lua](https://github.com/yetone/avante.nvim/blob/main/lua/avante/utils/tokens.lua)           |
-| [img-clip.nvim](https://github.com/HakonHarnes/img-clip.nvim)         | MIT License        | Clipboard image support       | [avante/clipboard.lua](https://github.com/yetone/avante.nvim/blob/main/lua/avante/clipboard.lua)                 |
-| [copilot.lua](https://github.com/zbirenbaum/copilot.lua)              | MIT License        | Copilot support               | [avante/providers/copilot.lua](https://github.com/yetone/avante.nvim/blob/main/lua/avante/providers/copilot.lua) |
-| [jinja.vim](https://github.com/HiPhish/jinja.vim)                     | MIT License        | Template filetype support     | [syntax/jinja.vim](https://github.com/yetone/avante.nvim/blob/main/syntax/jinja.vim)                             |
-| [codecompanion.nvim](https://github.com/olimorris/codecompanion.nvim) | MIT License        | Secrets logic support         | [avante/providers/init.lua](https://github.com/yetone/avante.nvim/blob/main/lua/avante/providers/init.lua)       |
+| Nvim Plugin | License | Functionality | Location |
+| --- | --- | --- | --- |
+| [git-conflict.nvim](https://github.com/akinsho/git-conflict.nvim) | No License | Diff comparison functionality | [lua/avante/diff.lua](https://github.com/yetone/avante.nvim/blob/main/lua/avante/diff.lua) |
+| [ChatGPT.nvim](https://github.com/jackMort/ChatGPT.nvim) | Apache 2.0 License | Calculation of tokens count | [avante/utils/tokens.lua](https://github.com/yetone/avante.nvim/blob/main/lua/avante/utils/tokens.lua) |
+| [img-clip.nvim](https://github.com/HakonHarnes/img-clip.nvim) | MIT License | Clipboard image support | [avante/clipboard.lua](https://github.com/yetone/avante.nvim/blob/main/lua/avante/clipboard.lua) |
+| [copilot.lua](https://github.com/zbirenbaum/copilot.lua) | MIT License | Copilot support | [avante/providers/copilot.lua](https://github.com/yetone/avante.nvim/blob/main/lua/avante/providers/copilot.lua) |
+| [jinja.vim](https://github.com/HiPhish/jinja.vim) | MIT License | Template filetype support | [syntax/jinja.vim](https://github.com/yetone/avante.nvim/blob/main/syntax/jinja.vim) |
+| [codecompanion.nvim](https://github.com/olimorris/codecompanion.nvim) | MIT License | Secrets logic support | [avante/providers/init.lua](https://github.com/yetone/avante.nvim/blob/main/lua/avante/providers/init.lua) |
 
 The high quality and ingenuity of these projects' source code have been immensely beneficial throughout our development process. We extend our sincere thanks and respect to the authors and contributors of these projects. It is the selfless dedication of the open-source community that drives projects like avante.nvim forward.
 

--- a/lua/avante/config.lua
+++ b/lua/avante/config.lua
@@ -148,6 +148,10 @@ You are an excellent programming expert.
       hint = "<leader>ah",
       suggestion = "<leader>as",
     },
+    sidebar = {
+      switch_windows = "<Tab>",
+      reverse_switch_windows = "<S-Tab>",
+    },
   },
   windows = {
     ---@alias AvantePosition "right" | "left" | "top" | "bottom"

--- a/lua/avante/sidebar.lua
+++ b/lua/avante/sidebar.lua
@@ -616,8 +616,12 @@ function Sidebar:render_input(ask)
 
   local code_file_fullpath = api.nvim_buf_get_name(self.code.bufnr)
   local code_filename = fn.fnamemodify(code_file_fullpath, ":t")
-  local header_text =
-    string.format("󱜸 %s %s %s (<Tab>: switch focus)", ask and "Ask" or "Chat with", icon, code_filename)
+  local header_text = string.format(
+    "󱜸 %s %s %s (" .. Config.mappings.sidebar.switch_windows .. ": switch focus)",
+    ask and "Ask" or "Chat with",
+    icon,
+    code_filename
+  )
 
   if self.code.selection ~= nil then
     header_text = string.format(
@@ -887,15 +891,15 @@ function Sidebar:refresh_winids()
 
   for _, winid in ipairs(winids) do
     local buf = api.nvim_win_get_buf(winid)
-    vim.keymap.set(
+    Utils.safe_keymap_set(
       { "n", "i" },
-      "<Tab>",
+      Config.mappings.sidebar.switch_windows,
       function() switch_windows() end,
       { buffer = buf, noremap = true, silent = true }
     )
-    vim.keymap.set(
+    Utils.safe_keymap_set(
       { "n", "i" },
-      "<S-Tab>",
+      Config.mappings.sidebar.reverse_switch_windows,
       function() reverse_switch_windows() end,
       { buffer = buf, noremap = true, silent = true }
     )


### PR DESCRIPTION
### Motivation
The default settings for switching window focus in sidebar interfered with my copilot config, making it impossible to use it for writing prompts.

### What has been changed
I kept the default bindings `<Tab>/<S-Tab>`, but added possibility for user to override it via `opts.mappings`.

Hope it's useful! :slightly_smiling_face: 