### PR TITLE
feat (sidebar) nvim-web-devicons support files with multiple dots and unknown file types

### DIFF
--- a/lua/avante/sidebar.lua
+++ b/lua/avante/sidebar.lua
@@ -755,25 +755,6 @@ function Sidebar:render_result()
   )
 end
 
-function Sidebar:get_file_icon(filepath)
-  local filetype = vim.filetype.match({ filename = filepath }) or "unknown"
-  ---@type string
-  local icon
-  ---@diagnostic disable-next-line: undefined-field
-  if _G.MiniIcons ~= nil then
-    ---@diagnostic disable-next-line: undefined-global
-    icon, _, _ = MiniIcons.get("filetype", filetype) -- luacheck: ignore
-  else
-    local ok, devicons = pcall(require, "nvim-web-devicons")
-    if ok then
-      icon = devicons.get_icon_by_filetype(filetype, {})
-    else
-      icon = ""
-    end
-  end
-  return icon
-end
-
 ---@param ask? boolean
 function Sidebar:render_input(ask)
   if ask == nil then ask = true end
@@ -2050,7 +2031,7 @@ function Sidebar:create_selected_files_container()
 
     local selected_filepaths_with_icon = {}
     for _, filepath in ipairs(selected_filepaths_) do
-      local icon = self:get_file_icon(filepath)
+      local icon = Utils.file.get_file_icon(filepath)
       table.insert(selected_filepaths_with_icon, string.format("%s %s", icon, filepath))
     end
 

--- a/lua/avante/utils/file.lua
+++ b/lua/avante/utils/file.lua
@@ -1,4 +1,5 @@
 local LRUCache = require("avante.utils.lru_cache")
+local Filetype = require("plenary.filetype")
 
 ---@class avante.utils.file
 local M = {}
@@ -36,6 +37,29 @@ end
 function M.exists(filepath)
   local stat = vim.loop.fs_stat(filepath)
   return stat ~= nil
+end
+
+function M.get_file_icon(filepath)
+  local filetype = Filetype.detect(filepath, {}) or "unknown"
+  ---@type string
+  local icon
+  ---@diagnostic disable-next-line: undefined-field
+  if _G.MiniIcons ~= nil then
+    ---@diagnostic disable-next-line: undefined-global
+    icon, _, _ = MiniIcons.get("filetype", filetype) -- luacheck: ignore
+  else
+    local ok, devicons = pcall(require, "nvim-web-devicons")
+    if ok then
+      icon = devicons.get_icon(filepath, filetype, { default = false })
+      if not icon then
+        icon = devicons.get_icon(filepath, nil, { default = true })
+        icon = icon or " "
+      end
+    else
+      icon = ""
+    end
+  end
+  return icon
 end
 
 return M


### PR DESCRIPTION
Adds support for files with multiple dots in the name and selects the default icon as a fallback when using nvim-web-devicons.

I moved the get_file_icon function into the file utils module however I'm happy to move it out again if it's not desired.

Credit to this pr for the telescope project for some of the implementation ideas. 
https://github.com/nvim-telescope/telescope.nvim/pull/2256

Before:
<img width="580" alt="image" src="https://github.com/user-attachments/assets/eae8c929-47f9-4b16-afde-3fd5b2bc83d9" />
<img width="580" alt="image" src="https://github.com/user-attachments/assets/749e8879-7a35-45cc-84a6-d2a9c96e17fe" />


After:
<img width="579" alt="image" src="https://github.com/user-attachments/assets/be659dd5-5bb6-4734-89a0-20302521a1e0" />
<img width="577" alt="image" src="https://github.com/user-attachments/assets/84e4603e-483f-40b6-ad69-9c0c92ea72d0" />


