### PR TITLE
fix (sidebar) rendering and applying snippets for new files

### DIFF
--- a/lua/avante/sidebar.lua
+++ b/lua/avante/sidebar.lua
@@ -232,6 +232,14 @@ local function transform_result_content(selected_files, result_content, prev_fil
         ::continue1::
       end
 
+      -- when the filetype isn't detected, fallback to matching based on filepath.
+      -- can happen if the llm tries to edit or create a file outside of it's context.
+      if not match_filetype then
+        local snippet_file_path = current_filepath or prev_filepath
+        local snippet_file_type = vim.filetype.match({ filename = snippet_file_path }) or "unknown"
+        match_filetype = snippet_file_type
+      end
+
       local search_start_tag_idx_in_transformed_lines = 0
       for j = 1, #transformed_lines do
         if transformed_lines[j] == "<SEARCH>" then
@@ -430,7 +438,8 @@ local function ensure_snippets_no_overlap(snippets_map)
     table.sort(snippets, function(a, b) return a.range[1] < b.range[1] end)
 
     local original_content = ""
-    if Utils.file.exists(filepath) then original_content = Utils.file.read_content(filepath) or "" end
+    local file_exists = Utils.file.exists(filepath)
+    if file_exists then original_content = Utils.file.read_content(filepath) or "" end
 
     local original_lines = vim.split(original_content, "\n")
 
@@ -438,6 +447,10 @@ local function ensure_snippets_no_overlap(snippets_map)
     local last_end_line = 0
     for _, snippet in ipairs(snippets) do
       if snippet.range[1] > last_end_line then
+        table.insert(new_snippets, snippet)
+        last_end_line = snippet.range[2]
+      elseif not file_exists and #snippets <= 1 then
+        -- if the file doesn't exist, and we only have 1 snippet, then we don't have to check for overlaps.
         table.insert(new_snippets, snippet)
         last_end_line = snippet.range[2]
       else


### PR DESCRIPTION
Applying and creating new files from the sidebar would result in an overlap detection error. Also fixes a rendering bug for snippets for new files and files that are outside of the llm file context.

As always, let me know if you need any improvements/changes/adjustments e.t.c.

Issue reported in: https://github.com/yetone/avante.nvim/issues/978

Before:
<img width="1512" alt="image" src="https://github.com/user-attachments/assets/839eb710-9300-4eeb-adfe-f704673cf31e" />

After:
<img width="1512" alt="image" src="https://github.com/user-attachments/assets/1ec50af9-ee9b-48d9-a9db-c4c5d24dd7c2" />

