### PR TITLE
chore: allow to pass raw curl args

### DIFF
--- a/lua/avante/llm.lua
+++ b/lua/avante/llm.lua
@@ -155,6 +155,7 @@ M._stream = function(opts, Provider)
     proxy = spec.proxy,
     insecure = spec.insecure,
     body = curl_body_file,
+    raw = spec.rawArgs,
     stream = function(err, data, _)
       if err then
         completed = true

--- a/lua/avante/providers/init.lua
+++ b/lua/avante/providers/init.lua
@@ -31,7 +31,7 @@ local DressingState = { winid = nil, input_winid = nil, input_bufnr = nil }
 ---
 ---@alias AvanteMessagesParser fun(opts: AvantePromptOptions): AvanteChatMessage[]
 ---
----@class AvanteCurlOutput: {url: string, proxy: string, insecure: boolean, body: table<string, any> | string, headers: table<string, string>}
+---@class AvanteCurlOutput: {url: string, proxy: string, insecure: boolean, body: table<string, any> | string, headers: table<string, string>, rawArgs: string[] | nil}
 ---@alias AvanteCurlArgsParser fun(opts: AvanteProvider | AvanteProviderFunctor, code_opts: AvantePromptOptions): AvanteCurlOutput
 ---
 ---@class ResponseParser


### PR DESCRIPTION
This can be used to pass additional arguments to curl, which can be helpful when working on new providers like bedrock, that can use curl arguments for authorization.