### PR TITLE
fix: Build.ps1 build from source not work

### DIFF
--- a/Build.ps1
+++ b/Build.ps1
@@ -17,10 +17,11 @@ function Build-FromSource($feature) {
 
     cargo build --release --features=$feature
 
+    $SCRIPT_DIR = $PSScriptRoot
     $targetTokenizerFile = "avante_tokenizers.dll"
     $targetTemplatesFile = "avante_templates.dll"
-    Copy-Item (Join-Path "target\release\avante_tokenizers.dll") (Join-Path $BuildDir $targetTokenizerFile)
-    Copy-Item (Join-Path "target\release\avante_templates.dll") (Join-Path $BuildDir $targetTemplatesFile)
+    Copy-Item (Join-Path $SCRIPT_DIR "target\release\avante_tokenizers.dll") (Join-Path $BuildDir $targetTokenizerFile)
+    Copy-Item (Join-Path $SCRIPT_DIR "target\release\avante_templates.dll") (Join-Path $BuildDir $targetTemplatesFile)
 
     Remove-Item -Recurse -Force "target"
 }


### PR DESCRIPTION
`.\Build.ps1 -BuildFromSource true` was broken, because `Join-Path` was passed only one parameter