### PR TITLE
feat: :sparkles: Added vertex AI provider for orgs using gemini

### DIFF
--- a/lua/avante/config.lua
+++ b/lua/avante/config.lua
@@ -5,11 +5,10 @@ local Utils = require("avante.utils")
 
 ---@class avante.CoreConfig: avante.Config
 local M = {}
-
 ---@class avante.Config
 M.defaults = {
   debug = false,
-  ---@alias Provider "claude" | "openai" | "azure" | "gemini" | "cohere" | "copilot" | [string]
+  ---@alias Provider "claude" | "openai" | "azure" | "gemini" | "vertex" | "cohere" | "copilot" | [string]
   provider = "claude", -- Only recommend using Claude
   auto_suggestions_provider = "claude",
   ---@alias Tokenizer "tiktoken" | "hf"
@@ -59,6 +58,15 @@ M.defaults = {
   ---@type AvanteSupportedProvider
   gemini = {
     endpoint = "https://generativelanguage.googleapis.com/v1beta/models",
+    model = "gemini-1.5-flash-latest",
+    timeout = 30000, -- Timeout in milliseconds
+    temperature = 0,
+    max_tokens = 4096,
+    ["local"] = false,
+  },
+  ---@type AvanteSupportedProvider
+  vertex = {
+    endpoint = "https://LOCATION-aiplatform.googleapis.com/v1/projects/PROJECT_ID/locations/LOCATION/publishers/google/models",
     model = "gemini-1.5-flash-latest",
     timeout = 30000, -- Timeout in milliseconds
     temperature = 0,

--- a/lua/avante/providers/vertex.lua
+++ b/lua/avante/providers/vertex.lua
@@ -1,0 +1,69 @@
+local P = require("avante.providers")
+local Gemini = require("avante.providers.gemini")
+
+---@class AvanteProviderFunctor
+local M = {}
+
+M.api_key_name = "cmd:gcloud auth application-default print-access-token"
+
+M.role_map = {
+  user = "user",
+  assistant = "model",
+}
+
+M.parse_messages = Gemini.parse_messages
+M.parse_response = Gemini.parse_response
+
+local function execute_command(command)
+  local handle = io.popen(command)
+  local result = handle:read("*a")
+  handle:close()
+  return result:match("^%s*(.-)%s*$")
+end
+
+M.parse_api_key = function()
+  if M.api_key_name:match("^cmd:") then
+    local command = M.api_key_name:sub(5)
+    return execute_command(command)
+  else
+    return vim.fn.getenv(M.api_key_name)
+  end
+end
+
+M.parse_curl_args = function(provider, code_opts)
+  local base, body_opts = P.parse_config(provider)
+
+  local location = vim.fn.getenv("LOCATION") or "default-location"
+  local project_id = vim.fn.getenv("PROJECT_ID") or "default-project-id"
+  local model_id = base.model or "default-model-id"
+
+  local url = string.format(
+    "https://%s-aiplatform.googleapis.com/v1/projects/%s/locations/%s/publishers/google/models/%s:streamGenerateContent?alt=sse",
+    location,
+    project_id,
+    location,
+    model_id
+  )
+
+  body_opts = vim.tbl_deep_extend("force", body_opts, {
+    generationConfig = {
+      temperature = body_opts.temperature,
+      maxOutputTokens = body_opts.max_tokens,
+    },
+  })
+  body_opts.temperature = nil
+  body_opts.max_tokens = nil
+
+  return {
+    url = url,
+    headers = {
+      ["Authorization"] = "Bearer " .. M.parse_api_key(),
+      ["Content-Type"] = "application/json; charset=utf-8",
+    },
+    proxy = base.proxy,
+    insecure = base.allow_insecure,
+    body = vim.tbl_deep_extend("force", {}, M.parse_messages(code_opts), body_opts),
+  }
+end
+
+return M

--- a/lua/avante/providers/vertex.lua
+++ b/lua/avante/providers/vertex.lua
@@ -32,18 +32,12 @@ end
 
 M.parse_curl_args = function(provider, code_opts)
   local base, body_opts = P.parse_config(provider)
-
   local location = vim.fn.getenv("LOCATION") or "default-location"
   local project_id = vim.fn.getenv("PROJECT_ID") or "default-project-id"
   local model_id = base.model or "default-model-id"
+  local url = base.endpoint:gsub("LOCATION", location):gsub("PROJECT_ID", project_id)
 
-  local url = string.format(
-    "https://%s-aiplatform.googleapis.com/v1/projects/%s/locations/%s/publishers/google/models/%s:streamGenerateContent?alt=sse",
-    location,
-    project_id,
-    location,
-    model_id
-  )
+  url = string.format("%s/%s:streamGenerateContent?alt=sse", url, model_id)
 
   body_opts = vim.tbl_deep_extend("force", body_opts, {
     generationConfig = {
@@ -53,7 +47,6 @@ M.parse_curl_args = function(provider, code_opts)
   })
   body_opts.temperature = nil
   body_opts.max_tokens = nil
-
   return {
     url = url,
     headers = {


### PR DESCRIPTION
Organisations or users that use the vertex AI API through google instead of the gemini API need to be able to SSO with gcloud authentication in order to use LLMs. You can see documentation for the API here, viewing the curl tab.

https://cloud.google.com/vertex-ai/generative-ai/docs/start/quickstarts/quickstart-multimodal#send-text-only-request

The vertex AI is gemini compatible (i.e it uses the same API under the hood), so we can use the same gemini parse message and response attributes. 

It would greatly help if this provider could be added, as it would allow me to use avante with models available via the vertex AI model garden.

The changes have been tested locally, and I would be happy to maintain this if the API changes as I regularly use this API and can keep track.