### PR TITLE
feat(sidebar): move quit and close key mappings into config values.

### DIFF
--- a/lua/avante/config.lua
+++ b/lua/avante/config.lua
@@ -188,6 +188,7 @@ M.defaults = {
       reverse_switch_windows = "<S-Tab>",
       remove_file = "d",
       add_file = "@",
+      close = { "<Esc>", "q" },
     },
     files = {
       add_current = "<leader>ac", -- Add current buffer to selected files

--- a/lua/avante/sidebar.lua
+++ b/lua/avante/sidebar.lua
@@ -1988,12 +1988,7 @@ function Sidebar:render(opts)
     xpcall(function() api.nvim_buf_set_name(self.result_container.bufnr, RESULT_BUF_NAME) end, function(_) end)
   end)
 
-  self.result_container:map("n", "q", function()
-    Llm.cancel_inflight_request()
-    self:close()
-  end)
-
-  self.result_container:map("n", "<Esc>", function()
+  self.result_container:map("n", Config.mappings.sidebar.close, function()
     Llm.cancel_inflight_request()
     self:close()
   end)


### PR DESCRIPTION
Small change that makes quitting / closing the sidebar with `<Esc>` or `q`, configurable via the Avante config. This should help with reported bugs such as this: https://github.com/yetone/avante.nvim/issues/917.