### PR TITLE
feat(sidebar): allow chat without any files selected.

### DIFF
--- a/lua/avante/sidebar.lua
+++ b/lua/avante/sidebar.lua
@@ -2054,11 +2054,6 @@ function Sidebar:create_selected_files_container()
   local render = function()
     local selected_filepaths_ = self.file_selector:get_selected_filepaths()
 
-    if #selected_filepaths_ == 0 then
-      self.selected_files_container:unmount()
-      return
-    end
-
     local selected_filepaths_with_icon = {}
     for _, filepath in ipairs(selected_filepaths_) do
       local icon = Utils.file.get_file_icon(filepath)


### PR DESCRIPTION
Small change to allow a user to remove all files without closing the sidebar. I've created this as a result of this issue: https://github.com/yetone/avante.nvim/issues/970.

I'm not sure if it was intended that the sidebar would close when the file context was removed as the WinClosed auto command is closing the entire sidebar.

Happy to find another way if we'd prefer to have the selected files container not visible after all files have been deleted.

Raised PR as a result of this isssue: https://github.com/yetone/avante.nvim/issues/970

After:
<img width="463" alt="image" src="https://github.com/user-attachments/assets/f62563ac-ae90-4af2-a350-02a5a21d8acd" />
