### PR TITLE
fix: get selection range from previous visual mode

### DIFF
--- a/lua/avante/selection.lua
+++ b/lua/avante/selection.lua
@@ -274,6 +274,11 @@ function Selection:create_editing_input()
 
   self.selection = Utils.get_visual_selection_and_range()
 
+  if self.selection == nil then
+    Utils.error("No visual selection found", { once = true, title = "Avante" })
+    return
+  end
+
   local start_row
   local start_col
   local end_row

--- a/lua/avante/utils/init.lua
+++ b/lua/avante/utils/init.lua
@@ -161,7 +161,7 @@ function M.trim(str, opts)
 end
 
 function M.in_visual_mode()
-  local current_mode = vim.fn.mode()
+  local current_mode = fn.mode()
   return current_mode == "v" or current_mode == "V" or current_mode == ""
 end
 
@@ -171,10 +171,15 @@ function M.get_visual_selection_and_range()
   local Range = require("avante.range")
   local SelectionResult = require("avante.selection_result")
 
-  if not M.in_visual_mode() then return nil end
   -- Get the start and end positions of Visual mode
-  local start_pos = vim.fn.getpos("v")
-  local end_pos = vim.fn.getpos(".")
+  local start_pos = fn.getpos("v")
+  local end_pos = fn.getpos(".")
+
+  if not M.in_visual_mode() then
+    start_pos = fn.getpos("'<")
+    end_pos = fn.getpos("'>")
+  end
+
   -- Get the start and end line and column numbers
   local start_line = start_pos[2]
   local start_col = start_pos[3]
@@ -190,12 +195,12 @@ function M.get_visual_selection_and_range()
   -- Check if it's a single-line selection
   if start_line == end_line then
     -- Get partial content of a single line
-    local line = vim.fn.getline(start_line)
+    local line = fn.getline(start_line)
     -- content = string.sub(line, start_col, end_col)
     content = line
   else
     -- Multi-line selection: Get all lines in the selection
-    local lines = vim.fn.getline(start_line, end_line)
+    local lines = fn.getline(start_line, end_line)
     -- Extract partial content of the first line
     -- lines[1] = string.sub(lines[1], start_col)
     -- Extract partial content of the last line


### PR DESCRIPTION
fix: https://github.com/yetone/avante.nvim/issues/688