### PR TITLE
feat(sidebar): support file context when buffer is outside the cwd

### DIFF
--- a/.github/workflows/lua.yaml
+++ b/.github/workflows/lua.yaml
@@ -13,6 +13,41 @@ on:
       - "**/*.lua"
 
 jobs:
+  # reference from: https://github.com/nvim-lua/plenary.nvim/blob/2d9b06177a975543726ce5c73fca176cedbffe9d/.github/workflows/default.yml#L6C3-L43C20
+  run_tests:
+    name: unit tests
+    runs-on: ${{ matrix.os }}
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - os: ubuntu-22.04
+            rev: v0.10.0/nvim-linux64.tar.gz
+    steps:
+      - uses: actions/checkout@v3
+      - run: date +%F > todays-date
+      - name: Restore cache for today's nightly.
+        uses: actions/cache@v3
+        with:
+          path: _neovim
+          key: ${{ runner.os }}-${{ matrix.rev }}-${{ hashFiles('todays-date') }}
+
+      - name: Prepare
+        run: |
+          test -d _neovim || {
+            mkdir -p _neovim
+            curl -sL "https://github.com/neovim/neovim/releases/download/${{ matrix.rev }}" | tar xzf - --strip-components=1 -C "${PWD}/_neovim"
+          }
+
+      - name: Run tests
+        run: |
+          export PATH="${PWD}/_neovim/bin:${PATH}"
+          export VIM="${PWD}/_neovim/share/nvim/runtime"
+          # install nvim-lua/plenary.nvim
+          git clone --depth 1 https://github.com/nvim-lua/plenary.nvim ~/.local/share/nvim/site/pack/vendor/start/plenary.nvim
+          nvim --version
+          make luatest
+
   stylua:
     name: Check Lua style
     runs-on: ubuntu-latest
@@ -24,7 +59,8 @@ jobs:
           crate: stylua
           features: lua54
       - run: stylua --version
-      - run: stylua --check ./lua/ ./plugin/
+      - run: stylua --color always --check ./lua/ ./plugin/ ./tests/
+
   luacheck:
     name: Lint Lua
     runs-on: ubuntu-latest

--- a/Build.ps1
+++ b/Build.ps1
@@ -17,10 +17,11 @@ function Build-FromSource($feature) {
 
     cargo build --release --features=$feature
 
+    $SCRIPT_DIR = $PSScriptRoot
     $targetTokenizerFile = "avante_tokenizers.dll"
     $targetTemplatesFile = "avante_templates.dll"
-    Copy-Item (Join-Path "target\release\avante_tokenizers.dll") (Join-Path $BuildDir $targetTokenizerFile)
-    Copy-Item (Join-Path "target\release\avante_templates.dll") (Join-Path $BuildDir $targetTemplatesFile)
+    Copy-Item (Join-Path $SCRIPT_DIR "target\release\avante_tokenizers.dll") (Join-Path $BuildDir $targetTokenizerFile)
+    Copy-Item (Join-Path $SCRIPT_DIR "target\release\avante_templates.dll") (Join-Path $BuildDir $targetTemplatesFile)
 
     Remove-Item -Recurse -Force "target"
 }

--- a/Build.ps1
+++ b/Build.ps1
@@ -25,6 +25,19 @@ function Build-FromSource($feature) {
     Remove-Item -Recurse -Force "target"
 }
 
