### PR TITLE
fix (sidebar) only display apply hint ext marks when code block can be replaced

### DIFF
--- a/lua/avante/sidebar.lua
+++ b/lua/avante/sidebar.lua
@@ -530,7 +530,7 @@ local function parse_codeblocks(buf)
       if in_codeblock and not lang_ then
         table.insert(codeblocks, { start_line = start_line, end_line = i - 1, lang = lang })
         in_codeblock = false
-      elseif lang_ then
+      elseif lang_ and lines[i - 1]:match("^%s*(%d*)[%.%)%s]*[Aa]?n?d?%s*[Rr]eplace%s+[Ll]ines:?%s*(%d+)%-(%d+)") then
         lang = lang_
         start_line = i - 1
         in_codeblock = true


### PR DESCRIPTION
When the LLM chat output generates a codeblock as an example that can't be search/replaced in the file, the `[<a>: apply this, <A>: apply all]` hint text is displayed but the code is not applicable.

This small change prevents it being detected as a code block.

Before:
<img width="583" alt="image" src="https://github.com/user-attachments/assets/f8fb5d62-d638-46ea-8bc0-153927c8c421">

After:
<img width="582" alt="image" src="https://github.com/user-attachments/assets/2c57cc41-6f6b-497a-a047-209d8fb369c1">

Example sidebar results buffer content
~~~markdown
> refactor this package to follow best practices.
> 
> output a simple example of using this for me so that I can understand how the package is used.

I'll refactor the logger package to follow best practices and provide a clear example of usage.

Filepath: pkg/logger/logger.go
Replace lines: 1-11
```go
// Package logger provides a simple wrapper around slog with standardized configuration
package logger

import (
	"errors"
	"io"
	"log/slog"
	"os"
)

// LogLevel represents the logging level
type LogLevel string

const (
	// Available log levels
	LevelDebug LogLevel = "debug"
	LevelInfo  LogLevel = "info"
	LevelWarn  LogLevel = "warn"
	LevelError LogLevel = "error"
)

// Config holds the logger configuration
type Config struct {
	// Service name for identification
	Service string
	// Version of Go being used
	GoVersion string
	// Environment (e.g., development, staging, production)
	Env string
	// Log level to filter logs
	Level LogLevel
	// Output destination (defaults to os.Stdout if nil)
	Output io.Writer
}

var (
	ErrLogLevel  = errors.New("invalid log level, must be one of debug, info, warn, error")
	ErrNilConfig = errors.New("config cannot be nil")
)
```

The logger will output JSON-formatted logs with consistent fields:
```json
{"time":"2023-11-07T10:00:00.000Z","level":"INFO","msg":"application started","service":"my-service","go_version":"unknown","env":"development"}
```

Would you like me to explain any part in more detail?
~~~

The downside of implementing this in the `parse_codeblocks` function is that the user will no longer be able to jump to these types of code blocks using `[[` and `]]`. 

Alternative approaches that don't alter the functionality of juming between codeblocks are:
1. implementing this check in the `show_apply_button` function
or 
2. Track if the code block can be applied as part of the codeblocks table via a new property.

If there are better alternatives let me know as I'm happy to make changes.