### PR TITLE
fix(copilot): Prioritize `XDG_CONFIG_HOME` for OAuth token references on Windows

### DIFF
--- a/lua/avante/providers/copilot.lua
+++ b/lua/avante/providers/copilot.lua
@@ -104,8 +104,10 @@ H.get_oauth_token = function()
   ---@type string
   local config_dir
 
-  if vim.tbl_contains({ "linux", "darwin" }, os_name) then
-    config_dir = (xdg_config and vim.fn.isdirectory(xdg_config) > 0) and xdg_config or vim.fn.expand("~/.config")
+  if xdg_config and vim.fn.isdirectory(xdg_config) > 0 then
+    config_dir = xdg_config
+  elseif vim.tbl_contains({ "linux", "darwin" }, os_name) then
+    config_dir = vim.fn.expand("~/.config")
   else
     config_dir = vim.fn.expand("~/AppData/Local")
   end


### PR DESCRIPTION
## Overview

This PR fixes an issue where, on Windows environments with `XDG_CONFIG_HOME` set, Copilot's OAuth token cannot be found, resulting in the following error:

```
...m-data/lazy/avante.nvim/lua/avante/providers/copilot.lua:293: You must setup copilot with either copilot.lua or copilot.vim
```

The detailed stack trace is as follows:

```
- avante.nvim\lua\avante\providers\copilot.lua:120 _in_ **get_oauth_token**
- avante.nvim\lua\avante\providers\copilot.lua:293 _in_ **setup**
- avante.nvim\lua\avante\providers\init.lua:164 _in_ **setup**
- avante.nvim\lua\avante\providers\init.lua:317 _in_ **setup**
- avante.nvim\lua\avante\init.lua:367 _in_ **setup**
```

## Cause

On Windows, the current implementation attempts to load the authentication file (`hosts.json` , `apps.json`) from:
```
~/AppData/Local/github-copilot/
```

However, if `XDG_CONFIG_HOME` is set, the file is actually generated at:
```
$XDG_CONFIG_HOME/github-copilot/
```

As a result, the OAuth token cannot be retrieved and the above error is triggered.

## Changes

- The code now checks `XDG_CONFIG_HOME` first on all platforms.
- If the file is not found there, it falls back to the existing logic (on Windows, `~/AppData/Local`).

This behavior aligns with how `copilot.lua` currently works:

https://github.com/zbirenbaum/copilot.lua/blob/886ee73b6d464b2b3e3e6a7ff55ce87feac423a9/lua/copilot/auth.lua#L171

https://github.com/zbirenbaum/copilot.lua/blob/886ee73b6d464b2b3e3e6a7ff55ce87feac423a9/lua/copilot/auth.lua#L134-L151

## Repro

1. On Windows, define the `XDG_CONFIG_HOME` environment variable and point it to any directory.
2. Sign in to Copilot so that `$XDG_CONFIG_HOME/github-copilot/apps.json` is generated.
3. Apply the following configuration:
   ```lua
   require("avante").setup({
     provider = "copilot",
   })
   ```
