### PR TITLE
fix(openai): add backward compat for `get_user_message`

### DIFF
--- a/lua/avante/providers/openai.lua
+++ b/lua/avante/providers/openai.lua
@@ -39,7 +39,10 @@ M.role_map = {
 }
 
 ---@param opts AvantePromptOptions
-M.get_user_message = function(opts) return table.concat(opts.messages, "\n") end
+M.get_user_message = function(opts)
+  local content = vim.tbl_map(function(message) return message.content end, opts.messages)
+  return table.concat(content, "\n")
+end
 
 M.parse_messages = function(opts)
   local messages = {}

--- a/lua/avante/providers/openai.lua
+++ b/lua/avante/providers/openai.lua
@@ -44,7 +44,7 @@ M.get_user_message = function(opts)
   return table.concat(
     vim.iter(opts.messages):filter(function(_, value) return value.role == "user" end):fold({}, function(acc, value)
       acc = vim.list_extend({}, acc)
-      acc = vim.list_extend(acc, { value })
+      acc = vim.list_extend(acc, { value.content })
       return acc
     end),
     "\n"

--- a/lua/avante/providers/openai.lua
+++ b/lua/avante/providers/openai.lua
@@ -40,8 +40,15 @@ M.role_map = {
 
 ---@param opts AvantePromptOptions
 M.get_user_message = function(opts)
-  local content = vim.tbl_map(function(message) return message.content end, opts.messages)
-  return table.concat(content, "\n")
+  vim.deprecate("get_user_message", "parse_messages", "0.1.0", "avante.nvim")
+  return table.concat(
+    vim.iter(opts.messages):filter(function(_, value) return value.role == "user" end):fold({}, function(acc, value)
+      acc = vim.list_extend({}, acc)
+      acc = vim.list_extend(acc, { value })
+      return acc
+    end),
+    "\n"
+  )
 end
 
 M.parse_messages = function(opts)


### PR DESCRIPTION
opts.message is of type AvanteLLMMessage. The message.content field should be used. Otherwise, table.concat(opts.messages) will fail.