### PR TITLE
fix(llm): make response ends properly

### DIFF
--- a/lua/avante/llm.lua
+++ b/lua/avante/llm.lua
@@ -228,6 +228,7 @@ M._stream = function(opts, Provider)
           parse_response_without_stream(result.body)
         end)
       end
+      opts.on_complete(nil)
     end,
   })
 


### PR DESCRIPTION
fix: https://github.com/yetone/avante.nvim/issues/627

There was no `Generation Complete!` message and no history files before this fix.
I think this is because there was no `on_complete` function call at callback but I'm not sure about this