### PR TITLE
Specify the host so the API always finds the release.

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -67,7 +67,7 @@ if [ ! -d "$TARGET_DIR" ]; then
 fi
 
 if test_command "gh" && test_gh_auth; then
-    gh release download --repo "$REPO_OWNER/$REPO_NAME" --pattern "*$ARTIFACT_NAME_PATTERN*" --clobber --output - | tar -zxv -C "$TARGET_DIR"
+    gh release download --repo "github.com/$REPO_OWNER/$REPO_NAME" --pattern "*$ARTIFACT_NAME_PATTERN*" --clobber --output - | tar -zxv -C "$TARGET_DIR"
 else
     # Get the artifact download URL
     ARTIFACT_URL=$(curl -s "https://api.github.com/repos/$REPO_OWNER/$REPO_NAME/releases/latest" | grep "browser_download_url" | cut -d '"' -f 4 | grep $ARTIFACT_NAME_PATTERN)


### PR DESCRIPTION
There was an issue where since I'm authenticated to an enterprise Github, this refused to find the release. Even running the switch with `gh auth switch` and switching to github.com didn't resolve the issue. However, since this command's documentation shows host is an expected, optional component of the `--repo` argument, and we know this should be looking there, this avoids any trouble. Now the build and install works correctly.