### PR TITLE
fix(file_selector): make sure to flatten selected_paths if picker yields a single string

### DIFF
--- a/lua/avante/config.lua
+++ b/lua/avante/config.lua
@@ -252,6 +252,8 @@ M._defaults = {
     provider = "native",
     -- Options override for custom providers
     provider_opts = {},
+    --- @type fun(selected_paths: string[] | string | nil): nil
+    handler = nil,
   },
   suggestion = {
     debounce = 600,

--- a/lua/avante/file_selector.lua
+++ b/lua/avante/file_selector.lua
@@ -234,7 +234,7 @@ function FileSelector:mini_pick_ui(handler)
     Utils.error("mini.pick is not installed. Please install mini.pick to use it as a file selector.")
     return
   end
-  handler(MiniPick.builtin.files())
+  handler(mini_pick.builtin.files())
 end
 
 function FileSelector:snacks_picker_ui(handler)


### PR DESCRIPTION
add a custom handler from config if users wish to manage this manually

Signed-off-by: Aaron Pham <contact@aarnphm.xyz>
