### PR TITLE
feat: add configurable input window height for vertical layout

### DIFF
--- a/README.md
+++ b/README.md
@@ -261,6 +261,7 @@ _See [config.lua#L9](./lua/avante/config.lua) for the full config_
     },
     input = {
       prefix = "> ",
+      height = 8, -- Height of the input window in vertical layout
     },
     edit = {
       border = "rounded",

--- a/lua/avante/config.lua
+++ b/lua/avante/config.lua
@@ -172,6 +172,7 @@ Respect and use existing conventions, libraries, etc that are already present in
     },
     input = {
       prefix = "> ",
+      height = 8, -- Height of the input window in vertical layout
     },
     edit = {
       border = "rounded",

--- a/lua/avante/sidebar.lua
+++ b/lua/avante/sidebar.lua
@@ -1414,7 +1414,7 @@ function Sidebar:create_input(opts)
 
   local get_size = function()
     if self:get_layout() == "vertical" then return {
-      height = 8,
+      height = Config.windows.input.height,
     } end
 
     local selected_code_size = self:get_selected_code_size()


### PR DESCRIPTION
- Updated README.md and config.lua to include a new height option for the input window in vertical layout.
- Modified sidebar.lua to use the new configurable height instead of a hard-coded value of 8.

This change allows users to customize the height of the input window when using the vertical layout, providing more flexibility in the UI.