### PR TITLE
option for additional nvim cmp sources

### DIFF
--- a/README.md
+++ b/README.md
@@ -270,6 +270,12 @@ _See [config.lua#L9](./lua/avante/config.lua) for the full config_
       incoming = "DiffAdd",
     },
   },
+
+  additional_cmp_sources = {
+    { name = "path" },
+    { name = "nvim_lsp" },
+    { name = "buffer" },
+  }, -- Additional cmp sources to be used in the sidebar and selection buffers
   --- @class AvanteConflictUserConfig
   diff = {
     autojump = true,

--- a/lua/avante/config.lua
+++ b/lua/avante/config.lua
@@ -182,6 +182,7 @@ Respect and use existing conventions, libraries, etc that are already present in
   hints = {
     enabled = true,
   },
+  additional_cmp_sources = {}, -- Additional cmp sources to be used in the sidebar and selection buffers
 }
 
 ---@type avante.Config

--- a/lua/avante/selection.lua
+++ b/lua/avante/selection.lua
@@ -478,12 +478,19 @@ function Selection:create_editing_input()
     callback = function()
       local has_cmp, cmp = pcall(require, "cmp")
       if has_cmp then
+        local sources = {
+          { name = "avante_mentions" },
+        }
+        local additional_cmp_sources = Config.additional_cmp_sources
+        if additional_cmp_sources then
+          for _, source in ipairs(additional_cmp_sources) do
+            table.insert(sources, source)
+          end
+        end
         cmp.register_source("avante_mentions", require("cmp_avante.mentions").new(Utils.get_mentions(), bufnr))
         cmp.setup.buffer({
           enabled = true,
-          sources = {
-            { name = "avante_mentions" },
-          },
+          sources = sources,
         })
       end
     end,

--- a/lua/avante/sidebar.lua
+++ b/lua/avante/sidebar.lua
@@ -1421,12 +1421,19 @@ function Sidebar:create_input(opts)
           "avante_mentions",
           require("cmp_avante.mentions").new(Utils.get_mentions(), self.input.bufnr)
         )
+        local sources = {
+          { name = "avante_commands" },
+          { name = "avante_mentions" },
+        }
+        local additional_cmp_sources = Config.additional_cmp_sources
+        if additional_cmp_sources then
+          for _, source in ipairs(additional_cmp_sources) do
+            table.insert(sources, source)
+          end
+        end
         cmp.setup.buffer({
           enabled = true,
-          sources = {
-            { name = "avante_commands" },
-            { name = "avante_mentions" },
-          },
+          sources = sources,
         })
       end
     end,
@@ -1441,10 +1448,19 @@ function Sidebar:create_input(opts)
     callback = function()
       local has_cmp, cmp = pcall(require, "cmp")
       if has_cmp then
-        for _, source in ipairs(cmp.core:get_sources()) do
-          if source.name == "avante_commands" or source.name == "avante_mentions" then
-            cmp.unregister_source(source.id)
+        local sources = {
+          "avante_commands",
+          "avante_mentions",
+        }
+        local additional_cmp_sources = Config.additional_cmp_sources
+        if additional_cmp_sources then
+          for _, source in ipairs(additional_cmp_sources) do
+            table.insert(sources, source.name)
           end
+        end
+
+        for _, source in ipairs(cmp.core:get_sources()) do
+          if vim.tbl_contains(sources, source.name) then cmp.unregister_source(source.id) end
         end
       end
     end,


### PR DESCRIPTION
Hi there, 

First of all, id like to thank you for creating this plugin. I use it all the time and its wonderful, please keep up the good work!

This PR adds an extra configuration parameter so that the nvim user can define extra cmp sources to be used in the sidebar / selection buffers. 

Selfishly this is helpful for another plugin that im working on but i think other users will find utility in the ability to tailor exactly which cmp sources contribute suggestions via cmp type-ahead. IE it may be helpful to have path suggestions to auto complete file names etc.

Let me know what you think,
~Nick