+function Test-Command($cmdname) {
+    return $null -ne (Get-Command $cmdname -ErrorAction SilentlyContinue)
+}
+
+function Test-GHAuth {
+    try {
+        $null = gh api user
+        return $true
+    } catch {
+        return $false
+    }
+}
+
 function Download-Prebuilt($feature) {
     $REPO_OWNER = "yetone"
     $REPO_NAME = "avante.nvim"
@@ -46,18 +59,23 @@ function Download-Prebuilt($feature) {
     # Set the artifact name pattern
     $ARTIFACT_NAME_PATTERN = "avante_lib-$PLATFORM-$ARCH-$LUA_VERSION"
 
-    # Get the artifact download URL
-    $LATEST_RELEASE = Invoke-RestMethod -Uri "https://api.github.com/repos/$REPO_OWNER/$REPO_NAME/releases/latest"
-    $ARTIFACT_URL = $LATEST_RELEASE.assets | Where-Object { $_.name -like "*$ARTIFACT_NAME_PATTERN*" } | Select-Object -ExpandProperty browser_download_url
+    $TempFile = Get-Item ([System.IO.Path]::GetTempFilename()) | Rename-Item -NewName { $_.Name + ".zip" } -PassThru
+
+    if ((Test-Command "gh") -and (Test-GHAuth)) {
+        gh release download --repo "$REPO_OWNER/$REPO_NAME" --pattern "*$ARTIFACT_NAME_PATTERN*" --output $TempFile --clobber
+    } else {
+      # Get the artifact download URL
+      $LATEST_RELEASE = Invoke-RestMethod -Uri "https://api.github.com/repos/$REPO_OWNER/$REPO_NAME/releases/latest"
+      $ARTIFACT_URL = $LATEST_RELEASE.assets | Where-Object { $_.name -like "*$ARTIFACT_NAME_PATTERN*" } | Select-Object -ExpandProperty browser_download_url
+
+      # Download and extract the artifact
+      Invoke-WebRequest -Uri $ARTIFACT_URL -OutFile $TempFile
+    }
 
     # Create target directory if it doesn't exist
     if (-not (Test-Path $TARGET_DIR)) {
         New-Item -ItemType Directory -Path $TARGET_DIR | Out-Null
     }
-
-    # Download and extract the artifact
-    $TempFile = Get-Item ([System.IO.Path]::GetTempFilename()) | Rename-Item -NewName { $_.Name + ".zip" } -PassThru
-    Invoke-WebRequest -Uri $ARTIFACT_URL -OutFile $TempFile
     Expand-Archive -Path $TempFile -DestinationPath $TARGET_DIR -Force
     Remove-Item $TempFile
 }

--- a/Makefile
+++ b/Makefile
@@ -66,8 +66,8 @@ clean:
 luacheck:
 	@luacheck `find -name "*.lua"` --codes
 
-stylecheck:
-	@stylua --check lua/ plugin/
+luastylecheck:
+	@stylua --check lua/ plugin/ tests/
 
 stylefix:
 	@stylua lua/ plugin/
@@ -81,3 +81,14 @@ ruststylecheck:
 rustlint:
 	@rustup component add clippy 2> /dev/null
 	@cargo clippy -F luajit --all -- -F clippy::dbg-macro -D warnings
+
+.PHONY: rusttest
+rusttest:
+	@cargo test --features luajit
+
+.PHONY: luatest
+luatest:
+	nvim --headless -c "PlenaryBustedDirectory tests/"
+
+.PHONY: lint
+lint: luacheck luastylecheck ruststylecheck rustlint

--- a/README.md
+++ b/README.md
@@ -107,7 +107,7 @@ Plug 'nvim-lua/plenary.nvim'
 Plug 'MunifTanjim/nui.nvim'
 
 " Optional deps
-Plug "hrsh7th/nvim-cmp"
+Plug 'hrsh7th/nvim-cmp'
 Plug 'nvim-tree/nvim-web-devicons' "or Plug 'echasnovski/mini.icons'
 Plug 'HakonHarnes/img-clip.nvim'
 Plug 'zbirenbaum/copilot.lua'

--- a/README.md
+++ b/README.md
@@ -319,6 +319,62 @@ _See [config.lua#L9](./lua/avante/config.lua) for the full config_
   },
 }
 ```
+## Blink.cmp users
+For blink cmp users (nvim-cmp alternative) view below instruction for configuration
+This is acheived but emulating nvim-cmp using blink.compat
+<details>
+  <summary>Lua</summary>
+
+```lua
+      file_selector = {
+        --- @alias FileSelectorProvider "native" | "fzf" | "telescope" | string
+        provider = "fzf",
+        -- Options override for custom providers
+        provider_opts = {},
+      }
+```
+Choose a selector other that native, the default as that currently has an issue
+For lazyvim users copy the full config for blink.cmp from the website or extend the options
+```lua
+      compat = {
+        "avante_commands",
+        "avante_mentions",
+        "avante_files",
+      }
+```
+For other users just add a custom provider
+```lua
+      default = {
+        ...
+        "avante_commands",
+        "avante_mentions",
+        "avante_files",
+      }
+```
+```lua
+      providers = {
+        avante_commands = {
+          name = "avante_commands",
+          module = "blink.compat.source",
+          score_offset = 90, -- show at a higher priority than lsp
+          opts = {},
+        },
+        avante_files = {
+          name = "avante_commands",
+          module = "blink.compat.source",
+          score_offset = 100, -- show at a higher priority than lsp
+          opts = {},
+        },
+        avante_mentions = {
+          name = "avante_mentions",
+          module = "blink.compat.source",
+          score_offset = 1000, -- show at a higher priority than lsp
+          opts = {},
+        }
+        ...
+    }
+```
+</details>
 
 ## Usage
 

--- a/README.md
+++ b/README.md
@@ -49,7 +49,7 @@ For building binary if you wish to build from source, then `cargo` is required. 
   "yetone/avante.nvim",
   event = "VeryLazy",
   lazy = false,
-  version = false, -- set this if you want to always pull the latest change
+  version = false, -- set this to "*" if you want to always pull the latest change, false to update on release
   opts = {
     -- add any opts here
   },

--- a/crates/avante-tokenizers/src/lib.rs
+++ b/crates/avante-tokenizers/src/lib.rs
@@ -71,7 +71,9 @@ impl HuggingFaceTokenizer {
 
         if !cached_path.exists() {
             let response = ureq::get(url).call().unwrap();
-            let _ = std::fs::write(&cached_path, response.into_string().unwrap());
+            let mut file = std::fs::File::create(&cached_path).unwrap();
+            let mut reader = response.into_reader();
+            std::io::copy(&mut reader, &mut file).unwrap();
         }
         cached_path
     }

--- a/lua/avante/api.lua
+++ b/lua/avante/api.lua
@@ -134,10 +134,10 @@ M.ask = function(opts)
       submit_callback = function(input) ask(input) end,
       close_on_submit = true,
       win_opts = {
-        border = Config.options.windows.ask.border,
+        border = Config.windows.ask.border,
         title = { { "ask", "FloatTitle" } },
       },
-      start_insert = Config.options.windows.ask.start_insert,
+      start_insert = Config.windows.ask.start_insert,
     })
     prompt_input:open()
     return true

--- a/lua/avante/config.lua
+++ b/lua/avante/config.lua
@@ -6,7 +6,7 @@ local Utils = require("avante.utils")
 ---@class avante.CoreConfig: avante.Config
 local M = {}
 ---@class avante.Config
-M.defaults = {
+M._defaults = {
   debug = false,
   ---@alias Provider "claude" | "openai" | "azure" | "gemini" | "vertex" | "cohere" | "copilot" | string
   provider = "claude", -- Only recommend using Claude
@@ -247,7 +247,7 @@ M.defaults = {
 }
 
 ---@type avante.Config
-M.options = {}
+M._options = {}
 
 ---@class avante.ConflictConfig: AvanteConflictConfig
 ---@field mappings AvanteConflictMappings
@@ -261,9 +261,9 @@ M.providers = {}
 function M.setup(opts)
   vim.validate({ opts = { opts, "table", true } })
 
-  M.options = vim.tbl_deep_extend(
+  M._options = vim.tbl_deep_extend(
     "force",
-    M.defaults,
+    M._defaults,
     opts or {},
     ---@type avante.Config
     {
@@ -273,7 +273,7 @@ function M.setup(opts)
     }
   )
   M.providers = vim
-    .iter(M.defaults)
+    .iter(M._defaults)
     :filter(function(_, value) return type(value) == "table" and value.endpoint ~= nil end)
     :fold({}, function(acc, k)
       acc = vim.list_extend({}, acc)
@@ -281,21 +281,21 @@ function M.setup(opts)
       return acc
     end)
 
-  vim.validate({ provider = { M.options.provider, "string", false } })
+  vim.validate({ provider = { M._options.provider, "string", false } })
 
   M.diff = vim.tbl_deep_extend(
     "force",
     {},
-    M.options.diff,
-    { mappings = M.options.mappings.diff, highlights = M.options.highlights.diff }
+    M._options.diff,
+    { mappings = M._options.mappings.diff, highlights = M._options.highlights.diff }
   )
 
-  if next(M.options.vendors) ~= nil then
-    for k, v in pairs(M.options.vendors) do
-      M.options.vendors[k] = type(v) == "function" and v() or v
+  if next(M._options.vendors) ~= nil then
+    for k, v in pairs(M._options.vendors) do
+      M._options.vendors[k] = type(v) == "function" and v() or v
     end
-    vim.validate({ vendors = { M.options.vendors, "table", true } })
-    M.providers = vim.list_extend(M.providers, vim.tbl_keys(M.options.vendors))
+    vim.validate({ vendors = { M._options.vendors, "table", true } })
+    M.providers = vim.list_extend(M.providers, vim.tbl_keys(M._options.vendors))
   end
 end
 
@@ -303,26 +303,26 @@ end
 function M.override(opts)
   vim.validate({ opts = { opts, "table", true } })
 
-  M.options = vim.tbl_deep_extend("force", M.options, opts or {})
+  M._options = vim.tbl_deep_extend("force", M._options, opts or {})
   M.diff = vim.tbl_deep_extend(
     "force",
     {},
-    M.options.diff,
-    { mappings = M.options.mappings.diff, highlights = M.options.highlights.diff }
+    M._options.diff,
+    { mappings = M._options.mappings.diff, highlights = M._options.highlights.diff }
   )
 
-  if next(M.options.vendors) ~= nil then
-    for k, v in pairs(M.options.vendors) do
-      M.options.vendors[k] = type(v) == "function" and v() or v
+  if next(M._options.vendors) ~= nil then
+    for k, v in pairs(M._options.vendors) do
+      M._options.vendors[k] = type(v) == "function" and v() or v
       if not vim.tbl_contains(M.providers, k) then M.providers = vim.list_extend(M.providers, { k }) end
     end
-    vim.validate({ vendors = { M.options.vendors, "table", true } })
+    vim.validate({ vendors = { M._options.vendors, "table", true } })
   end
 end
 
 M = setmetatable(M, {
   __index = function(_, k)
-    if M.options[k] then return M.options[k] end
+    if M._options[k] then return M._options[k] end
   end,
 })
 
@@ -332,14 +332,14 @@ M.get_window_width = function() return math.ceil(vim.o.columns * (M.windows.widt
 
 ---@param provider Provider
 ---@return boolean
-M.has_provider = function(provider) return M.options[provider] ~= nil or M.vendors[provider] ~= nil end
+M.has_provider = function(provider) return M._options[provider] ~= nil or M.vendors[provider] ~= nil end
 
 ---get supported providers
 ---@param provider Provider
 ---@return AvanteProviderFunctor
 M.get_provider = function(provider)
-  if M.options[provider] ~= nil then
-    return vim.deepcopy(M.options[provider], true)
+  if M._options[provider] ~= nil then
+    return vim.deepcopy(M._options[provider], true)
   elseif M.vendors[provider] ~= nil then
     return vim.deepcopy(M.vendors[provider], true)
   else

--- a/lua/avante/config.lua
+++ b/lua/avante/config.lua
@@ -122,6 +122,7 @@ M._defaults = {
   ---4. support_paste_from_clipboard    : Whether to support pasting image from clipboard. This will be determined automatically based whether img-clip is available or not.
   ---5. minimize_diff                   : Whether to remove unchanged lines when applying a code block
   behaviour = {
+    auto_focus_sidebar = true,
     auto_suggestions = false, -- Experimental stage
     auto_set_highlight_group = true,
     auto_set_keymaps = true,

--- a/lua/avante/file_selector.lua
+++ b/lua/avante/file_selector.lua
@@ -267,4 +267,16 @@ end
 
 function FileSelector:get_selected_filepaths() return vim.deepcopy(self.selected_filepaths) end
 
+---@return nil
+function FileSelector:add_quickfix_files()
+  local quickfix_files = vim
+    .iter(vim.fn.getqflist({ items = 0 }).items)
+    :filter(function(item) return item.bufnr ~= 0 end)
+    :map(function(item) return Utils.relative_path(vim.api.nvim_buf_get_name(item.bufnr)) end)
+    :totable()
+  for _, filepath in ipairs(quickfix_files) do
+    self:add_selected_file(filepath)
+  end
+end
+
 return FileSelector

--- a/lua/avante/file_selector.lua
+++ b/lua/avante/file_selector.lua
@@ -142,8 +142,14 @@ function FileSelector:fzf_ui(handler)
     git_icons = false,
     actions = {
       ["default"] = function(selected)
-        local file = fzf_lua.path.entry_to_file(selected[1])
-        handler(file.path)
+        if not selected or #selected == 0 then return close_action() end
+        local selections = {}
+        for _, entry in ipairs(selected) do
+          local file = fzf_lua.path.entry_to_file(entry)
+          if file and file.path then table.insert(selections, file.path) end
+        end
+
+        if #selections > 0 then handler(#selections == 1 and selections[1] or selections) end
       end,
       ["esc"] = close_action,
       ["ctrl-c"] = close_action,
@@ -200,7 +206,6 @@ function FileSelector:telescope_ui(handler)
     :find()
 end
 
----@type FileSelectorHandler
 function FileSelector:native_ui(handler)
   local filepaths = vim
     .iter(self.file_cache)

--- a/lua/avante/file_selector.lua
+++ b/lua/avante/file_selector.lua
@@ -163,6 +163,7 @@ function FileSelector:telescope_ui(handler)
   local conf = require("telescope.config").values
   local actions = require("telescope.actions")
   local action_state = require("telescope.actions.state")
+  local action_utils = require("telescope.actions.utils")
 
   pickers
     .new(
@@ -176,9 +177,21 @@ function FileSelector:telescope_ui(handler)
           map("i", "<esc>", require("telescope.actions").close)
 
           actions.select_default:replace(function()
+            local picker = action_state.get_current_picker(prompt_bufnr)
+
+            if #picker:get_multi_selection() ~= 0 then
+              local selections = {}
+
+              action_utils.map_selections(prompt_bufnr, function(selection) table.insert(selections, selection[1]) end)
+
+              if #selections > 0 then handler(selections) end
+            else
+              local selection = action_state.get_selected_entry()
+
+              handler(selection[1])
+            end
+
             actions.close(prompt_bufnr)
-            local selection = action_state.get_selected_entry()
-            handler(selection[1])
           end)
           return true
         end,
@@ -202,19 +215,23 @@ end
 
 ---@return nil
 function FileSelector:show_select_ui()
-  local handler = function(filepath)
-    if not filepath then return end
-    local uniform_path = Utils.uniform_path(filepath)
-    if Config.file_selector.provider == "native" then
-      -- Native handler filters out already selected files
-      table.insert(self.selected_filepaths, uniform_path)
-      self:emit("update")
-    else
-      if not vim.tbl_contains(self.selected_filepaths, uniform_path) then
+  local handler = function(filepaths)
+    if not filepaths then return end
+    -- Convert single filepath to array for unified handling
+    local paths = type(filepaths) == "string" and { filepaths } or filepaths
+
+    for _, filepath in ipairs(paths) do
+      local uniform_path = Utils.uniform_path(filepath)
+      if Config.file_selector.provider == "native" then
         table.insert(self.selected_filepaths, uniform_path)
-        self:emit("update")
+      else
+        if not vim.tbl_contains(self.selected_filepaths, uniform_path) then
+          table.insert(self.selected_filepaths, uniform_path)
+        end
       end
     end
+
+    self:emit("update")
   end
 
   vim.schedule(function()

--- a/lua/avante/llm.lua
+++ b/lua/avante/llm.lua
@@ -183,7 +183,7 @@ M._stream = function(opts)
       end
       if not data then return end
       vim.schedule(function()
-        if Config.options[Config.provider] == nil and Provider.parse_stream_data ~= nil then
+        if Config[Config.provider] == nil and Provider.parse_stream_data ~= nil then
           if Provider.parse_response ~= nil then
             Utils.warn(
               "parse_stream_data and parse_response are mutually exclusive, and thus parse_response will be ignored. Make sure that you handle the incoming data correctly.",

--- a/lua/avante/llm.lua
+++ b/lua/avante/llm.lua
@@ -250,7 +250,6 @@ M._stream = function(opts)
           parse_response_without_stream(result.body)
         end)
       end
-      opts.on_complete(nil)
     end,
   })
 

--- a/lua/avante/llm.lua
+++ b/lua/avante/llm.lua
@@ -250,6 +250,7 @@ M._stream = function(opts)
           parse_response_without_stream(result.body)
         end)
       end
+      opts.on_complete(nil)
     end,
   })
 

--- a/lua/avante/providers/copilot.lua
+++ b/lua/avante/providers/copilot.lua
@@ -104,8 +104,10 @@ H.get_oauth_token = function()
   ---@type string
   local config_dir
 
-  if vim.tbl_contains({ "linux", "darwin" }, os_name) then
-    config_dir = (xdg_config and vim.fn.isdirectory(xdg_config) > 0) and xdg_config or vim.fn.expand("~/.config")
+  if xdg_config and vim.fn.isdirectory(xdg_config) > 0 then
+    config_dir = xdg_config
+  elseif vim.tbl_contains({ "linux", "darwin" }, os_name) then
+    config_dir = vim.fn.expand("~/.config")
   else
     config_dir = vim.fn.expand("~/AppData/Local")
   end

--- a/lua/avante/providers/gemini.lua
+++ b/lua/avante/providers/gemini.lua
@@ -69,8 +69,13 @@ M.parse_response = function(data_stream, _, opts)
   if not ok then opts.on_complete(json) end
   if json.candidates then
     if #json.candidates > 0 then
-      opts.on_chunk(json.candidates[1].content.parts[1].text)
-    elseif json.candidates.finishReason and json.candidates.finishReason == "STOP" then
+      if json.candidates[1].finishReason and json.candidates[1].finishReason == "STOP" then
+        opts.on_chunk(json.candidates[1].content.parts[1].text)
+        opts.on_complete(nil)
+      else
+        opts.on_chunk(json.candidates[1].content.parts[1].text)
+      end
+    else
       opts.on_complete(nil)
     end
   end

--- a/lua/avante/providers/openai.lua
+++ b/lua/avante/providers/openai.lua
@@ -54,6 +54,10 @@ M.get_user_message = function(opts)
   )
 end
 
+M.is_o_series_model = function(model)
+  return model and string.match(model, "^o%d+") ~= nil
+end
+
 M.parse_messages = function(opts)
   local messages = {}
   local provider = P[Config.provider]
@@ -61,7 +65,7 @@ M.parse_messages = function(opts)
 
   -- NOTE: Handle the case where the selected model is the `o1` model
   -- "o1" models are "smart" enough to understand user prompt as a system prompt in this context
-  if base.model and string.find(base.model, "o1") then
+  if M.is_o_series_model(base.model) then
     table.insert(messages, { role = "user", content = opts.system_prompt })
   else
     table.insert(messages, { role = "system", content = opts.system_prompt })
@@ -150,9 +154,10 @@ M.parse_curl_args = function(provider, code_opts)
     headers["Authorization"] = "Bearer " .. api_key
   end
 
-  -- NOTE: When using "o1" set the supported parameters only
+  -- NOTE: When using "o" series set the supported parameters only
   local stream = true
-  if base.model and string.find(base.model, "o1") then
+  if M.is_o_series_model(base.model) then
+    body_opts.max_completion_tokens = body_opts.max_tokens
     body_opts.max_tokens = nil
     body_opts.temperature = 1
   end

--- a/lua/avante/providers/openai.lua
+++ b/lua/avante/providers/openai.lua
@@ -54,9 +54,7 @@ M.get_user_message = function(opts)
   )
 end
 
-M.is_o_series_model = function(model)
-  return model and string.match(model, "^o%d+") ~= nil
-end
+M.is_o_series_model = function(model) return model and string.match(model, "^o%d+") ~= nil end
 
 M.parse_messages = function(opts)
   local messages = {}

--- a/lua/avante/selection.lua
+++ b/lua/avante/selection.lua
@@ -163,9 +163,10 @@ function Selection:create_editing_input()
       local response_lines_ = vim.split(full_response, "\n")
       local response_lines = {}
       for i, line in ipairs(response_lines_) do
-        if not (string.match(line, "^```") and (i == 1 or i == #response_lines_)) then
-          table.insert(response_lines, line)
-        end
+        if string.match(line, "^```") and (i == 1 or i == #response_lines_) then goto continue end
+        if string.match(line, "^```$") then goto continue end
+        table.insert(response_lines, line)
+        ::continue::
       end
       if #response_lines == 1 then
         local first_line = response_lines[1]
@@ -194,6 +195,7 @@ function Selection:create_editing_input()
       end
       self.prompt_input:stop_spinner()
       vim.defer_fn(function() self:close_editing_input() end, 0)
+      Utils.debug("full response:", full_response)
     end
 
     local filetype = api.nvim_get_option_value("filetype", { buf = code_bufnr })

--- a/lua/avante/sidebar.lua
+++ b/lua/avante/sidebar.lua
@@ -1803,6 +1803,13 @@ function Sidebar:create_input_container(opts)
           callback = function() self.file_selector:open() end,
         })
 
