### PR TITLE
Write curl body to a temporary JSON file

### DIFF
--- a/lua/avante/llm.lua
+++ b/lua/avante/llm.lua
@@ -122,11 +122,15 @@ M.stream = function(opts)
 
   local active_job
 
+  local temp_file = vim.fn.tempname() .. ".json"
+  local json_content = vim.json.encode(spec.body)
+  vim.fn.writefile(vim.split(json_content, "\n"), temp_file)
+
   active_job = curl.post(spec.url, {
     headers = spec.headers,
     proxy = spec.proxy,
     insecure = spec.insecure,
-    body = vim.json.encode(spec.body),
+    body = temp_file,
     stream = function(err, data, _)
       if err then
         completed = true

--- a/lua/avante/llm.lua
+++ b/lua/avante/llm.lua
@@ -159,10 +159,12 @@ M.stream = function(opts)
     on_error = function()
       active_job = nil
       completed = true
+      pcall(os.remove, temp_file)
       opts.on_complete(nil)
     end,
     callback = function(result)
       active_job = nil
+      pcall(os.remove, temp_file)
       if result.status >= 400 then
         if Provider.on_error then
           Provider.on_error(result)

--- a/lua/avante/llm.lua
+++ b/lua/avante/llm.lua
@@ -1,4 +1,5 @@
 local api = vim.api
+local fn = vim.fn
 
 local curl = require("plenary.curl")
 
@@ -101,8 +102,6 @@ M.stream = function(opts)
   ---@type AvanteCurlOutput
   local spec = Provider.parse_curl_args(Provider, code_opts)
 
-  Utils.debug("curl spec:", spec)
-
   ---@param line string
   local function parse_stream_data(line)
     local event = line:match("^event: (.+)$")
@@ -122,15 +121,22 @@ M.stream = function(opts)
 
   local active_job
 
-  local temp_file = vim.fn.tempname() .. ".json"
+  local curl_body_file = fn.tempname() .. ".json"
   local json_content = vim.json.encode(spec.body)
-  vim.fn.writefile(vim.split(json_content, "\n"), temp_file)
+  fn.writefile(vim.split(json_content, "\n"), curl_body_file)
+
+  Utils.debug("curl body file:", curl_body_file)
+
+  local function cleanup()
+    if Config.debug then return end
+    vim.schedule(function() fn.delete(curl_body_file) end)
+  end
 
   active_job = curl.post(spec.url, {
     headers = spec.headers,
     proxy = spec.proxy,
     insecure = spec.insecure,
-    body = temp_file,
+    body = curl_body_file,
     stream = function(err, data, _)
       if err then
         completed = true
@@ -159,12 +165,12 @@ M.stream = function(opts)
     on_error = function()
       active_job = nil
       completed = true
-      pcall(os.remove, temp_file)
+      cleanup()
       opts.on_complete(nil)
     end,
     callback = function(result)
       active_job = nil
-      pcall(os.remove, temp_file)
+      cleanup()
       if result.status >= 400 then
         if Provider.on_error then
           Provider.on_error(result)


### PR DESCRIPTION
Fixes #672

Should have the same effect as #622, but cross-platform since this uses a tempname() provided by neovim instead.
(Somewhat surprising to me: the plenary curl wrapper checks whether the content of `body` is a file, and if so, it prepends `@` telling curl to read the file contents. See: https://github.com/nvim-lua/plenary.nvim/blob/2d9b06177a975543726ce5c73fca176cedbffe9d/lua/plenary/curl.lua#L205)

I don't think you'd want to put the logic at the provider, since you'll have to repeat it for every provider. This will work for all providers since it's just calling curl in a slightly different way.