### PR TITLE
fix(repo-map) go vendor included in repo map causing token limit error

### DIFF
--- a/lua/avante/utils/init.lua
+++ b/lua/avante/utils/init.lua
@@ -583,7 +583,7 @@ local function pattern_to_lua(pattern)
 end
 
 function M.parse_gitignore(gitignore_path)
-  local ignore_patterns = { "%.git", "%.worktree", "__pycache__", "node_modules" }
+  local ignore_patterns = { "%.git", "%.worktree", "__pycache__", "node_modules", "vendor" }
   local negate_patterns = {}
   local file = io.open(gitignore_path, "r")
   if not file then return ignore_patterns, negate_patterns end


### PR DESCRIPTION
When using the `@codebase` flag, I encountered token exceeded errors. Upon investigation, I discovered that this issue arises because the Go project I'm working on uses a `vendor` folder for its dependencies. This folder was being included as part of the repo map, resulting in larger project context.

I am open to feedback and willing to alter the solution if this approach is not suitable. Please let me know if there are any suggestions or improvements that can be made.