### PR TITLE
fix(copilot): setup M.state when not initialized

### DIFF
--- a/lua/avante/providers/copilot.lua
+++ b/lua/avante/providers/copilot.lua
@@ -119,6 +119,7 @@ end
 M.state = nil
 
 M.api_key_name = ""
+M.setup_without_api_key = true
 M.tokenizer_id = "gpt-4o"
 M.role_map = {
   user = "user",

--- a/lua/avante/providers/init.lua
+++ b/lua/avante/providers/init.lua
@@ -78,6 +78,7 @@ local DressingState = { winid = nil, input_winid = nil, input_bufnr = nil }
 ---@field model? string
 ---@field parse_api_key fun(): string | nil
 ---@field parse_stream_data? AvanteStreamParser
+---@field setup_without_api_key? boolean
 ---@field on_error? fun(result: table<string, any>): nil
 ---
 ---@class avante.Providers
@@ -162,8 +163,9 @@ end
 ---@private
 E.setup = function(opts)
   local var = opts.provider.api_key_name
+  local must_setup = opts.provider.setup_without_api_key
 
-  if var == nil or var == "" then
+  if not must_setup and (var == nil or var == "") then
     vim.g.avante_login = true
     return
   end


### PR DESCRIPTION
fixes https://github.com/yetone/avante.nvim/issues/861

Copilot was broken and wouldn't work at all for me. PR resolves it.