### PR TITLE
Add File Selector Provider for mini.pick.

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,7 +61,10 @@ For building binary if you wish to build from source, then `cargo` is required. 
     "nvim-lua/plenary.nvim",
     "MunifTanjim/nui.nvim",
     --- The below dependencies are optional,
+    "echasnovski/mini.pick", -- for file_selector provider mini.pick
+    "nvim-telescope/telescope.nvim", -- for file_selector provider telescope
     "hrsh7th/nvim-cmp", -- autocompletion for avante commands and mentions
+    "ibhagwan/fzf-lua", -- for file_selector provider fzf
     "nvim-tree/nvim-web-devicons", -- or echasnovski/mini.icons
     "zbirenbaum/copilot.lua", -- for providers='copilot'
     {
@@ -327,7 +330,7 @@ This is achieved but emulating nvim-cmp using blink.compat
 
 ```lua
       file_selector = {
-        --- @alias FileSelectorProvider "native" | "fzf" | "telescope" | string
+        --- @alias FileSelectorProvider "native" | "fzf" | "mini.pick" | "telescope" | string
         provider = "fzf",
         -- Options override for custom providers
         provider_opts = {},

--- a/lua/avante/config.lua
+++ b/lua/avante/config.lua
@@ -241,7 +241,7 @@ M._defaults = {
   },
   --- @class AvanteFileSelectorConfig
   file_selector = {
-    --- @alias FileSelectorProvider "native" | "fzf" | "telescope" | string
+    --- @alias FileSelectorProvider "native" | "fzf" | "mini.pick" | "telescope" | string
     provider = "native",
     -- Options override for custom providers
     provider_opts = {},

--- a/lua/avante/file_selector.lua
+++ b/lua/avante/file_selector.lua
@@ -158,6 +158,15 @@ function FileSelector:fzf_ui(handler)
   }))
 end
 
+function FileSelector:mini_pick_ui(handler)
+  local success, mini_pick = pcall(require, "mini.pick")
+  if not success then
+    Utils.error("mini.pick is not installed. Please install mini.pick to use it as a file selector.")
+    return
+  end
+  handler(mini_pick.builtin.files())
+end
+
 function FileSelector:telescope_ui(handler)
   local success, _ = pcall(require, "telescope")
   if not success then
@@ -245,6 +254,8 @@ function FileSelector:show_select_ui()
       self:native_ui(handler)
     elseif Config.file_selector.provider == "fzf" then
       self:fzf_ui(handler)
+    elseif Config.file_selector.provider == "mini.pick" then
+      self:mini_pick_ui(handler)
     elseif Config.file_selector.provider == "telescope" then
       self:telescope_ui(handler)
     else


### PR DESCRIPTION
While I think it might be a good idea to just accept a handler for picking in files, this follows the pattern that is already in place and allows a user to specify mini.pick if preferred.