### PR TITLE
Pipline aarch64 fix

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -54,14 +54,16 @@ jobs:
         config:
           - os: ubuntu-latest
             os_name: linux
+            arch: aarch64
+            rust_target: aarch64-unknown-linux-gnu
+            docker_platform: linux/aarch64
+            container: quay.io/pypa/manylinux2014_aarch64
+          - os: ubuntu-latest
+            os_name: linux
             arch: x86_64
             rust_target: x86_64-unknown-linux-gnu
             docker_platform: linux/amd64
             container: quay.io/pypa/manylinux2014_x86_64 # for glibc 2.17
-          - os: ubuntu-latest
-            os_name: linux
-            arch: aarch64
-            rust_target: aarch64-unknown-linux-gnu
           - os: macos-13
             os_name: darwin
             arch: x86_64
@@ -83,6 +85,13 @@ jobs:
 
     steps:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # ratchet:actions/checkout@v4
+
+      # Step 1: Set up QEMU for multi-architecture support
+      - name: Set up QEMU
+        if: ${{ matrix.config.docker_platform == 'linux/aarch64' }}
+        uses: docker/setup-qemu-action@v2
+        with:
+          platforms: all
 
       - uses: Swatinem/rust-cache@82a92a6e8fbeee089604da2575dc567ae9ddeaab # ratchet:Swatinem/rust-cache@v2
         if: ${{ matrix.config.container == null }}


### PR DESCRIPTION
Mentioned in issue #882 the binaries provided for linux-aarch64 are currently x86_64 architecture. 

This PR changes the GitHub CI pipeline to use QEMU to emulate aarch64 architecture to compile the right bin's.
One thing I noticed is that the pipeline step for aarch64 will now take much longer (obviously because of the emulation). 

Maybe there is a better way but I just wanted to get the ball rolling on this.