### PR TITLE
chore: make azure o series models stream

### DIFF
--- a/lua/avante/providers/azure.lua
+++ b/lua/avante/providers/azure.lua
@@ -25,12 +25,10 @@ M.parse_curl_args = function(provider, code_opts)
   }
   if P.env.require_api_key(base) then headers["api-key"] = provider.parse_api_key() end
 
-  -- NOTE: When using "o1" set the supported parameters only
-  local stream = true
-  if base.model and string.find(base.model, "o1") then
+  -- NOTE: When using "o" series set the supported parameters only
+  if O.is_o_series_model(base.model) then
     body_opts.max_tokens = nil
     body_opts.temperature = 1
-    stream = false
   end
 
   return {
@@ -43,7 +41,7 @@ M.parse_curl_args = function(provider, code_opts)
     headers = headers,
     body = vim.tbl_deep_extend("force", {
       messages = M.parse_messages(code_opts),
-      stream = stream,
+      stream = true,
     }, body_opts),
   }
 end


### PR DESCRIPTION
It appears the Azure o series models now support streaming, like their OpenAI counterparts do. This small changes bring the Azure implementation in line with this. Coincidentally, this works around issue #1008, at least for the o series models, although it doesn't fix it.