### PR TITLE
Fix: Prevent nil result_container error on buffer detach

### DIFF
--- a/lua/avante/sidebar.lua
+++ b/lua/avante/sidebar.lua
@@ -68,7 +68,7 @@ function Sidebar:reset()
   self.code = { bufnr = 0, winid = 0, selection = nil }
   self.winids =
     { result_container = 0, selected_files_container = 0, selected_code_container = 0, input_container = 0 }
-  self.result_container = nil
+  self.result_container = self.result_container or {}
   self.selected_code_container = nil
   self.selected_files_container = nil
   self.input_container = nil
@@ -2100,7 +2100,11 @@ function Sidebar:render(opts)
 
   -- reset states when buffer is closed
   api.nvim_buf_attach(self.code.bufnr, false, {
-    on_detach = function(_, _) self:reset() end,
+    on_detach = function(_, _)
+      if self and self.reset then
+        self:reset()
+      end
+    end,
   })
 
   self:create_selected_code_container()


### PR DESCRIPTION
## Description
This PR fixes an issue where `avante.nvim` throws an error when a buffer is closed. The error occurs in `sidebar.lua` at line 951 because `self.result_container` becomes `nil`, leading to an attempt to index a nil value.

## Issue
When `api.nvim_buf_attach()` is used to reset states on `on_detach`, `self:reset()` is called, which inadvertently clears `result_container`. This causes an error when the plugin tries to reference it later.
![image](https://github.com/user-attachments/assets/e2c00710-21bb-4a54-8fdb-edde3bdf9e7e)

## Solution
- Added a **nil check** before calling `self:reset()`.
- Ensured that `result_container` is always a **valid table** in `reset()`.

### **Code Changes**
#### **Before**
```lua
api.nvim_buf_attach(self.code.bufnr, false, {
  on_detach = function(_, _)
    self:reset()
  end,
})
```

#### **After**
```lua
api.nvim_buf_attach(self.code.bufnr, false, {
  on_detach = function(_, _)
    if self and self.reset then
      self:reset()
    end
  end,
})
```

### **Testing**

- Tested in Neovim v0.10+
- No longer triggers an error when buffers are closed.

### **Checklist**

- [x]  Fixes the result_container nil error.
- [x]  Tested on multiple buffers.
- [x]  No breaking changes.