### PR TITLE
fix (sidebar) lock avante input and avante buffers to the sidebar window

### DIFF
--- a/lua/avante/sidebar.lua
+++ b/lua/avante/sidebar.lua
@@ -584,6 +584,7 @@ local buf_options = {
 }
 
 local base_win_options = {
+  winfixbuf = true,
   spell = false,
   signcolumn = "no",
   foldcolumn = "0",


### PR DESCRIPTION
While using telescope to open a file or `bNext` to switch buffers the user can mistakenly open a buffer in place of the avante input / avante buffers. Locking the buffers to the window seems to resolve this issue.
<img width="1510" alt="image" src="https://github.com/user-attachments/assets/5b8318ae-3603-4655-bdfa-0791a6e739b1">

Alternatively, I can expose winfixbuf as a config option if that makes more sense. Please let me know if you'd like to see this changed.