### PR TITLE
feat (file_selector): Add multi select

### DIFF
--- a/lua/avante/file_selector.lua
+++ b/lua/avante/file_selector.lua
@@ -223,7 +223,6 @@ function FileSelector:show_select_ui()
     for _, filepath in ipairs(paths) do
       local uniform_path = Utils.uniform_path(filepath)
       if Config.file_selector.provider == "native" then
-        -- Native handler filters out already selected files
         table.insert(self.selected_filepaths, uniform_path)
       else
         if not vim.tbl_contains(self.selected_filepaths, uniform_path) then


### PR DESCRIPTION
Allows the user to select multiple at once when using the Telescope selector. Uses the default keybind of tab to select and `<CR>` confirms the selection


![multi_picker](https://github.com/user-attachments/assets/b19e80f9-d440-4bcb-b289-4c20e77c5d0c)
