### PR TITLE
fix(hl): use correct highlighting for inline hints

### DIFF
--- a/lua/avante/diff.lua
+++ b/lua/avante/diff.lua
@@ -292,8 +292,8 @@ local function register_cursor_move_events(bufnr)
     )
 
     show_keybinding_hint_extmark_id = api.nvim_buf_set_extmark(bufnr, KEYBINDING_NAMESPACE, lnum - 1, -1, {
-      hl_group = "Keyword",
-      virt_text = { { hint, "Keyword" } },
+      hl_group = "AvanteInlineHint",
+      virt_text = { { hint, "AvanteInlineHint" } },
       virt_text_pos = "right_align",
       priority = PRIORITY,
     })

--- a/lua/avante/sidebar.lua
+++ b/lua/avante/sidebar.lua
@@ -703,9 +703,9 @@ function Sidebar:on_mount(opts)
 
     current_apply_extmark_id =
       api.nvim_buf_set_extmark(self.result.bufnr, CODEBLOCK_KEYBINDING_NAMESPACE, block.start_line, -1, {
-        virt_text = { { " [<a>: apply this, <A>: apply all] ", "Keyword" } },
+        virt_text = { { " [<a>: apply this, <A>: apply all] ", "AvanteInlineHint" } },
         virt_text_pos = "right_align",
-        hl_group = "Keyword",
+        hl_group = "AvanteInlineHint",
         priority = PRIORITY,
       })
   end


### PR DESCRIPTION
this fixes up two places I missed in https://github.com/yetone/avante.nvim/pull/590