### PR TITLE
fix: ensure paths are recreated after calling :AvanteClear to avoid errors

### DIFF
--- a/lua/avante/path.lua
+++ b/lua/avante/path.lua
@@ -181,6 +181,9 @@ P.available = function() return templates ~= nil end
 P.clear = function()
   P.cache_path:rm({ recursive = true })
   P.history_path:rm({ recursive = true })
+
+  if not P.cache_path:exists() then P.cache_path:mkdir({ parents = true }) end
+  if not P.history_path:exists() then P.history_path:mkdir({ parents = true }) end
 end
 
 return P


### PR DESCRIPTION
Previously, as mentioned by @jackschedel in #579, running `:AvanteClear` before `:AvanteAsk` would cause an error due to missing directories. The `P.clear` function was deleting the cache and history directories, which were later needed by other commands like `:AvanteAsk`. This led to `ENOENT` errors when attempting to write to non-existent paths.

To resolve this, the fix ensures that the necessary directories (`cache` and `history`) are recreated immediately after they are cleared, preventing file write errors in subsequent commands.