### PR TITLE
fix: Add escaping characters to ignore patterns

### DIFF
--- a/lua/avante/utils/init.lua
+++ b/lua/avante/utils/init.lua
@@ -583,7 +583,7 @@ local function pattern_to_lua(pattern)
 end
 
 function M.parse_gitignore(gitignore_path)
-  local ignore_patterns = { ".git", ".worktree", "__pycache__", "node_modules" }
+  local ignore_patterns = { "%.git", "%.worktree", "__pycache__", "node_modules" }
   local negate_patterns = {}
   local file = io.open(gitignore_path, "r")
   if not file then return ignore_patterns, negate_patterns end


### PR DESCRIPTION
* Escape `.` in the `.git` and `.worktree` as otherwise any file, which has `<any character>git` or `<any character>worktree` would be ignored, like  anything inside `~/Source/github.com/i1skn/.....` would be ignored as it would match `/git`