### PR TITLE
fix(docs): correct typo in README and config.lua

### DIFF
--- a/README.md
+++ b/README.md
@@ -214,7 +214,7 @@ _See [config.lua#L9](./lua/avante/config.lua) for the full config_
   ---3. second_provider: The second provider to generate response. Default to "claude".
   ---4. prompt: The prompt to generate response based on the two reference outputs.
   ---5. timeout: Timeout in milliseconds. Default to 60000.
-  ---Whow it works:
+  ---How it works:
   --- When dual_boost is enabled, avante will generate two responses from the first_provider and second_provider respectively. Then use the response from the first_provider as provider1_output and the response from the second_provider as provider2_output. Finally, avante will generate a response based on the prompt and the two reference outputs, with the default Provider as normal.
   ---Note: This is an experimental feature and may not work as expected.
   dual_boost = {

--- a/lua/avante/config.lua
+++ b/lua/avante/config.lua
@@ -103,7 +103,7 @@ M.defaults = {
   ---3. second_provider: The second provider to generate response. Default to "claude".
   ---4. prompt: The prompt to generate response based on the two reference outputs.
   ---5. timeout: Timeout in milliseconds. Default to 60000.
-  ---Whow it works:
+  ---How it works:
   --- When dual_boost is enabled, avante will generate two responses from the first_provider and second_provider respectively. Then use the response from the first_provider as provider1_output and the response from the second_provider as provider2_output. Finally, avante will generate a response based on the prompt and the two reference outputs, with the default Provider as normal.
   ---Note: This is an experimental feature and may not work as expected.
   dual_boost = {


### PR DESCRIPTION
This pull request includes a minor correction to the documentation in the `README.md` and `lua/avante/config.lua` files to fix a typo.

Documentation correction:

* [`README.md`](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L217-R217): Corrected the typo "Whow it works" to "How it works" in the description of the dual boost
* [`lua/avante/config.lua`](diffhunk://#diff-4f9ab2121e449ed4df68152ef7ca083a1cc5eaf429c39348f73119abd75a6edbL106-R106): Corrected the typo "Whow it works" to "How it works" in the configuration comments