### PR TITLE
feat(ci/release): use ubuntu-24.04-arm on aarch64

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -52,7 +52,7 @@ jobs:
       matrix:
         feature: [lua51, luajit]
         config:
-          - os: ubuntu-latest
+          - os: ubuntu-24.04-arm
             os_name: linux
             arch: aarch64
             rust_target: aarch64-unknown-linux-gnu
@@ -85,14 +85,6 @@ jobs:
 
     steps:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # ratchet:actions/checkout@v4
-
-      # Step 1: Set up QEMU for multi-architecture support
-      - name: Set up QEMU
-        if: ${{ matrix.config.docker_platform == 'linux/aarch64' }}
-        uses: docker/setup-qemu-action@v2
-        with:
-          platforms: all
-
       - uses: Swatinem/rust-cache@82a92a6e8fbeee089604da2575dc567ae9ddeaab # ratchet:Swatinem/rust-cache@v2
         if: ${{ matrix.config.container == null }}
       - uses: dtolnay/rust-toolchain@7b1c307e0dcbda6122208f10795a713336a9b35a # ratchet:dtolnay/rust-toolchain@master


### PR DESCRIPTION
Linux arm64 hosted runners now available for free in public repositories.

FYI: https://github.blog/changelog/2025-01-16-linux-arm64-hosted-runners-now-available-for-free-in-public-repositories-public-preview

Tested against: https://github.com/yuchanns/avante.nvim/actions/runs/12827307859/job/35769003270

Benifits: reducing build time from 32m to 2m.