### PR TITLE
fix(sidebar): fix get_sources when blink.compat is installed

### DIFF
--- a/lua/avante/sidebar.lua
+++ b/lua/avante/sidebar.lua
@@ -1544,9 +1544,11 @@ function Sidebar:create_input(opts)
     callback = function()
       local has_cmp, cmp = pcall(require, "cmp")
       if has_cmp then
-        for _, source in ipairs(cmp.core:get_sources()) do
-          if source.name == "avante_commands" or source.name == "avante_mentions" then
-            cmp.unregister_source(source.id)
+        if type(cmp.core.get_sources) == "function" then
+          for _, source in ipairs(cmp.core:get_sources()) do
+            if source.name == "avante_commands" or source.name == "avante_mentions" then
+              cmp.unregister_source(source.id)
+            end
           end
         end
       end


### PR DESCRIPTION
Hello,

`blink.cmp` has a module: `blink.compat`. This module is used to work with `nvim-cmp` sources but does not "emulate" all the functions present in `nvim-cmp`.

As a result, when the autocmds in the sidebar are set up and used (like quitting the sidebar), it is checked whether `require("cmp")` exists. With `blink.compat`, it does indeed exist, but the `get_sources` function used afterward does not, which causes an error: `Error executing lua callback: ...local/share/nvim/lazy/avante.nvim/lua/avante/sidebar.lua:1547: attempt to call method 'get_sources' (a nil value)`

This small fix adds a check for the `get_sources` method. If it does not exist, the rest of the function is aborted. 