### PR TITLE
move curl body to file

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@ For building binary if you wish to build from source, then `cargo` is required. 
   },
   -- if you want to build from source then do `make BUILD_FROM_SOURCE=true`
   build = "make",
-  -- build = "powershell -ExecutionPolicy Bypass -File Build.ps1 -BuildFromSource false" -- for windows
+  -- build = "pwsh -ExecutionPolicy Bypass -File Build.ps1 -BuildFromSource false" -- for windows
   dependencies = {
     "nvim-treesitter/nvim-treesitter",
     "stevearc/dressing.nvim",

--- a/lua/avante/llm.lua
+++ b/lua/avante/llm.lua
@@ -122,7 +122,7 @@ M.stream = function(opts)
     headers = spec.headers,
     proxy = spec.proxy,
     insecure = spec.insecure,
-    body = vim.json.encode(spec.body),
+    body = spec.body_file,
     stream = function(err, data, _)
       if err then
         completed = true

--- a/lua/avante/providers/init.lua
+++ b/lua/avante/providers/init.lua
@@ -35,7 +35,7 @@ local DressingState = { winid = nil, input_winid = nil, input_bufnr = nil }
 ---
 ---@alias AvanteMessageParser fun(opts: AvantePromptOptions): AvanteChatMessage[]
 ---
----@class AvanteCurlOutput: {url: string, proxy: string, insecure: boolean, body: table<string, any> | string, headers: table<string, string>}
+---@class AvanteCurlOutput: {url: string, proxy: string, insecure: boolean, body: string, headers: table<string, string>}
 ---@alias AvanteCurlArgsParser fun(opts: AvanteProvider | AvanteProviderFunctor, code_opts: AvantePromptOptions): AvanteCurlOutput
 ---
 ---@class ResponseParser


### PR DESCRIPTION
On windows I noticed I kept getting `ENAMETOOLONG` since the curl argument was so long, so I moved the body into a file.
This is a draft since I would def need to do this for the other providers too and the temp path is currently only valid for windows, but I am unsure if this is even the correct direction to go in.

Also I had to use `pwsh` instead of `powershell` otherwise the build failed with: 
```
New-TemporaryFile : The term 'New-TemporaryFile' is not recognized as the name of a cmdlet, function, script file, or  operable program. Check the spelling of the name, or if a path was included, verify that the path is correct and try again.
```