### PR TITLE
chore(sidebar): set different filetype for the selected files buffer

### DIFF
--- a/lua/avante/sidebar.lua
+++ b/lua/avante/sidebar.lua
@@ -2097,7 +2097,7 @@ function Sidebar:create_selected_files_container()
       swapfile = false,
       buftype = "nofile",
       bufhidden = "wipe",
-      filetype = "Avante",
+      filetype = "AvanteSelectedFiles",
     }),
     win_options = vim.tbl_deep_extend("force", base_win_options, {
       wrap = Config.windows.wrap,


### PR DESCRIPTION
Set different filetypes so that [edgy.nvim](https://github.com/folke/edgy.nvim) can easily identify the result buffer and the selected files buffer.