### PR TITLE
Add shortcuts for both avante ask and edit scenarios to avoid repeating common query and submit it to AI immediately

### DIFF
--- a/lua/avante/config.lua
+++ b/lua/avante/config.lua
@@ -351,6 +351,7 @@ local avante_explain_code = 'Explain the following code'
 local avante_complete_code = 'Complete the following codes written in ' .. vim.bo.filetype
 local avante_add_docstring = 'Add docstring to the following codes'
 local avante_fix_bugs = 'Fix the bugs inside the following codes if any'
+local avante_add_tests = 'Implement tests for the following code'
 
 require('which-key').add {
   { '<leader>a', group = 'Avante' }, -- NOTE: add for avante.nvim
@@ -426,6 +427,13 @@ require('which-key').add {
       end,
       desc = 'Fix Bugs(ask)',
     },
+    {
+      '<leader>au',
+      function()
+        require('avante.api').ask { question = avante_add_tests }
+      end,
+      desc = 'Add Tests(ask)',
+    },
   },
 }
 
@@ -474,6 +482,13 @@ require('which-key').add {
         prefill_edit_window(avante_fix_bugs)
       end,
       desc = 'Fix Bugs(edit)',
+    },
+    {
+      '<leader>aU',
+      function()
+        prefill_edit_window(avante_add_tests)
+      end,
+      desc = 'Add Tests(edit)',
     },
   },
 }

--- a/lua/avante/config.lua
+++ b/lua/avante/config.lua
@@ -310,4 +310,171 @@ M.BASE_PROVIDER_KEYS = {
   "use_xml_format",
 }
 
