### PR TITLE
fix(hl): use global namespace (closes #563)

### DIFF
--- a/README.md
+++ b/README.md
@@ -349,6 +349,8 @@ The following key bindings are available for use with `avante.nvim`:
 | AvanteConflictIncoming | Incoming conflict highlight | Default to `Config.highlights.diff.incoming` |
 | AvanteConflictCurrentLabel | Current conflict label highlight | Default to shade of `AvanteConflictCurrent` |
 | AvanteConflictIncomingLabel | Incoming conflict label highlight | Default to shade of `AvanteConflictIncoming` |
+| AvantePopupHint | Usage hints in popup menus | |
+| AvanteInlineHint | The end-of-line hint displayed in visual mode | |
 
 See [highlights.lua](./lua/avante/highlights.lua) for more information
 

--- a/lua/avante/highlights.lua
+++ b/lua/avante/highlights.lua
@@ -13,6 +13,8 @@ local Highlights = {
   REVERSED_THIRD_TITLE = { name = "AvanteReversedThirdTitle", fg = "#353B45" },
   SUGGESTION = { name = "AvanteSuggestion", link = "Comment" },
   ANNOTATION = { name = "AvanteAnnotation", link = "Comment" },
+  POPUP_HINT = { name = "AvantePopupHint", link = "NormalFloat" },
+  INLINE_HINT = { name = "AvanteInlineHint", link = "Keyword" },
 }
 
 Highlights.conflict = {
@@ -29,17 +31,12 @@ local H = {}
 
 local M = {}
 
-M.input_ns = api.nvim_create_namespace("avante_input")
-M.hint_ns = api.nvim_create_namespace("avante_hint")
-
 local function has_set_colors(hl_group)
   local hl = api.nvim_get_hl(0, { name = hl_group })
   return next(hl) ~= nil
 end
 
 M.setup = function()
-  local normal = api.nvim_get_hl(0, { name = "Normal" })
-  local normal_float = api.nvim_get_hl(0, { name = "NormalFloat" })
 
   if Config.behaviour.auto_set_highlight_group then
     vim
@@ -55,9 +52,6 @@ M.setup = function()
       end)
   end
 
-  api.nvim_set_hl(M.hint_ns, "NormalFloat", { fg = normal_float.fg, bg = normal_float.bg })
-  api.nvim_set_hl(M.input_ns, "NormalFloat", { fg = normal_float.fg, bg = normal_float.bg })
-  api.nvim_set_hl(M.input_ns, "FloatBorder", { fg = normal.fg, bg = normal.bg })
   M.conflict_highlights()
 end
 

--- a/lua/avante/highlights.lua
+++ b/lua/avante/highlights.lua
@@ -37,7 +37,6 @@ local function has_set_colors(hl_group)
 end
 
 M.setup = function()
-
   if Config.behaviour.auto_set_highlight_group then
     vim
       .iter(Highlights)

--- a/lua/avante/selection.lua
+++ b/lua/avante/selection.lua
@@ -175,7 +175,7 @@ function Selection:show_editing_input_shortcuts_hints()
 
   local buf = api.nvim_create_buf(false, true)
   api.nvim_buf_set_lines(buf, 0, -1, false, { hint_text })
-  vim.api.nvim_buf_add_highlight(buf, 0, 'AvantePopupHint', 0, 0, -1)
+  vim.api.nvim_buf_add_highlight(buf, 0, "AvantePopupHint", 0, 0, -1)
 
   local function update_spinner()
     spinner_index = (spinner_index % #spinner_chars) + 1

--- a/lua/avante/selection.lua
+++ b/lua/avante/selection.lua
@@ -66,7 +66,7 @@ function Selection:show_shortcuts_hints_popup()
   local virt_text_line = self:get_virt_text_line()
 
   self.shortcuts_extmark_id = api.nvim_buf_set_extmark(0, NAMESPACE, virt_text_line, -1, {
-    virt_text = { { hint_text, "Keyword" } },
+    virt_text = { { hint_text, "AvanteInlineHint" } },
     virt_text_pos = "eol",
     priority = PRIORITY,
   })
@@ -175,6 +175,7 @@ function Selection:show_editing_input_shortcuts_hints()
 
   local buf = api.nvim_create_buf(false, true)
   api.nvim_buf_set_lines(buf, 0, -1, false, { hint_text })
+  vim.api.nvim_buf_add_highlight(buf, 0, 'AvantePopupHint', 0, 0, -1)
 
   local function update_spinner()
     spinner_index = (spinner_index % #spinner_chars) + 1
@@ -254,8 +255,6 @@ function Selection:show_editing_input_shortcuts_hints()
   }
 
   self.editing_input_shortcuts_hints_winid = api.nvim_open_win(buf, false, opts)
-
-  api.nvim_win_set_hl_ns(self.editing_input_shortcuts_hints_winid, Highlights.hint_ns)
 end
 
 function Selection:create_editing_input()

--- a/lua/avante/sidebar.lua
+++ b/lua/avante/sidebar.lua
@@ -1399,7 +1399,7 @@ function Sidebar:create_input(opts)
 
     local buf = api.nvim_create_buf(false, true)
     api.nvim_buf_set_lines(buf, 0, -1, false, { hint_text })
-    api.nvim_buf_add_highlight(buf, 0, 'AvantePopupHint', 0, 0, -1)
+    api.nvim_buf_add_highlight(buf, 0, "AvantePopupHint", 0, 0, -1)
 
     -- Get the current window size
     local win_width = api.nvim_win_get_width(self.input.winid)

--- a/lua/avante/sidebar.lua
+++ b/lua/avante/sidebar.lua
@@ -1399,7 +1399,7 @@ function Sidebar:create_input(opts)
 
     local buf = api.nvim_create_buf(false, true)
     api.nvim_buf_set_lines(buf, 0, -1, false, { hint_text })
-    vim.api.nvim_buf_add_highlight(buf, 0, 'AvantePopupHint', 0, 0, -1)
+    api.nvim_buf_add_highlight(buf, 0, 'AvantePopupHint', 0, 0, -1)
 
     -- Get the current window size
     local win_width = api.nvim_win_get_width(self.input.winid)

--- a/lua/avante/sidebar.lua
+++ b/lua/avante/sidebar.lua
@@ -554,7 +554,6 @@ local base_win_options = {
   breakindent = true,
   wrap = false,
   cursorline = false,
-  -- winhighlight = "Normal:NormalFloat,Border:FloatBorder,VertSplit:NormalFloat,WinSeparator:NormalFloat,CursorLine:NormalFloat",
   fillchars = "eob: ",
   winhighlight = "CursorLine:Normal,CursorColumn:Normal",
   winbar = "",
@@ -1342,7 +1341,6 @@ function Sidebar:create_input(opts)
   end
 
   place_sign_at_first_line(self.input.bufnr)
-  api.nvim_win_set_hl_ns(self.input.winid, Highlights.input_ns)
 
   if Utils.in_visual_mode() then
     -- Exit visual mode
@@ -1401,6 +1399,7 @@ function Sidebar:create_input(opts)
 
     local buf = api.nvim_create_buf(false, true)
     api.nvim_buf_set_lines(buf, 0, -1, false, { hint_text })
+    vim.api.nvim_buf_add_highlight(buf, 0, 'AvantePopupHint', 0, 0, -1)
 
     -- Get the current window size
     local win_width = api.nvim_win_get_width(self.input.winid)
@@ -1422,8 +1421,6 @@ function Sidebar:create_input(opts)
 
     -- Create the floating window
     hint_window = api.nvim_open_win(buf, false, win_opts)
-
-    api.nvim_win_set_hl_ns(hint_window, Highlights.hint_ns)
   end
 
   api.nvim_create_autocmd({ "TextChanged", "TextChangedI", "VimResized" }, {


### PR DESCRIPTION
as per #563, using namespaces introduced an unwanted ordering dependency on when the base color scheme was set

Based on playing around with the split pane and reading the code, I'm pretty sure the `input_ns` namespace highlights did nothing, so everything to do with them was just removed (the removed winhighlight comment is probably when they went dead)

The `hint_ns` namespace is replaced with the `AvantePopupHint` highlight group, which by default links to `NormalFloat`

In the same vein, I added the `AvanteInlineHint` group to be able to style the hint that appears at the end of the line in visual mode, because `keyword` leads to quite obnoxious visuals by default imho.

