### PR TITLE
Handle backticks before decoding JSON

### DIFF
--- a/lua/avante/suggestion.lua
+++ b/lua/avante/suggestion.lua
@@ -85,6 +85,7 @@ function Suggestion:suggest()
       vim.schedule(function()
         local cursor_row, cursor_col = Utils.get_cursor_pos()
         if cursor_row ~= doc.position.row or cursor_col ~= doc.position.col then return end
+        full_response = full_response:gsub("^`*%w*\n(.-)\n`*$", "%1")
         local ok, suggestions = pcall(vim.json.decode, full_response)
         if not ok then
           Utils.error("Error while decoding suggestions: " .. full_response, { once = true, title = "Avante" })

--- a/lua/avante/suggestion.lua
+++ b/lua/avante/suggestion.lua
@@ -85,7 +85,7 @@ function Suggestion:suggest()
       vim.schedule(function()
         local cursor_row, cursor_col = Utils.get_cursor_pos()
         if cursor_row ~= doc.position.row or cursor_col ~= doc.position.col then return end
-        full_response = full_response:gsub("^`*%w*\n(.-)\n`*$", "%1")
+        full_response = full_response:gsub("^```%w*\n(.-)\n```$", "%1")
         local ok, suggestions = pcall(vim.json.decode, full_response)
         if not ok then
           Utils.error("Error while decoding suggestions: " .. full_response, { once = true, title = "Avante" })


### PR DESCRIPTION
Since LLM models often do not remove backticks in their suggesting responses, particularly with smaller models, I have implemented backtick handling in the code. Please let me know your thoughts.
![backticks_example](https://github.com/user-attachments/assets/d8040553-4d6f-4ff8-8d42-37b41ec7ebc5)
