### PR TITLE
feat(context): add current buffer to selected file ctx

### DIFF
--- a/lua/avante/config.lua
+++ b/lua/avante/config.lua
@@ -189,6 +189,9 @@ M.defaults = {
       remove_file = "d",
       add_file = "@",
     },
+    files = {
+      add_current = "<leader>ac", -- Add current buffer to selected files
+    },
   },
   windows = {
     ---@alias AvantePosition "right" | "left" | "top" | "bottom" | "smart"

--- a/lua/avante/file_selector.lua
+++ b/lua/avante/file_selector.lua
@@ -27,7 +27,39 @@ function FileSelector:reset()
   self.event_handlers = {}
 end
 
-function FileSelector:add_selected_file(filepath) table.insert(self.selected_filepaths, Utils.uniform_path(filepath)) end
+function FileSelector:add_selected_file(filepath)
+    local uniform_path = Utils.uniform_path(filepath)
+    -- Avoid duplicates
+    if not vim.tbl_contains(self.selected_filepaths, uniform_path) then
+        table.insert(self.selected_filepaths, uniform_path)
+        self:emit("update")
+    end
+end
+
+function FileSelector:add_current_buffer()
+    local current_buf = vim.api.nvim_get_current_buf()
+    local filepath = vim.api.nvim_buf_get_name(current_buf)
+
+    -- Only process if it's a real file buffer
+    if filepath and filepath ~= "" and not vim.startswith(filepath, "avante://") then
+        local relative_path = require("avante.utils").relative_path(filepath)
+
+        -- Check if file is already in list
+        for i, path in ipairs(self.selected_filepaths) do
+            if path == relative_path then
+                -- Remove if found
+                table.remove(self.selected_filepaths, i)
+                self:emit("update")
+                return true
+            end
+        end
+
+        -- Add if not found
+        self:add_selected_file(relative_path)
+        return true
+    end
+    return false
+end
 
 function FileSelector:on(event, callback)
   local handlers = self.event_handlers[event]

--- a/lua/avante/sidebar.lua
+++ b/lua/avante/sidebar.lua
@@ -845,6 +845,21 @@ end
 function Sidebar:on_mount(opts)
   self:refresh_winids()
 
+  -- Add keymap to add current buffer while sidebar is open
+  if Config.mappings.files and Config.mappings.files.add_current then
+    vim.keymap.set("n", Config.mappings.files.add_current, function()
+      if self:is_open() and self.file_selector:add_current_buffer() then
+        vim.notify("Added current buffer to file selector", vim.log.levels.DEBUG, { title = "Avante" })
+      else
+        vim.notify("Failed to add current buffer", vim.log.levels.WARN, { title = "Avante" })
+      end
+    end, {
+      desc = "avante: add current buffer to file selector",
+      noremap = true,
+      silent = true,
+    })
+  end
+
   api.nvim_set_option_value("wrap", Config.windows.wrap, { win = self.result_container.winid })
 
   local current_apply_extmark_id = nil


### PR DESCRIPTION
Often while I'm working on something I'll open new buffers, browse code, and **then** decide that the context would be useful in my current Avante session.

This PR adds a configurable command that is enabled while the sidebar is open so that you can add the current buffer to the selected file context.