### PR TITLE
feat (file_selector) command for switching the file picker provider.

### DIFF
--- a/lua/avante/api.lua
+++ b/lua/avante/api.lua
@@ -11,6 +11,15 @@ local PromptInput = require("avante.prompt_input")
 ---@field toggle avante.ApiToggle
 local M = {}
 
+---@param target_provider FileSelectorProvider
+M.switch_file_selector_provider = function(target_provider)
+  require("avante.config").override({
+    file_selector = {
+      provider = target_provider,
+    },
+  })
+end
+
 ---@param target Provider
 M.switch_provider = function(target) require("avante.providers").refresh(target) end
 

--- a/lua/avante/config.lua
+++ b/lua/avante/config.lua
@@ -238,8 +238,8 @@ M.defaults = {
     negate_patterns = {}, -- negate ignore files matching these.
   },
   --- @class AvanteFileSelectorConfig
-  --- @field provider "native" | "fzf" | "telescope"
   file_selector = {
+    --- @alias FileSelectorProvider "native" | "fzf" | "telescope" | string
     provider = "native",
     -- Options override for custom providers
     provider_opts = {},

--- a/plugin/avante.lua
+++ b/plugin/avante.lua
@@ -116,6 +116,14 @@ cmd("SwitchProvider", function(opts) require("avante.api").switch_provider(vim.t
     return vim.tbl_filter(function(key) return key:find(prefix, 1, true) == 1 end, Config.providers)
   end,
 })
+cmd(
+  "SwitchFileSelectorProvider",
+  function(opts) require("avante.api").switch_file_selector_provider(vim.trim(opts.args or "")) end,
+  {
+    nargs = 1,
+    desc = "avante: switch file selector provider",
+  }
+)
 cmd("Clear", function(opts)
   local arg = vim.trim(opts.args or "")
   arg = arg == "" and "history" or arg


### PR DESCRIPTION
Useful for testing, debugging or programatically changing the file picker. Avante command for changing the file picker in neovim.