### PR TITLE
Packer fix: Rename avante_repo_map to avante.repo_map in setup

### DIFF
--- a/lua/avante/repo_map.lua
+++ b/lua/avante/repo_map.lua
@@ -14,9 +14,9 @@ local RepoMap = {}
 
 function RepoMap.setup()
   vim.defer_fn(function()
-    local ok, core = pcall(require, "avante_repo_map")
+    local ok, core = pcall(require, "avante.repo_map")
     if not ok then
-      error("Failed to load avante_repo_map")
+      error("Failed to load avante.repo_map")
       return
     end
 


### PR DESCRIPTION
This change fixed #581 for me after building 
```
make BUILD_FROM_SOURCE=true
```
and `:PackerCompile`

Not sure if it makes sense, otherwise than that it fixed this issue for me. 
Hope this change will be helpful :)