### PR TITLE
feat: add Dual Boost Mode for Enhanced LLM Responses with Multi-Provider Support

### DIFF
--- a/README.md
+++ b/README.md
@@ -208,6 +208,22 @@ _See [config.lua#L9](./lua/avante/config.lua) for the full config_
     temperature = 0,
     max_tokens = 4096,
   },
+  ---Specify the special dual_boost mode
+  ---1. enabled: Whether to enable dual_boost mode. Default to false.
+  ---2. first_provider: The first provider to generate response. Default to "openai".
+  ---3. second_provider: The second provider to generate response. Default to "claude".
+  ---4. prompt: The prompt to generate response based on the two reference outputs.
+  ---5. timeout: Timeout in milliseconds. Default to 60000.
+  ---Whow it works:
+  --- When dual_boost is enabled, avante will generate two responses from the first_provider and second_provider respectively. Then use the response from the first_provider as provider1_output and the response from the second_provider as provider2_output. Finally, avante will generate a response based on the prompt and the two reference outputs, with the default Provider as normal.
+  ---Note: This is an experimental feature and may not work as expected.
+  dual_boost = {
+    enabled = false,
+    first_provider = "openai",
+    second_provider = "claude",
+    prompt = "Based on the two reference outputs below, generate a response that incorporates elements from both but reflects your own judgment and unique perspective. Do not provide any explanation, just give the response directly. Reference Output 1: [{{provider1_output}}], Reference Output 2: [{{provider2_output}}]",
+    timeout = 60000, -- Timeout in milliseconds
+  },
   behaviour = {
     auto_suggestions = false, -- Experimental stage
     auto_set_highlight_group = true,

--- a/lua/avante/config.lua
+++ b/lua/avante/config.lua
@@ -112,13 +112,13 @@ M.defaults = {
   ---4. prompt: The prompt to generate response based on the two reference outputs.
   ---5. timeout: Timeout in milliseconds. Default to 60000.
   ---Whow it works:
-  --- When dual_boost is enabled, avante will generate two responses from the first_provider and second_provider respectively. Then use  the response from the first_provider as provider1_output and the response from the second_provider as provider2_output. Finally, avante will generate a response based on the prompt and the two reference outputs, with the default Provider as normal.
+  --- When dual_boost is enabled, avante will generate two responses from the first_provider and second_provider respectively. Then use the response from the first_provider as provider1_output and the response from the second_provider as provider2_output. Finally, avante will generate a response based on the prompt and the two reference outputs, with the default Provider as normal.
   ---Note: This is an experimental feature and may not work as expected.
   dual_boost = {
     enabled = false,
     first_provider = "openai",
     second_provider = "claude",
-    prompt = "Based on the two reference outputs below, generate a response that incorporates elements from both but reflects your own judgment and unique perspective. Do not provide any explanation, just give the response directly. Reference Output 1: [{% provider1_output %}], Reference Output 2: [{% provider2_output %}]",
+    prompt = "Based on the two reference outputs below, generate a response that incorporates elements from both but reflects your own judgment and unique perspective. Do not provide any explanation, just give the response directly. Reference Output 1: [{{provider1_output}}], Reference Output 2: [{{provider2_output}}]",
     timeout = 60000, -- Timeout in milliseconds
   },
   ---Specify the behaviour of avante.nvim

--- a/lua/avante/config.lua
+++ b/lua/avante/config.lua
@@ -97,6 +97,19 @@ M.defaults = {
       ["local"] = false,
     },
   },
+  ---Specify the special dual_boost mode
+  ---1. first_provider: The first provider to use
+  ---2. second_provider: The second provider to use
+  ---3. enabled: Whether to enable dual_boost mode. Default to false.
+  ---Whow it works:
+  --- When dual_boost is enabled, avante will generate two responses from the first_provider and second_provider respectively. Then use  the response from the first_provider as provider1_output and the response from the second_provider as provider2_output. Finally, avante will generate a response based on the prompt and the two reference outputs, with the default Provider as normal.
+  ---Note: This is an experimental feature and may not work as expected.
+  dual_boost = {
+    first_provider = "openai",
+    second_provider = "claude",
+    prompt = "Based on the two reference outputs below, generate a response that incorporates elements from both but reflects your own judgment and unique perspective. Do not provide any explanation, just give the response directly. Reference Output 1: [{% provider1_output %}], Reference Output 2: [{% provider2_output %}]",
+    enabled = true,
+  },
   ---Specify the behaviour of avante.nvim
   ---1. auto_apply_diff_after_generation: Whether to automatically apply diff after LLM response.
   ---                                     This would simulate similar behaviour to cursor. Default to false.

--- a/lua/avante/config.lua
+++ b/lua/avante/config.lua
@@ -106,14 +106,16 @@ M.defaults = {
     },
   },
   ---Specify the special dual_boost mode
-  ---1. first_provider: The first provider to use
-  ---2. second_provider: The second provider to use
-  ---3. enabled: Whether to enable dual_boost mode. Default to false.
+  ---1. enabled: Whether to enable dual_boost mode. Default to false.
+  ---2. first_provider: The first provider to generate response. Default to "openai".
+  ---3. second_provider: The second provider to generate response. Default to "claude".
+  ---4. prompt: The prompt to generate response based on the two reference outputs.
+  ---5. timeout: Timeout in milliseconds. Default to 60000.
   ---Whow it works:
   --- When dual_boost is enabled, avante will generate two responses from the first_provider and second_provider respectively. Then use  the response from the first_provider as provider1_output and the response from the second_provider as provider2_output. Finally, avante will generate a response based on the prompt and the two reference outputs, with the default Provider as normal.
   ---Note: This is an experimental feature and may not work as expected.
   dual_boost = {
-    enabled = true,
+    enabled = false,
     first_provider = "openai",
     second_provider = "claude",
     prompt = "Based on the two reference outputs below, generate a response that incorporates elements from both but reflects your own judgment and unique perspective. Do not provide any explanation, just give the response directly. Reference Output 1: [{% provider1_output %}], Reference Output 2: [{% provider2_output %}]",

--- a/lua/avante/llm.lua
+++ b/lua/avante/llm.lua
@@ -245,8 +245,8 @@ end
 local function _merge_response(first_response, second_response, opts, Provider)
   local prompt = "\n" .. Config.dual_boost.prompt
   prompt = prompt
-    :gsub("{%%[%s]*provider1_output[%s]*%%}", first_response)
-    :gsub("{%%[%s]*provider2_output[%s]*%%}", second_response)
+    :gsub("{{[%s]*provider1_output[%s]*}}", first_response)
+    :gsub("{{[%s]*provider2_output[%s]*}}", second_response)
 
   prompt = prompt .. "\n"
 


### PR DESCRIPTION
This PR introduces an experimental Dual Boost Mode to avante.nvim, allowing simultaneous response generation from two LLM providers (e.g., OpenAI and Claude). The outputs from these providers are included in a prompt as references for the default provider to generate a final, consolidated response.

Key Changes:

Added Dual Boost Mode configuration options.
Implemented response merging and error handling logic.
Updated stream management to support dual providers.
This feature enables users to leverage multiple providers for more robust responses.