+-- prefil edit window with common scenarios to avoid repeating query and submit immediately
+local prefill_edit_window = function(request)
+  require('avante.api').edit()
+  local code_bufnr = vim.api.nvim_get_current_buf()
+  local code_winid = vim.api.nvim_get_current_win()
+  if code_bufnr == nil or code_winid == nil then
+    return
+  end
+  vim.api.nvim_buf_set_lines(code_bufnr, 0, -1, false, { request })
+  -- Optionally set the cursor position to the end of the input
+  vim.api.nvim_win_set_cursor(code_winid, { 1, #request + 1 })
+  -- Simulate Ctrl+S keypress to submit
+  vim.api.nvim_feedkeys(vim.api.nvim_replace_termcodes('<C-s>', true, true, true), 'v', true)
+end
+
+-- NOTE: most templates are inspired from ChatGPT.nvim -> chatgpt-actions.json
+local avante_grammar_correction = 'Correct the text to standard English, but keep any code blocks inside intact.'
+local avante_keywords = 'Extract the main keywords from the following text'
+local avante_code_readability_analysis = [[
+  You must identify any readability issues in the code snippet.
+  Some readability issues to consider:
+  - Unclear naming
+  - Unclear purpose
+  - Redundant or obvious comments
+  - Lack of comments
+  - Long or complex one liners
+  - Too much nesting
+  - Long variable names
+  - Inconsistent naming and code style.
+  - Code repetition
+  You may identify additional problems. The user submits a small section of code from a larger file.
+  Only list lines with readability issues, in the format <line_num>|<issue and proposed solution>
+  If there's no issues with code respond with only: <OK>
+]]
+local avante_optimize_code = 'Optimize the following code'
+local avante_summarize = 'Summarize the following text'
+local avante_translate = 'Translate this into Chinese, but keep any code blocks inside intact'
+local avante_explain_code = 'Explain the following code'
+local avante_complete_code = 'Complete the following codes written in ' .. vim.bo.filetype
+local avante_add_docstring = 'Add docstring to the following codes'
+local avante_fix_bugs = 'Fix the bugs inside the following codes if any'
+
+require('which-key').add {
+  { '<leader>a', group = 'Avante' }, -- NOTE: add for avante.nvim
+  {
+    mode = { 'n', 'v' },
+    {
+      '<leader>ag',
+      function()
+        require('avante.api').ask { question = avante_grammar_correction }
+      end,
+      desc = 'Grammar Correction(ask)',
+    },
+    {
+      '<leader>ak',
+      function()
+        require('avante.api').ask { question = avante_keywords }
+      end,
+      desc = 'Keywords(ask)',
+    },
+    {
+      '<leader>al',
+      function()
+        require('avante.api').ask { question = avante_code_readability_analysis }
+      end,
+      desc = 'Code Readability Analysis(ask)',
+    },
+    {
+      '<leader>ao',
+      function()
+        require('avante.api').ask { question = avante_optimize_code }
+      end,
+      desc = 'Optimize Code(ask)',
+    },
+    {
+      '<leader>am',
+      function()
+        require('avante.api').ask { question = avante_summarize }
+      end,
+      desc = 'Summarize text(ask)',
+    },
+    {
+      '<leader>an',
+      function()
+        require('avante.api').ask { question = avante_translate }
+      end,
+      desc = 'Translate text(ask)',
+    },
+    {
+      '<leader>ax',
+      function()
+        require('avante.api').ask { question = avante_explain_code }
+      end,
+      desc = 'Explain Code(ask)',
+    },
+    {
+      '<leader>ac',
+      function()
+        require('avante.api').ask { question = avante_complete_code }
+      end,
+      desc = 'Complete Code(ask)',
+    },
+    {
+      '<leader>ad',
+      function()
+        require('avante.api').ask { question = avante_add_docstring }
+      end,
+      desc = 'Docstring(ask)',
+    },
+    {
+      '<leader>ab',
+      function()
+        require('avante.api').ask { question = avante_fix_bugs }
+      end,
+      desc = 'Fix Bugs(ask)',
+    },
+  },
+}
+
+require('which-key').add {
+  { '<leader>a', group = 'Avante' }, -- NOTE: add for avante.nvim
+  {
+    mode = { 'v' },
+    {
+      '<leader>aG',
+      function()
+        prefill_edit_window(avante_grammar_correction)
+      end,
+      desc = 'Grammar Correction',
+    },
+    {
+      '<leader>aK',
+      function()
+        prefill_edit_window(avante_keywords)
+      end,
+      desc = 'Keywords',
+    },
+    {
+      '<leader>aO',
+      function()
+        prefill_edit_window(avante_optimize_code)
+      end,
+      desc = 'Optimize Code(edit)',
+    },
+    {
+      '<leader>aC',
+      function()
+        prefill_edit_window(avante_complete_code)
+      end,
+      desc = 'Complete Code(edit)',
+    },
+    {
+      '<leader>aD',
+      function()
+        prefill_edit_window(avante_add_docstring)
+      end,
+      desc = 'Docstring(edit)',
+    },
+    {
+      '<leader>aB',
+      function()
+        prefill_edit_window(avante_fix_bugs)
+      end,
+      desc = 'Fix Bugs(edit)',
+    },
+  },
+}
 return M


### PR DESCRIPTION
The pre-defined common queries include:

```lua
local avante_optimize_code = 'Optimize the following code'
local avante_summarize = 'Summarize the following text'
local avante_translate = 'Translate this into Chinese, but keep any code blocks inside intact'
local avante_explain_code = 'Explain the following code'
local avante_complete_code = 'Complete the following codes written in ' .. vim.bo.filetype
local avante_add_docstring = 'Add docstring to the following codes'
local avante_fix_bugs = 'Fix the bugs inside the following codes if any'
local avante_add_tests = 'Implement tests for the following code'
```

**avante ask (just ask, no edition):**
each query above is assigned to one shortcut like `<leader>ac` for code completion in normal and visual mode, the request will be submitted to AI without additional input and confirmation to save productivity, no existing code will be updated but the answers will be shown in AI chat window.

**avante edit (replace existing code):**
most queries above are assigned to respective and corresponding shortcuts like `<leader>aC` for code completion in visual mode, which will auto-fill out the edit window with the pre-defined query above and simulate <C>-s to submit the query and edit the existing code with the AI response.