### PR TITLE
refactor(provider): :recycle: Updated API parsing logic for vertex AI

### DIFF
--- a/lua/avante/providers/vertex.lua
+++ b/lua/avante/providers/vertex.lua
@@ -23,12 +23,12 @@ local function execute_command(command)
 end
 
 M.parse_api_key = function()
-  if M.api_key_name:match("^cmd:") then
-    local command = M.api_key_name:sub(5)
-    return execute_command(command)
-  else
-    return vim.fn.getenv(M.api_key_name)
+  if not M.api_key_name:match("^cmd:") then
+    error("Invalid api_key_name: Expected 'cmd:<command>' format, got '" .. M.api_key_name .. "'")
   end
+  local command = M.api_key_name:sub(5)
+  local direct_output = execute_command(command)
+  return direct_output
 end
 
 M.parse_curl_args = function(provider, code_opts)
@@ -48,10 +48,12 @@ M.parse_curl_args = function(provider, code_opts)
   })
   body_opts.temperature = nil
   body_opts.max_tokens = nil
+  local bearer_token = M.parse_api_key()
+
   return {
     url = url,
     headers = {
-      ["Authorization"] = "Bearer " .. M.parse_api_key(),
+      ["Authorization"] = "Bearer " .. bearer_token,
       ["Content-Type"] = "application/json; charset=utf-8",
     },
     proxy = base.proxy,


### PR DESCRIPTION
This PR contains a small refactor to clean up the provider code a bit and improve its coding standards (I originally wrote it very quickly as a POC):

- The vertex AI API shouldn't accept a new API key name - the purpose of the api key is to authenticate the client, and that **has** to be done through the gcloud command. This removes the chance of end-users messing up interactions with the vertex API clients. 

I've added a screenshot of this working locally so there is not much doubt over how this affects functionality.

<img width="465" alt="image" src="https://github.com/user-attachments/assets/8e19d7f5-2824-42f1-a07e-371b10917a50">
