### PR TITLE
feat(sidebar): enhance pattern matching for local LLM (closes #588)

### DIFF
--- a/lua/avante/sidebar.lua
+++ b/lua/avante/sidebar.lua
@@ -330,12 +330,19 @@ local function extract_code_snippets(code_content, response_content)
   local explanation = ""
 
   for idx, line in ipairs(vim.split(response_content, "\n")) do
-    local start_line_str, end_line_str = line:match("^Replace lines: (%d+)-(%d+)")
+    local _, start_line_str, end_line_str =
+      line:match("^%s*(%d*)[%.%)%s]*[Aa]?n?d?%s*[Rr]eplace%s+[Ll]ines:?%s*(%d+)%-(%d+)")
     if start_line_str ~= nil and end_line_str ~= nil then
       start_line = tonumber(start_line_str)
       end_line = tonumber(end_line_str)
+    else
+      _, start_line_str = line:match("^%s*(%d*)[%.%)%s]*[Aa]?n?d?%s*[Rr]eplace%s+[Ll]ine:?%s*(%d+)")
+      if start_line_str ~= nil then
+        start_line = tonumber(start_line_str)
+        end_line = tonumber(start_line_str)
+      end
     end
-    if line:match("^```") then
+    if line:match("^%s*```") then
       if in_code_block then
         if start_line ~= nil and end_line ~= nil then
           local snippet = {
@@ -354,7 +361,7 @@ local function extract_code_snippets(code_content, response_content)
         explanation = ""
         in_code_block = false
       else
-        lang = line:match("^```(%w+)")
+        lang = line:match("^%s*```(%w+)")
         if not lang or lang == "" then lang = "text" end
         in_code_block = true
         start_line_in_response_buf = idx
@@ -479,9 +486,9 @@ local function parse_codeblocks(buf)
 
   local lines = Utils.get_buf_lines(0, -1, buf)
   for i, line in ipairs(lines) do
-    if line:match("^```") then
+    if line:match("^%s*```") then
       -- parse language
-      local lang_ = line:match("^```(%w+)")
+      local lang_ = line:match("^%s*```(%w+)")
       if in_codeblock and not lang_ then
         table.insert(codeblocks, { start_line = start_line, end_line = i - 1, lang = lang })
         in_codeblock = false


### PR DESCRIPTION
This update strengthens pattern matching to handle slight deviations in output introduced by local LLMs. Instead of manually adjusting templates for each LLM, we capture the most common variations to improve robustness, while ensuring compatibility with the officially supported LLM (e.g., Claude-3.5-Sonnet).


**Enhanced Pattern Matching:**

The primary pattern we are currently targeting is:
- `"Replace lines: 5-7"`

This update also captures the following common deviations:
- `" Replace lines: 5-7"` — Extra whitespace after a line break.
- `"1. Replace lines: 5-7"` — Numbered changes.
- `"1 Replace lines: 5-7"` — Numbering without punctuation.
- `"1) Replace lines: 5-7"` and `"1.) Replace lines: 5-7"` — Different numbering formats.
- `"Replace lines 5-7"` — Missing colon (`:`), now optional.
- `"Replace line: 5"` — Singular line references.
- `"And replace lines: 5-7"` — Optional keywords before the pattern.
- `"replace lines: 5-7"` — Case-insensitive matching.

Additionally, we now support indented code blocks, allowing for whitespace before the opening backticks (```). Previously, code blocks could not be indented, which caused issues when certain LLMs added indentation to code snippets. This update ensures that these blocks can be correctly processed and included in the original file.

By broadening pattern recognition, this update ensures we capture common deviations from local LLMs while preserving compatibility with officially supported models.