### PR TITLE
feat: improve ruby parsing

### DIFF
--- a/crates/avante-repo-map/queries/tree-sitter-ruby-defs.scm
+++ b/crates/avante-repo-map/queries/tree-sitter-ruby-defs.scm
@@ -1,16 +1,26 @@
 ;; Capture top-level methods, class definitions, and methods within classes
-(program
-  (class
-    (body_statement
-      (call) @class_call
-      (assignment) @class_assignment
-      (method) @method
-    )
-  ) @class
-)
+
+(class
+  (body_statement
+    (call)? @class_call
+    (assignment)? @class_assignment
+    (method)? @method
+  )
+) @class
+
 (program
   (method) @function
 )
 (program
   (assignment) @assignment
+)
+
+(module) @module
+
+(module
+  (body_statement
+    (call)? @class_call
+    (assignment)? @class_assignment
+    (method)? @method
+  )
 )


### PR DESCRIPTION
I noticed the ruby parsing didn't work for most ruby files, so I adjusted the treesitter query and implemented module and class definitions with proper namespaced names. Also implemented detection of private class methods.
Check the test result for `test_ruby2`:

It parses this:
```ruby
# frozen_string_literal: true

require('jwt')

top_level_var = 1

def top_level_func
  inner_var_in_func = 2
end

module A
  module B
    @module_var = :foo

    def module_method
      @module_var
    end

    class C < Base
      TEST_CONST = 1
      @class_var = :bar
      attr_accessor :a, :b

      def initialize(a, b)
        @a = a
        @b = b
        super
      end

      def bar
        inner_var_in_method = 1
        true
      end

      private

      def baz(request, params)
        auth_header = request.headers['Authorization']
        parts = auth_header.try(:split, /\s+/)
        JWT.decode(parts.last)
      end
    end
  end
end

```

into

```
var top_level_var
func top_level_func() -> void
module A{}
module A::B{
  func module_method() -> void
  var @module_var
}
class A::B::C{
  func initialize(a, b) -> void
  func bar() -> void
  private func baz(request, params) -> void
  var TEST_CONST
  var @class_var
}
```
I create a new test `test_ruby2` since I wanted to show the results of `test_ruby` with the changes. I noticed `test_ruby` includes invalid ruby syntax (functions in functions, classes in functions), so I figured it would be best to replace `test_ruby` with `test_ruby2` since `test_ruby2` includes the same tests but only valid syntax. If a user wants to create a repo map for a file with errors, I would think they should expect the parser to pick up the invalid syntax.