### PR TITLE
fix: typo in suggesting.avanterules

### DIFF
--- a/lua/avante/templates/suggesting.avanterules
+++ b/lua/avante/templates/suggesting.avanterules
@@ -42,7 +42,7 @@ Guidelines:
   3. DO NOT include three backticks: {%raw%}```{%endraw%} in your suggestion. Treat the suggested code AS IS.
   4. Each element in the returned list is a COMPLETE code snippet.
   5. MUST be a valid JSON format. DO NOT be lazy!
-  6. Only return the new code to be inserted. DON NOT be lazy!
+  6. Only return the new code to be inserted. DO NOT be lazy!
   7. Please strictly check the code around the position and ensure that the complete code after insertion is correct. DO NOT be lazy!
   8. Do not return the entire file content or any surrounding code.
   9. Do not include any explanations, comments, or line numbers in your response.


### PR DESCRIPTION
Change:
- Typo in suggesting.avanterules: "DON NOT" -> "DO NOT".

Was reviewing the latest changes to avante and noticed this small typo introduced in #1071, doubt it would confuse the model much anyway but figured I might as well throw in a quick fix.