### PR TITLE
Update Discord link in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@
   <a href="https://github.com/yetone/avante.nvim/actions/workflows/ci.yaml" target="_blank">
     <img src="https://img.shields.io/github/actions/workflow/status/yetone/avante.nvim/ci.yaml?style=flat-square&logo=github&logoColor=c7c7c7&label=CI&labelColor=282828&color=347D39&event=push" alt="CI status" />
   </a>
-  <a href="https://discordapp.com/channels/1302530866362323016" target="_blank">
+  <a href="https://discord.com/invite/wUuZz7VxXD" target="_blank">
     <img src="https://img.shields.io/discord/1302530866362323016?style=flat-square&logo=discord&label=Discord&logoColor=ffffff&labelColor=7376CF&color=268165" alt="Discord" />
   </a>
   <a href="https://dotfyle.com/plugins/yetone/avante.nvim">


### PR DESCRIPTION
The previous link did not properly connect the user to Discord.

I went and found this link in a random twitter post, and I was able to join that way.