### PR TITLE
fix (filetype detection) improve filetype detection for find and replace snippets

### DIFF
--- a/lua/avante/file_selector.lua
+++ b/lua/avante/file_selector.lua
@@ -285,7 +285,9 @@ function FileSelector:get_selected_files_contents()
       if read_err then Utils.debug("failed to read:", file_path, read_err) end
 
       -- Detect the file type
-      local filetype = vim.filetype.match({ filename = file_path, contents = contents }) or "unknown"
+      local filetype = Utils.file.detect_filetype(file_path, {
+        contents = vim.split(content, "\n"),
+      })
 
       table.insert(contents, { path = file_path, content = content, file_type = filetype })
     end

--- a/lua/avante/sidebar.lua
+++ b/lua/avante/sidebar.lua
@@ -253,7 +253,7 @@ local function transform_result_content(selected_files, result_content, prev_fil
       -- can happen if the llm tries to edit or create a file outside of it's context.
       if not match_filetype then
         local snippet_file_path = current_filepath or prev_filepath
-        local snippet_file_type = vim.filetype.match({ filename = snippet_file_path }) or "unknown"
+        local snippet_file_type = Utils.file.detect_filetype(snippet_file_path, {})
         match_filetype = snippet_file_type
       end
 


### PR DESCRIPTION
Added some code to improve filetype detection.

Before:
<img width="586" alt="image" src="https://github.com/user-attachments/assets/6bf33599-3122-48bc-a4ba-a8b325690999" />

After:
<img width="580" alt="image" src="https://github.com/user-attachments/assets/ac7a5fe4-f4df-478b-ab39-dab7b9dba5ea" />

Credit to commit from this repository commit and the discussion in the neovim repo:
https://github.com/artemave/workspace-diagnostics.nvim/commit/ed04f40ec2ca55a9dab42ef0e4d3e7b655b752cd