### PR TITLE
feat: allow configurable file select provider (fzf and telescope)

### DIFF
--- a/lua/avante/config.lua
+++ b/lua/avante/config.lua
@@ -234,6 +234,13 @@ M.defaults = {
     ignore_patterns = { "%.git", "%.worktree", "__pycache__", "node_modules" }, -- ignore files matching these
     negate_patterns = {}, -- negate ignore files matching these.
   },
+  --- @class AvanteFileSelectorConfig
+  --- @field provider "native" | "fzf" | "telescope"
+  file_selector = {
+    provider = "native",
+    -- Options override for custom providers
+    provider_opts = {},
+  },
 }
 
 ---@type avante.Config


### PR DESCRIPTION
## Feature
The current implementation for using `vim.ui.select` for `FileSelector` **takes 7+ seconds** to load the select interface on large repos. I decided it would be best to allow use of `fzf` or `telescope` to load a file list quickly, asynchronously and with fuzzy finding. 

I've added a config for `file_selector`:
```
  --- @class AvanteFileSelectorConfig
  --- @field provider "native" | "fzf" | "telescope"
  file_selector = {
    provider = "native",
    -- Options override for custom providers
    provider_opts = {},
  },
```
and default provider implementations for `fzf` and `telescope`.
To use `fzf`, you would set provider to `fzf`, and likewise for `telescope`. Otherwise, leave the `file_selector` config out or set provider to "native" for default `vim.ui.select`.


## Videos

**Fzf** 
`{ provider = "fzf" }`

https://github.com/user-attachments/assets/bcbfb2cd-d1c6-4bd3-a987-719f1df9a040

**Telescope**
`{ provider = "telescope" }`

https://github.com/user-attachments/assets/1521d0ec-d5d8-46d8-8c54-93ce83d5c4c5

