### PR TITLE
fix(switch_windows): add nowait to avoid pre-<Tab> keymap

### DIFF
--- a/lua/avante/sidebar.lua
+++ b/lua/avante/sidebar.lua
@@ -1104,13 +1104,13 @@ function Sidebar:refresh_winids()
       { "n", "i" },
       Config.mappings.sidebar.switch_windows,
       function() switch_windows() end,
-      { buffer = buf, noremap = true, silent = true }
+      { buffer = buf, noremap = true, silent = true, nowait = true }
     )
     Utils.safe_keymap_set(
       { "n", "i" },
       Config.mappings.sidebar.reverse_switch_windows,
       function() reverse_switch_windows() end,
-      { buffer = buf, noremap = true, silent = true }
+      { buffer = buf, noremap = true, silent = true, nowait = true }
     )
   end
 end


### PR DESCRIPTION
if you have an global `<Tab><Tab>` keymap, there will be an delay when using `<Tab>`, and i think this `nowait` will be useful.