### PR TITLE
Make O1 models work with avante#575

### DIFF
--- a/lua/avante/llm.lua
+++ b/lua/avante/llm.lua
@@ -114,6 +114,10 @@ M.stream = function(opts)
     if data_match then Provider.parse_response(data_match, current_event_state, handler_opts) end
   end
 
+  local function parse_response_without_stream(data)
+    Provider.parse_response_without_stream(data, current_event_state, handler_opts)
+  end
+
   local completed = false
 
   local active_job
@@ -168,6 +172,14 @@ M.stream = function(opts)
               "API request failed with status " .. result.status .. ". Body: " .. vim.inspect(result.body)
             )
           end
+        end)
+      end
+
+      -- If stream is not enabled, then handle the response here
+      if spec.body.stream == false and result.status == 200 then
+        vim.schedule(function()
+          completed = true
+          parse_response_without_stream(result.body)
         end)
       end
     end,

--- a/lua/avante/providers/openai.lua
+++ b/lua/avante/providers/openai.lua
@@ -113,11 +113,12 @@ M.parse_curl_args = function(provider, code_opts)
   }
   if not P.env.is_local("openai") then headers["Authorization"] = "Bearer " .. provider.parse_api_key() end
 
-  -- NOTE: When using "o1" set streaming to false and remove max_tokens from the body
+  -- NOTE: When using "o1" set the supported parameters only
   local stream = true
   if base.model and string.find(base.model, "o1") then
     stream = false
     body_opts.max_tokens = nil
+    body_opts.temperature = 1
   end
 
   return {


### PR DESCRIPTION
# Overview
I've implemented a functionality for supporting the current 'o1' models of OpenAI. I've tested the integration with a tier 5 API access so that those that have it can also get the benefits of those powerful models.
The integration with O1 models doesn't interfere with current code and implementation for all other models from all my tests.

**IMPORTANT**: To make it work in an appropriate manner set the **model** and **timeout** for the openai provider in your configurations:
```lua
    opts.openai = {
      endpoint = "https://api.openai.com/v1",
      model = "o1-preview",
      timeout = 120000, -- Timeout in milliseconds
      temperature = 1,
      max_tokens = 4096,
      ["local"] = false,
    }
```
The temperature and max_tokens are then automatically reset for you to fit the contemporary constraints of the API for the O1 models. Though I'm not sure that timeout variable has any affect in this case, but it's worth setting it anyways.
As O1 models are chain-of-thought models without streaming, then answers might take some time.

# Change Log
- Add new `parse_response_without_stream` function to openai provider for handling non-stream requests to solve hanging answer from OpenAI
- Modify `parse_message` on openai provider to check when an o1 model is used to set system role as user role. O1 is smart enough to understand when a user message is a prompt - works like magic from my tests.
- Modify `parse_curl_args` on openai provider to ensure we comply with the o1 models limitations when o1 is used
- Modify `stream` function in llm file to handle non-stream requests. When a request is not streaming nothing basically happens, so I've added to the `on_complete` lambda handling in case of no stream to parse it correctly.
- Add new `OpenAIResponseChoiceComplete` class to parse and use results from a non-streaming request