### PR TITLE
feat(context): mention @quickfix to add files in qf to context

### DIFF
--- a/lua/avante/file_selector.lua
+++ b/lua/avante/file_selector.lua
@@ -267,4 +267,16 @@ end
 
 function FileSelector:get_selected_filepaths() return vim.deepcopy(self.selected_filepaths) end
 
+---@return nil
+function FileSelector:add_quickfix_files()
+  local quickfix_files = vim
+    .iter(vim.fn.getqflist({ items = 0 }).items)
+    :filter(function(item) return item.bufnr ~= 0 end)
+    :map(function(item) return Utils.relative_path(vim.api.nvim_buf_get_name(item.bufnr)) end)
+    :totable()
+  for _, filepath in ipairs(quickfix_files) do
+    self:add_selected_file(filepath)
+  end
+end
+
 return FileSelector

--- a/lua/avante/sidebar.lua
+++ b/lua/avante/sidebar.lua
@@ -1790,6 +1790,13 @@ function Sidebar:create_input_container(opts)
           callback = function() self.file_selector:open() end,
         })
 
+        table.insert(mentions, {
+          description = "quickfix",
+          command = "quickfix",
+          details = "add files in quickfix list to chat context",
+          callback = function() self.file_selector:add_quickfix_files() end,
+        })
+
         cmp.register_source(
           "avante_commands",
           require("cmp_avante.commands"):new(self:get_commands(), self.input_container.bufnr)


### PR DESCRIPTION
Neovim allows quickfix list to be populated in a variety of ways: grep, lsp symbol references etc. Being able to add files in the quickfix window to the LLM chat context allows for interesting workflows. For example, one could search for a symbol using the LSP integration, populate the quickfix with that list and then pass those along as context in Avante using @quickfix mention in the sidebar.

If there are no files in the quickfix list or the items do not have a file, nothing is added to the context.