### PR TITLE
feat: respect gitignore for autosuggestions

### DIFF
--- a/lua/avante/config.lua
+++ b/lua/avante/config.lua
@@ -123,6 +123,7 @@ M.defaults = {
   ---5. minimize_diff                   : Whether to remove unchanged lines when applying a code block
   behaviour = {
     auto_suggestions = false, -- Experimental stage
+    auto_suggestions_respect_ignore = false,
     auto_set_highlight_group = true,
     auto_set_keymaps = true,
     auto_apply_diff_after_generation = false,

--- a/lua/avante/utils/init.lua
+++ b/lua/avante/utils/init.lua
@@ -631,7 +631,7 @@ function M.parse_gitignore(gitignore_path)
   return ignore_patterns, negate_patterns
 end
 
-local function is_ignored(file, ignore_patterns, negate_patterns)
+function M.is_ignored(file, ignore_patterns, negate_patterns)
   for _, pattern in ipairs(negate_patterns) do
     if file:match(pattern) then return false end
   end
@@ -655,7 +655,7 @@ function M.scan_directory(directory, ignore_patterns, negate_patterns)
     if type == "directory" then
       vim.list_extend(files, M.scan_directory(full_path, ignore_patterns, negate_patterns))
     elseif type == "file" then
-      if not is_ignored(full_path, ignore_patterns, negate_patterns) then table.insert(files, full_path) end
+      if not M.is_ignored(full_path, ignore_patterns, negate_patterns) then table.insert(files, full_path) end
     end
   end
 


### PR DESCRIPTION
Previously if autosuggestions were enabled, they were enabled for every file.

This PR introduces an option to disable autosuggestions on gitignored files.
Motivation was for env files which I did not want to send any data from with private content such as api keys.
```
behaviour.auto_suggestions_respect_ignore: bool
```

Further work could include a custom table config that includes patterns to ignore in addition to the gitignore.