### PR TITLE
fix(sidebar): apply windows.wrap setting to the selected code and avante input

### DIFF
--- a/lua/avante/sidebar.lua
+++ b/lua/avante/sidebar.lua
@@ -1368,7 +1368,9 @@ function Sidebar:create_selected_code()
         winid = self.input.winid,
       },
       buf_options = buf_options,
-      win_options = base_win_options,
+      win_options = vim.tbl_deep_extend("force", base_win_options, {
+        wrap = Config.windows.wrap,
+      }),
       position = "top",
       size = {
         height = selected_code_size + 3,
@@ -1602,7 +1604,7 @@ function Sidebar:create_input(opts)
       type = "win",
       winid = self.result.winid,
     },
-    win_options = vim.tbl_deep_extend("force", base_win_options, { signcolumn = "yes" }),
+    win_options = vim.tbl_deep_extend("force", base_win_options, { signcolumn = "yes", wrap = Config.windows.wrap }),
     position = get_position(),
     size = get_size(),
   })
@@ -1822,7 +1824,9 @@ function Sidebar:render(opts)
       bufhidden = "wipe",
       filetype = "Avante",
     }),
-    win_options = base_win_options,
+    win_options = vim.tbl_deep_extend("force", base_win_options, {
+      wrap = Config.windows.wrap,
+    }),
     size = {
       width = get_width(),
       height = get_height(),


### PR DESCRIPTION
Small change to apply the wrap setting to the selected code and avante input windows in the sidebar. 

If the preference is to allow the user to configure each window individually, I can implement this by extending the window configuration object to include a input and selected code wrap setting.

As always, let me know if there are any suggestions or improvements that can be made.

Before:
<img width="576" alt="image" src="https://github.com/user-attachments/assets/51eec191-341c-4ca6-9ece-b19336cecdd2">

After:
<img width="575" alt="image" src="https://github.com/user-attachments/assets/156bf9aa-2d75-4b8a-861c-86a3cd85f6a2">


