### PR TITLE
fix(sidebar): escape square brackets

### DIFF
--- a/lua/avante/sidebar.lua
+++ b/lua/avante/sidebar.lua
@@ -1004,7 +1004,7 @@ local function get_chat_record_prefix(timestamp, provider, model, request)
     .. "/"
     .. model
     .. "\n\n> "
-    .. request:gsub("\n", "\n> ")
+    .. request:gsub("\n", "\n> "):gsub("([%w-_]+)%b[]", "`%0`")
     .. "\n\n"
 end
 


### PR DESCRIPTION
### Properly escape square brackets in Markdown to prevent incorrect rendering

When submitting content from the sidebar that includes Markdown with square brackets (e.g., `arr[j]`), the text was being rendered incorrectly as `arrj`, losing the brackets. 

This fix ensures that square brackets are properly escaped, so `arr[j]` is now rendered as expected in Markdown, preserving the original format: `arr[j]`.