+        table.insert(mentions, {
+          description = "quickfix",
+          command = "quickfix",
+          details = "add files in quickfix list to chat context",
+          callback = function() self.file_selector:add_quickfix_files() end,
+        })
+
         cmp.register_source(
           "avante_commands",
           require("cmp_avante.commands"):new(self:get_commands(), self.input_container.bufnr)

--- a/lua/avante/sidebar.lua
+++ b/lua/avante/sidebar.lua
@@ -1104,13 +1104,13 @@ function Sidebar:refresh_winids()
       { "n", "i" },
       Config.mappings.sidebar.switch_windows,
       function() switch_windows() end,
-      { buffer = buf, noremap = true, silent = true }
+      { buffer = buf, noremap = true, silent = true, nowait = true }
     )
     Utils.safe_keymap_set(
       { "n", "i" },
       Config.mappings.sidebar.reverse_switch_windows,
       function() reverse_switch_windows() end,
-      { buffer = buf, noremap = true, silent = true }
+      { buffer = buf, noremap = true, silent = true, nowait = true }
     )
   end
 end

--- a/lua/avante/sidebar.lua
+++ b/lua/avante/sidebar.lua
@@ -224,8 +224,9 @@ local function transform_result_content(selected_files, result_content, prev_fil
       local start_line = 0
       local end_line = 0
       local match_filetype = nil
+      local filepath = current_filepath or prev_filepath or ""
       for _, file in ipairs(selected_files) do
-        if not Utils.is_same_file(file.path, prev_filepath or "") then goto continue1 end
+        if not Utils.is_same_file(file.path, filepath) then goto continue1 end
         local file_content = vim.split(file.content, "\n")
         if start_line ~= 0 or end_line ~= 0 then break end
         for j = 1, #file_content - (search_end - search_start) + 1 do

--- a/lua/avante/sidebar.lua
+++ b/lua/avante/sidebar.lua
@@ -1041,10 +1041,16 @@ function Sidebar:on_mount(opts)
     group = self.augroup,
     buffer = self.result_container.bufnr,
     callback = function()
-      self:focus()
-      if self.input_container and self.input_container.winid and api.nvim_win_is_valid(self.input_container.winid) then
-        api.nvim_set_current_win(self.input_container.winid)
-        if Config.windows.ask.start_insert then vim.cmd("startinsert") end
+      if Config.behaviour.auto_focus_sidebar then
+        self:focus()
+        if
+          self.input_container
+          and self.input_container.winid
+          and api.nvim_win_is_valid(self.input_container.winid)
+        then
+          api.nvim_set_current_win(self.input_container.winid)
+          if Config.windows.ask.start_insert then vim.cmd("startinsert") end
+        end
       end
       return true
     end,
@@ -1246,11 +1252,9 @@ function Sidebar:update_content(content, opts)
       Utils.update_buffer_content(self.result_container.bufnr, lines)
       Utils.lock_buf(self.result_container.bufnr)
       api.nvim_set_option_value("filetype", "Avante", { buf = self.result_container.bufnr })
-      if opts.focus and not self:is_focused_on_result() then
-        xpcall(function()
-          --- set cursor to bottom of result view
-          api.nvim_set_current_win(self.result_container.winid)
-        end, function(err) return err end)
+      if opts.focus and Config.behaviour.auto_focus_sidebar and not self:is_focused_on_result() then
+        --- set cursor to bottom of result view
+        xpcall(function() api.nvim_set_current_win(self.result_container.winid) end, function(err) return err end)
       end
 
       if opts.scroll then Utils.buf_scroll_to_end(self.result_container.bufnr) end
@@ -1710,6 +1714,7 @@ function Sidebar:create_input_container(opts)
           self.result_container
           and self.result_container.winid
           and api.nvim_win_is_valid(self.result_container.winid)
+          and Config.behaviour.auto_focus_sidebar
         then
           api.nvim_set_current_win(self.result_container.winid)
         end

--- a/lua/avante/sidebar.lua
+++ b/lua/avante/sidebar.lua
@@ -1326,13 +1326,15 @@ function Sidebar:render_history_content(history)
       goto continue
     end
     local selected_filepaths = entry.selected_filepaths
-    if not selected_filepaths then selected_filepaths = { entry.selected_file.filepath } end
+    if not selected_filepaths and entry.selected_file ~= nil then
+      selected_filepaths = { entry.selected_file.filepath }
+    end
     local prefix = render_chat_record_prefix(
       entry.timestamp,
       entry.provider,
       entry.model,
       entry.request or "",
-      selected_filepaths,
+      selected_filepaths or {},
       entry.selected_code
     )
     content = content .. prefix

--- a/lua/avante/sidebar.lua
+++ b/lua/avante/sidebar.lua
@@ -133,6 +133,13 @@ function Sidebar:focus()
   return false
 end
 
+function Sidebar:focus_input()
+  if self.input_container and self.input_container.winid and api.nvim_win_is_valid(self.input_container.winid) then
+    api.nvim_set_current_win(self.input_container.winid)
+    api.nvim_feedkeys("i", "n", false)
+  end
+end
+
 function Sidebar:is_open()
   return self.result_container
     and self.result_container.bufnr
@@ -1381,10 +1388,16 @@ function Sidebar:clear_history(args, cb)
   if next(chat_history) ~= nil then
     chat_history = {}
     Path.history.save(self.code.bufnr, chat_history)
-    self:update_content("Chat history cleared", { focus = false, scroll = false })
+    self:update_content(
+      "Chat history cleared",
+      { focus = false, scroll = false, callback = function() self:focus_input() end }
+    )
     if cb then cb(args) end
   else
-    self:update_content("Chat history is already empty", { focus = false, scroll = false })
+    self:update_content(
+      "Chat history is already empty",
+      { focus = false, scroll = false, callback = function() self:focus_input() end }
+    )
   end
 end
 
@@ -1404,10 +1417,17 @@ function Sidebar:reset_memory(args, cb)
     })
     Path.history.save(self.code.bufnr, chat_history)
     local history_content = self:render_history_content(chat_history)
