### PR TITLE
fix (prompt_input) limit the miximum row offset for hint text in floa…

### DIFF
--- a/lua/avante/prompt_input.lua
+++ b/lua/avante/prompt_input.lua
@@ -157,6 +157,7 @@ function PromptInput:show_shortcuts_hints()
   if not self.winid or not api.nvim_win_is_valid(self.winid) then return end
 
   local win_width = api.nvim_win_get_width(self.winid)
+  local win_height = api.nvim_win_get_height(self.winid)
   local buf_height = api.nvim_buf_line_count(self.bufnr)
 
   local hint_text = (vim.fn.mode() ~= "i" and Config.mappings.submit.normal or Config.mappings.submit.insert)
@@ -180,7 +181,7 @@ function PromptInput:show_shortcuts_hints()
     win = self.winid,
     width = width,
     height = 1,
-    row = buf_height,
+    row = math.min(buf_height, win_height),
     col = math.max(win_width - width, 0),
     style = "minimal",
     border = "none",


### PR DESCRIPTION
Minor change to limit the maximum offset of the prompt_input hint text to the height of the window. 

To reproduce the bug:
1. open a floating prompt input, via visually selecting a code block and executing `<leader>ae`
2. add 3 or more new lines in the input buffer.

Result:
The hint text will be offset by the height of the buffer and exceed the bounds of the window.

Before:
<img width="353" alt="image" src="https://github.com/user-attachments/assets/7e040e01-05df-4025-82f2-bf30f7126d39">

After:
<img width="373" alt="image" src="https://github.com/user-attachments/assets/926e8032-2557-4663-a85e-1c7342ffac36">