### PR TITLE
feat(build): support riscv

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -17,6 +17,10 @@ BUILD_DIR := build
 BUILD_FROM_SOURCE ?= false
 TARGET_LIBRARY ?= all
 
+ifeq ($(ARCH), riscv64)
+	BUILD_FROM_SOURCE := true
+endif
+
 all: luajit
 
 define make_definitions

--- a/build.sh
+++ b/build.sh
@@ -38,6 +38,9 @@ aarch64)
 arm64)
   ARCH="aarch64"
   ;;
+riscv64)
+  ARCH="riscv64"
+  ;;
 *)
   echo "Unsupported architecture"
   exit 1


### PR DESCRIPTION
Hi there!

First of all, thanks for creating this plugin. Been using it for weeks and I love it! 

I have a RISC-V workstation and I am working on adding support for Neovim and Neovim plugins that I use so everyone else also using RISC-V machines can benefit from it.

With the changes in this PR, avante builds and runs without any modification to the Rust/Lua code 🥳. It just needs a little nudge in the build scripts in RISC-V. I think it is a good middle ground to default to compile from source whenever we detect we are running on RISC-V. 

I think this does not break anything in other platforms.

### Sample run on my machine

[avante-works-riscv.webm](https://github.com/user-attachments/assets/b7bb5179-ac3e-4e15-8a3d-e043545363dc)

### Config I'm using

```lua
return {
  {
    "goyox86/avante.nvim",
    branch = "goyox86/riscv64",
    event = "VeryLazy",
    lazy = false,
    version = false, -- set this if you want to always pull the latest change
    opts = {
      -- add any opts here
    },
    -- cond = require("utils").arch() ~= "riscv64",
    -- if you want to build from source then do `make BUILD_FROM_SOURCE=true`
    build = "make",
    -- build = "powershell -ExecutionPolicy Bypass -File Build.ps1 -BuildFromSource false" -- for windows
    dependencies = {
      "stevearc/dressing.nvim",
      "nvim-lua/plenary.nvim",
      "MunifTanjim/nui.nvim",
      --- The below dependencies are optional,
      "nvim-tree/nvim-web-devicons", -- or echasnovski/mini.icons
      "zbirenbaum/copilot.lua", -- for providers='copilot'
      {
        -- support for image pasting
        "HakonHarnes/img-clip.nvim",
        event = "VeryLazy",
        opts = {
          -- recommended settings
          default = {
            embed_image_as_base64 = false,
            prompt_for_file_name = false,
            drag_and_drop = {
              insert_mode = true,
            },
            -- required for Windows users
            use_absolute_path = true,
          },
        },
      },
      {
        -- Make sure to set this up properly if you have lazy=true
        "MeanderingProgrammer/render-markdown.nvim",
        opts = {
          file_types = { "markdown", "Avante" },
        },
        ft = { "markdown", "Avante" },
      },
    },
  },
}
```

### Observations

- It takes some (longish) time to compile the Rust part of it. Even the fastest current RISC-V workstations (MILK-V Pioneer), are not super fast and Rust is known for being a bit slow compiling I increased my `lazy.nvim` git timeout which is by default 120 seconds killing processes that last longer than that while git fetching and building. I increased it to 600 seconds in my config and is more than enough. If you keep pressing `gs` in the LazyVim main window it will eventually finish but that is a bit annoying. It looks something like:

```lua
require("lazy").setup({
defaults = ...,
git = {
  timeout = 600,
}
install = ...
})
```

- I am using a local build of Neovim, RISC-V[ support is being added to LuaJIT](https://github.com/LuaJIT/LuaJIT/pull/1267) but it has not landed yet. Here are my versions

```bash
NVIM v0.11.0-dev-1057+g0b7cc014f
Build type: Debug
LuaJIT 2.1.1730654311
Run "nvim -V1 -v" for more info
```