### PR TITLE
fix 'bug: custom vendor configuration is broken (#1089)'

### DIFF
--- a/lua/avante/config.lua
+++ b/lua/avante/config.lua
@@ -263,9 +263,6 @@ M.diff = {}
 ---@type Provider[]
 M.providers = {}
 
----@type AvanteProvider[]
-M.vendors = {}
-
 ---@param opts? avante.Config
 function M.setup(opts)
   vim.validate({ opts = { opts, "table", true } })
@@ -357,7 +354,7 @@ M.has_provider = function(provider) return M._options[provider] ~= nil or M.vend
 M.get_provider = function(provider)
   if M._options[provider] ~= nil then
     return vim.deepcopy(M._options[provider], true)
-  elseif M.vendors[provider] ~= nil then
+  elseif M.vendors and M.vendors[provider] ~= nil then
     return vim.deepcopy(M.vendors[provider], true)
   else
     error("Failed to find provider: " .. provider, 2)


### PR DESCRIPTION
As mentioned in 'bug: custom vendor configuration is broken (#1089)', the changes made in commit 'fix(get_provider): fix nil access table for vendors (#1074)' has broken the vendors config.

Assigning M.vendors to an empty table {} at line 267 causes the metatable set for M at line 340 to lose its effect. As a result, accessing M.vendors does not retrieve the correct vendors from the configuration but instead always accesses an empty table.

To resolve this issue, I removed the assignment statement that sets M.vendors to {}, and now everything works as expected. Additionally, to address the concern that likely prompted commit #1074, I've implemented a check before accessing M.vendors to prevent potential indexing of a nil value.