### PR TITLE
fix (file_selector) empty buffer and chat without file context.

### DIFF
--- a/lua/avante/file_selector.lua
+++ b/lua/avante/file_selector.lua
@@ -33,6 +33,8 @@ function FileSelector:reset()
 end
 
 function FileSelector:add_selected_file(filepath)
+  if not filepath or filepath == "" then return end
+
   local uniform_path = Utils.uniform_path(filepath)
   -- Avoid duplicates
   if not vim.tbl_contains(self.selected_filepaths, uniform_path) then

--- a/lua/avante/llm.lua
+++ b/lua/avante/llm.lua
@@ -69,8 +69,10 @@ M._stream = function(opts, Provider)
     if diagnostics ~= "" then table.insert(messages, { role = "user", content = diagnostics }) end
   end
 
-  local code_context = Path.prompts.render_file("_context.avanterules", template_opts)
-  if code_context ~= "" then table.insert(messages, { role = "user", content = code_context }) end
+  if #opts.selected_files > 0 or opts.selected_code ~= nil then
+    local code_context = Path.prompts.render_file("_context.avanterules", template_opts)
+    if code_context ~= "" then table.insert(messages, { role = "user", content = code_context }) end
+  end
 
   if opts.use_xml_format then
     table.insert(messages, { role = "user", content = string.format("<question>%s</question>", instructions) })


### PR DESCRIPTION
Opening Avante in an empty buffer and trying to chat resulted in an error for some providers.
- File context will not add a file that is an empty string or nil.
- LLM will not send the context files message in cases where selected files is empty and the selected code is empty.

Before:
<img width="1511" alt="image" src="https://github.com/user-attachments/assets/342d0fb4-0e67-4f77-892e-d33e203ba041" />

After:
<img width="1351" alt="image" src="https://github.com/user-attachments/assets/aaed3067-0440-40f6-b2e7-154d1f765757" />
