### PR TITLE
Fix typo on config.lua example

### DIFF
--- a/lua/avante/config.lua
+++ b/lua/avante/config.lua
@@ -124,7 +124,7 @@ M._defaults = {
   ---4. auto_set_keymaps                : Whether to automatically set the keymap for the current line. Default to true.
   ---                                     Note that avante will safely set these keymap. See https://github.com/yetone/avante.nvim/wiki#keymaps-and-api-i-guess for more details.
   ---5. auto_set_highlight_group        : Whether to automatically set the highlight group for the current line. Default to true.
-  ---6. jump_to_result_buffer_on_finish = false, -- Whether to automatically jump to the result buffer after generation
+  ---6. jump_result_buffer_on_finish = false, -- Whether to automatically jump to the result buffer after generation
   ---7. support_paste_from_clipboard    : Whether to support pasting image from clipboard. This will be determined automatically based whether img-clip is available or not.
   ---8. minimize_diff                   : Whether to remove unchanged lines when applying a code block
   ---9. enable_token_counting           : Whether to enable token counting. Default to true.


### PR DESCRIPTION
variable `jump_result_buffer_on_finish` is incorrectly mentioned on comment `jump_to_result_buffer_on_finish`