### PR TITLE
fix: Improve TS support for @codebase

### DIFF
--- a/lua/avante/utils/init.lua
+++ b/lua/avante/utils/init.lua
@@ -545,8 +545,8 @@ function M.get_project_root() return M.root.get() end
 
 function M.is_same_file_ext(target_ext, filepath)
   local ext = fn.fnamemodify(filepath, ":e")
-  if target_ext == "tsx" and ext == "ts" then return true end
-  if target_ext == "jsx" and ext == "js" then return true end
+  if (target_ext == "tsx" and ext == "ts") or (target_ext == "ts" and ext == "tsx") then return true end
+  if (target_ext == "jsx" and ext == "js") or (target_ext == "js" and ext == "jsx") then return true end
   return ext == target_ext
 end
 


### PR DESCRIPTION
* `Utils.is_same_file_ext` now matches `tsx` and `ts` both ways (before it was only only one way)
* When `.ts` files are not correctly detected as TypeScript, fallback to manual solution.
* Handle situation, when filetype is `nil` and it causes a crash as `repo_map_lib.stringify_definitions` does not handle `nil` correctly

Fixes: https://github.com/yetone/avante.nvim/issues/675