-    self:update_content(history_content, { focus = false, scroll = true })
+    self:update_content(history_content, {
+      focus = false,
+      scroll = true,
+      callback = function() self:focus_input() end,
+    })
     if cb then cb(args) end
   else
-    self:update_content("Chat history is already empty", { focus = false, scroll = false })
+    self:update_content(
+      "Chat history is already empty",
+      { focus = false, scroll = false, callback = function() self:focus_input() end }
+    )
   end
 end
 

--- a/lua/avante/sidebar.lua
+++ b/lua/avante/sidebar.lua
@@ -193,6 +193,15 @@ local function transform_result_content(selected_files, result_content, prev_fil
     end
     if line_content == "<SEARCH>" then
       is_searching = true
+      local prev_line = result_lines[i - 1]
+      if
+        prev_line
+        and prev_filepath
+        and not prev_line:match("Filepath:.+")
+        and not prev_line:match("<FILEPATH>.+</FILEPATH>")
+      then
+        table.insert(transformed_lines, string.format("Filepath: %s", prev_filepath))
+      end
       local next_line = result_lines[i + 1]
       if next_line and next_line:match("^%s*```%w+$") then i = i + 1 end
       search_start = i + 1

--- a/lua/avante/sidebar.lua
+++ b/lua/avante/sidebar.lua
@@ -669,9 +669,7 @@ function Sidebar:apply(current_cursor)
     selected_snippets_map = all_snippets_map
   end
 
-  if Config.options.behaviour.minimize_diff then
-    selected_snippets_map = self:minimize_snippets(selected_snippets_map)
-  end
+  if Config.behaviour.minimize_diff then selected_snippets_map = self:minimize_snippets(selected_snippets_map) end
 
   vim.defer_fn(function()
     api.nvim_set_current_win(self.code.winid)

--- a/lua/avante/sidebar.lua
+++ b/lua/avante/sidebar.lua
@@ -232,6 +232,14 @@ local function transform_result_content(selected_files, result_content, prev_fil
         ::continue1::
       end
 
+      -- when the filetype isn't detected, fallback to matching based on filepath.
+      -- can happen if the llm tries to edit or create a file outside of it's context.
+      if not match_filetype then
+        local snippet_file_path = current_filepath or prev_filepath
+        local snippet_file_type = vim.filetype.match({ filename = snippet_file_path }) or "unknown"
+        match_filetype = snippet_file_type
+      end
+
       local search_start_tag_idx_in_transformed_lines = 0
       for j = 1, #transformed_lines do
         if transformed_lines[j] == "<SEARCH>" then
@@ -430,7 +438,8 @@ local function ensure_snippets_no_overlap(snippets_map)
     table.sort(snippets, function(a, b) return a.range[1] < b.range[1] end)
 
     local original_content = ""
-    if Utils.file.exists(filepath) then original_content = Utils.file.read_content(filepath) or "" end
+    local file_exists = Utils.file.exists(filepath)
+    if file_exists then original_content = Utils.file.read_content(filepath) or "" end
 
     local original_lines = vim.split(original_content, "\n")
 
@@ -438,6 +447,10 @@ local function ensure_snippets_no_overlap(snippets_map)
     local last_end_line = 0
     for _, snippet in ipairs(snippets) do
       if snippet.range[1] > last_end_line then
+        table.insert(new_snippets, snippet)
+        last_end_line = snippet.range[2]
+      elseif not file_exists and #snippets <= 1 then
+        -- if the file doesn't exist, and we only have 1 snippet, then we don't have to check for overlaps.
         table.insert(new_snippets, snippet)
         last_end_line = snippet.range[2]
       else

--- a/lua/avante/templates/planning.avanterules
+++ b/lua/avante/templates/planning.avanterules
@@ -116,6 +116,7 @@ Every *SEARCH/REPLACE block* must use this format:
 5. The start of replace block: <REPLACE>
 6. The lines to replace into the source code
 7. The end of the replace block: </REPLACE>
+8. Please *DO NOT* put *SEARCH/REPLACE block* inside three backticks: {%raw%}```{%endraw%}
 
 Use the *FULL* file path, as shown to you by the user.
 

--- a/lua/avante/utils/init.lua
+++ b/lua/avante/utils/init.lua
@@ -331,7 +331,7 @@ function M.warn(msg, opts)
 end
 
 function M.debug(...)
-  if not require("avante.config").options.debug then return end
+  if not require("avante.config").debug then return end
 
   local args = { ... }
   if #args == 0 then return end

--- a/lua/avante/utils/init.lua
+++ b/lua/avante/utils/init.lua
@@ -153,12 +153,12 @@ end
 ---@param str string
 ---@param opts? {suffix?: string, prefix?: string}
 function M.trim(str, opts)
-  if not opts then return str end
   local res = str
+  if not opts then return res end
   if opts.suffix then
-    res = str:sub(#str - #opts.suffix + 1) == opts.suffix and str:sub(1, #str - #opts.suffix) or str
+    res = res:sub(#res - #opts.suffix + 1) == opts.suffix and res:sub(1, #res - #opts.suffix) or res
   end
-  if opts.prefix then res = str:sub(1, #opts.prefix) == opts.prefix and str:sub(#opts.prefix + 1) or str end
+  if opts.prefix then res = res:sub(1, #opts.prefix) == opts.prefix and res:sub(#opts.prefix + 1) or res end
   return res
 end
 
@@ -462,6 +462,8 @@ function M.url_join(...)
 
     ::continue::
   end
+
+  if result:sub(-1) == "/" then result = result:sub(1, -2) end
 
   return result
 end

--- a/tests/utils/file_spec.lua
+++ b/tests/utils/file_spec.lua
@@ -1,0 +1,141 @@
+local File = require("avante.utils.file")
+local mock = require("luassert.mock")
+local stub = require("luassert.stub")
+
+describe("File", function()
+  local test_file = "test.txt"
+  local test_content = "test content\nline 2"
+
+  -- Mock vim API
+  local api_mock
+  local loop_mock
+
+  before_each(function()
+    -- Setup mocks
+    api_mock = mock(vim.api, true)
+    loop_mock = mock(vim.loop, true)
+  end)
+
+  after_each(function()
+    -- Clean up mocks
+    mock.revert(api_mock)
+    mock.revert(loop_mock)
+  end)
+
+  describe("read_content", function()
+    it("should read file content", function()
+      vim.fn.readfile = stub().returns({ "test content", "line 2" })
+
+      local content = File.read_content(test_file)
+      assert.equals(test_content, content)
+      assert.stub(vim.fn.readfile).was_called_with(test_file)
+    end)
+
+    it("should return nil for non-existent file", function()
+      vim.fn.readfile = stub().returns(nil)
+
+      local content = File.read_content("nonexistent.txt")
+      assert.is_nil(content)
+    end)
+
+    it("should use cache for subsequent reads", function()
+      vim.fn.readfile = stub().returns({ "test content", "line 2" })
+      local new_test_file = "test1.txt"
+
+      -- First read
+      local content1 = File.read_content(new_test_file)
+      assert.equals(test_content, content1)
+
+      -- Second read (should use cache)
+      local content2 = File.read_content(new_test_file)
+      assert.equals(test_content, content2)
+
+      -- readfile should only be called once
+      assert.stub(vim.fn.readfile).was_called(1)
+    end)
+  end)
+
+  describe("exists", function()
+    it("should return true for existing file", function()
+      loop_mock.fs_stat.returns({ type = "file" })
+
+      assert.is_true(File.exists(test_file))
+      assert.stub(loop_mock.fs_stat).was_called_with(test_file)
+    end)
+
+    it("should return false for non-existent file", function()
+      loop_mock.fs_stat.returns(nil)
+
+      assert.is_false(File.exists("nonexistent.txt"))
+    end)
+  end)
+
+  describe("get_file_icon", function()
+    local Filetype
+    local devicons_mock
+
+    before_each(function()
+      -- Mock plenary.filetype
+      Filetype = mock(require("plenary.filetype"), true)
+      -- Prepare devicons mock
+      devicons_mock = {
+        get_icon = stub().returns(""),
+      }
+      -- Reset _G.MiniIcons
+      _G.MiniIcons = nil
+    end)
+
+    after_each(function() mock.revert(Filetype) end)
+
+    it("should get icon using nvim-web-devicons", function()
+      Filetype.detect.returns("lua")
+      devicons_mock.get_icon.returns("")
+
+      -- Mock require for nvim-web-devicons
+      local old_require = _G.require
+      _G.require = function(module)
+        if module == "nvim-web-devicons" then return devicons_mock end
+        return old_require(module)
+      end
+
+      local icon = File.get_file_icon("test.lua")
+      assert.equals("", icon)
+      assert.stub(Filetype.detect).was_called_with("test.lua", {})
+      assert.stub(devicons_mock.get_icon).was_called()
+
+      _G.require = old_require
+    end)
+
+    it("should get icon using MiniIcons if available", function()
+      _G.MiniIcons = {
+        get = stub().returns("", "color", "name"),
+      }
+
+      Filetype.detect.returns("lua")
+
+      local icon = File.get_file_icon("test.lua")
+      assert.equals("", icon)
+      assert.stub(Filetype.detect).was_called_with("test.lua", {})
+      assert.stub(_G.MiniIcons.get).was_called_with("filetype", "lua")
+
+      _G.MiniIcons = nil
+    end)
+
+    it("should handle unknown filetypes", function()
+      Filetype.detect.returns(nil)
+      devicons_mock.get_icon.returns("")
+
+      -- Mock require for nvim-web-devicons
+      local old_require = _G.require
+      _G.require = function(module)
+        if module == "nvim-web-devicons" then return devicons_mock end
+        return old_require(module)
+      end
+
+      local icon = File.get_file_icon("unknown.xyz")
+      assert.equals("", icon)
+
+      _G.require = old_require
+    end)
+  end)
+end)

--- a/tests/utils/init_spec.lua
+++ b/tests/utils/init_spec.lua
@@ -1,0 +1,123 @@
+local Utils = require("avante.utils")
+
+describe("Utils", function()
+  describe("trim", function()
+    it("should trim prefix", function() assert.equals("test", Utils.trim("prefix_test", { prefix = "prefix_" })) end)
+
+    it("should trim suffix", function() assert.equals("test", Utils.trim("test_suffix", { suffix = "_suffix" })) end)
+
+    it(
+      "should trim both prefix and suffix",
+      function() assert.equals("test", Utils.trim("prefix_test_suffix", { prefix = "prefix_", suffix = "_suffix" })) end
+    )
+
+    it(
+      "should return original string if no match",
+      function() assert.equals("test", Utils.trim("test", { prefix = "xxx", suffix = "yyy" })) end
+    )
+  end)
+
+  describe("url_join", function()
+    it("should join url parts correctly", function()
+      assert.equals("http://example.com/path", Utils.url_join("http://example.com", "path"))
+      assert.equals("http://example.com/path", Utils.url_join("http://example.com/", "/path"))
+      assert.equals("http://example.com/path/to", Utils.url_join("http://example.com", "path", "to"))
+      assert.equals("http://example.com/path", Utils.url_join("http://example.com/", "/path/"))
+    end)
+
+    it("should handle empty parts", function()
+      assert.equals("http://example.com", Utils.url_join("http://example.com", ""))
+      assert.equals("http://example.com", Utils.url_join("http://example.com", nil))
+    end)
+  end)
+
+  describe("is_type", function()
+    it("should check basic types correctly", function()
+      assert.is_true(Utils.is_type("string", "test"))
+      assert.is_true(Utils.is_type("number", 123))
+      assert.is_true(Utils.is_type("boolean", true))
+      assert.is_true(Utils.is_type("table", {}))
+      assert.is_true(Utils.is_type("function", function() end))
+      assert.is_true(Utils.is_type("nil", nil))
+    end)
+
+    it("should check list type correctly", function()
+      assert.is_true(Utils.is_type("list", { 1, 2, 3 }))
+      assert.is_false(Utils.is_type("list", { a = 1, b = 2 }))
+    end)
+
+    it("should check map type correctly", function()
+      assert.is_true(Utils.is_type("map", { a = 1, b = 2 }))
+      assert.is_false(Utils.is_type("map", { 1, 2, 3 }))
+    end)
+  end)
+
+  describe("get_indentation", function()
+    it("should get correct indentation", function()
+      assert.equals("  ", Utils.get_indentation("  test"))
+      assert.equals("\t", Utils.get_indentation("\ttest"))
+      assert.equals("", Utils.get_indentation("test"))
+    end)
+
+    it("should handle empty or nil input", function()
+      assert.equals("", Utils.get_indentation(""))
+      assert.equals("", Utils.get_indentation(nil))
+    end)
+  end)
+
+  describe("remove_indentation", function()
+    it("should remove indentation correctly", function()
+      assert.equals("test", Utils.remove_indentation("  test"))
+      assert.equals("test", Utils.remove_indentation("\ttest"))
+      assert.equals("test", Utils.remove_indentation("test"))
+    end)
+
+    it("should handle empty or nil input", function()
+      assert.equals("", Utils.remove_indentation(""))
+      assert.equals(nil, Utils.remove_indentation(nil))
+    end)
+  end)
+
+  describe("is_first_letter_uppercase", function()
+    it("should detect uppercase first letter", function()
+      assert.is_true(Utils.is_first_letter_uppercase("Test"))
+      assert.is_true(Utils.is_first_letter_uppercase("ABC"))
+    end)
+
+    it("should detect lowercase first letter", function()
+      assert.is_false(Utils.is_first_letter_uppercase("test"))
+      assert.is_false(Utils.is_first_letter_uppercase("abc"))
+    end)
+  end)
+
+  describe("extract_mentions", function()
+    it("should extract @codebase mention", function()
+      local result = Utils.extract_mentions("test @codebase")
+      assert.equals("test ", result.new_content)
+      assert.is_true(result.enable_project_context)
+      assert.is_false(result.enable_diagnostics)
+    end)
+
+    it("should extract @diagnostics mention", function()
+      local result = Utils.extract_mentions("test @diagnostics")
+      assert.equals("test @diagnostics", result.new_content)
+      assert.is_false(result.enable_project_context)
+      assert.is_true(result.enable_diagnostics)
+    end)
+
+    it("should handle multiple mentions", function()
+      local result = Utils.extract_mentions("test @codebase @diagnostics")
+      assert.equals("test  @diagnostics", result.new_content)
+      assert.is_true(result.enable_project_context)
+      assert.is_true(result.enable_diagnostics)
+    end)
+  end)
+
+  describe("get_mentions", function()
+    it("should return valid mentions", function()
+      local mentions = Utils.get_mentions()
+      assert.equals("codebase", mentions[1].command)
+      assert.equals("diagnostics", mentions[2].command)
+    end)
+  end)
+end)


### PR DESCRIPTION
When you open a file that is outside of the current project directory/working directory, the file context for the current buffer is incorrect.

When opening a random file for example by running `:e ../../some-random-source-file.rs` the path would resolve to some-random-source-file.ts rather than the absolute path and the file context would be unable to read it.

Before:
<img width="474" alt="image" src="https://github.com/user-attachments/assets/a0f8ba5a-c061-4f49-925c-919beacbf0c6" />

After:
<img width="469" alt="image" src="https://github.com/user-attachments/assets/45345248-f9d8-4352-8974-7eb5cb397c95" />

