### PR TITLE
fix: cannot rename buffer

### DIFF
--- a/lua/avante/utils/init.lua
+++ b/lua/avante/utils/init.lua
@@ -669,7 +669,7 @@ function M.get_opened_buffer(filepath)
 end
 
 function M.create_new_buffer_with_file(filepath)
-  local buf = api.nvim_create_buf(false, true)
+  local buf = api.nvim_create_buf(true, false)
 
   api.nvim_buf_set_name(buf, filepath)
 


### PR DESCRIPTION
fix https://github.com/yetone/avante.nvim/issues/726