### PR TITLE
fix(get_provider): fix nil access table for vendors

### DIFF
--- a/lua/avante/config.lua
+++ b/lua/avante/config.lua
@@ -259,6 +259,9 @@ M.diff = {}
 ---@type Provider[]
 M.providers = {}
 
+---@type AvanteProvider[]
+M.vendors = {}
+
 ---@param opts? avante.Config
 function M.setup(opts)
   vim.validate({ opts = { opts, "table", true } })


### PR DESCRIPTION
We need to instantiate the vendors table so the method can properly check the vendors table to resolve `lua/avante/config.lua:343: attempt to index field 'vendors' (a nil value)`

```lua
  elseif M.vendors[provider] ~= nil then
    return vim.deepcopy(M.vendors[provider], true)
```

Just discovered while running tests in nixpkgs, figured I'd create a PR instead of just ignoring the modules for testing. 