### PR TITLE
fix: diff highlights doesn't reapply in colorscheme change

### DIFF
--- a/lua/avante/init.lua
+++ b/lua/avante/init.lua
@@ -304,6 +304,11 @@ H.autocmds = function()
     callback = function() require("avante.highlights").setup() end,
   })
 
+  api.nvim_create_autocmd("ColorScheme", {
+    group = H.augroup,
+    callback = function() require("avante.highlights").setup() end,
+  })
+
   -- automatically setup Avante filetype to markdown
   vim.treesitter.language.register("markdown", "Avante")
 


### PR DESCRIPTION
### Problem:

After switching colorschemes, some plugin elements like the diff, headers, etc., lose their color formatting. This is because the plugin's highlights are not reapplied correctly.

### Current Solution:

The plugin currently uses an autocmd for the `ColorSchemePre` event handle color scheme changes. However, this approach is not working as intended, and the documentation for `:h ColorSchemePre` suggests using it for removing highlights rather than reapplying them.

### Proposed Solution:

To address this issue, we can add an extra autocmd for the `ColorScheme` event. This will ensure that the plugin's highlights are reapplied after a color scheme change, restoring the correct formatting for elements like headers, diffs, etc.

### Important Note:

I've left the original autocmd in place because I'm unsure if there are other parts of the plugin that rely on its behavior. If someone with more expertise determines that the original autocmd is no longer needed, it can be safely removed.