### PR TITLE
Feat: Add Amazon Bedrock provider

### DIFF
--- a/README.md
+++ b/README.md
@@ -425,6 +425,12 @@ Given its early stage, `avante.nvim` currently supports the following basic func
 > ```sh
 > export AZURE_OPENAI_API_KEY=your-api-key
 > ```
+>
+> For Amazon Bedrock:
+>
+> ```sh
+> export BEDROCK_KEYS=aws_access_key_id,aws_secret_access_key,aws_region
+> ```
 
 1. Open a code file in Neovim.
 2. Use the `:AvanteAsk` command to query the AI about the code.

--- a/lua/avante/config.lua
+++ b/lua/avante/config.lua
@@ -57,7 +57,7 @@ M._defaults = {
   },
   ---@type AvanteSupportedProvider
   bedrock = {
-    model = "anthropic.claude-3-sonnet-20240229-v1:0",
+    model = "anthropic.claude-3-5-sonnet-20240620-v1:0",
     timeout = 30000, -- Timeout in milliseconds
     temperature = 0,
     max_tokens = 8000,

--- a/lua/avante/config.lua
+++ b/lua/avante/config.lua
@@ -56,6 +56,13 @@ M._defaults = {
     max_tokens = 8000,
   },
   ---@type AvanteSupportedProvider
+  bedrock = {
+    model = "anthropic.claude-3-sonnet-20240229-v1:0",
+    timeout = 30000, -- Timeout in milliseconds
+    temperature = 0,
+    max_tokens = 8000,
+  },
+  ---@type AvanteSupportedProvider
   gemini = {
     endpoint = "https://generativelanguage.googleapis.com/v1beta/models",
     model = "gemini-1.5-flash-latest",

--- a/lua/avante/llm.lua
+++ b/lua/avante/llm.lua
@@ -150,15 +150,6 @@ M._stream = function(opts)
     end
     local data_match = line:match("^data: (.+)$")
     if data_match then Provider.parse_response(resp_ctx, data_match, current_event_state, handler_opts) end
-
-    -- Bedrockのレスポンス形式をチェック
-    local bedrock_match = line:gmatch("event(%b{})")
-    for bedrock_data_match in bedrock_match do
-      local data = vim.json.decode(bedrock_data_match)
-      local data_stream = vim.base64.decode(data.bytes)
-      local json = vim.json.decode(data_stream)
-      Provider.parse_response(resp_ctx, data_stream, json.type, handler_opts)
-    end
   end
 
   local function parse_response_without_stream(data)

--- a/lua/avante/llm.lua
+++ b/lua/avante/llm.lua
@@ -153,8 +153,8 @@ M._stream = function(opts)
 
     -- Bedrockのレスポンス形式をチェック
     local bedrock_match = line:gmatch("event(%b{})")
-    for data_match in bedrock_match do
-      local data = vim.json.decode(data_match)
+    for bedrock_data_match in bedrock_match do
+      local data = vim.json.decode(bedrock_data_match)
       local data_stream = vim.base64.decode(data.bytes)
       local json = vim.json.decode(data_stream)
       Provider.parse_response(resp_ctx, data_stream, json.type, handler_opts)

--- a/lua/avante/providers/bedrock.lua
+++ b/lua/avante/providers/bedrock.lua
@@ -19,9 +19,8 @@ M.use_xml_format = true
 M.load_model_handler = function()
   local base, _ = P.parse_config(P["bedrock"])
   local bedrock_model = base.model
-  if base.model:match("anthropic") then
-    bedrock_model = "claude"
-  end
+  if base.model:match("anthropic") then bedrock_model = "claude" end
+
   local ok, model_module = pcall(require, "avante.providers.bedrock." .. bedrock_model)
   if ok then
     return model_module
@@ -62,11 +61,15 @@ M.parse_curl_args = function(provider, prompt_opts)
 
   local api_key = provider.parse_api_key()
   local parts = vim.split(api_key, ",")
-  local aws_access_key_id     = parts[1]
+  local aws_access_key_id = parts[1]
   local aws_secret_access_key = parts[2]
-  local aws_region            = parts[3]
+  local aws_region = parts[3]
 
-  local endpoint = string.format("https://bedrock-runtime.%s.amazonaws.com/model/%s/invoke-with-response-stream", aws_region, base.model)
+  local endpoint = string.format(
+    "https://bedrock-runtime.%s.amazonaws.com/model/%s/invoke-with-response-stream",
+    aws_region,
+    base.model
+  )
 
   local headers = {
     ["Content-Type"] = "application/json",
@@ -75,8 +78,10 @@ M.parse_curl_args = function(provider, prompt_opts)
   local body_payload = M.build_bedrock_payload(prompt_opts, body_opts)
 
   local rawArgs = {
-    "--aws-sigv4", string.format("aws:amz:%s:bedrock", aws_region),
-    "--user", string.format("%s:%s", aws_access_key_id, aws_secret_access_key)
+    "--aws-sigv4",
+    string.format("aws:amz:%s:bedrock", aws_region),
+    "--user",
+    string.format("%s:%s", aws_access_key_id, aws_secret_access_key),
   }
 
   return {

--- a/lua/avante/providers/bedrock.lua
+++ b/lua/avante/providers/bedrock.lua
@@ -1,0 +1,173 @@
+local Utils = require("avante.utils")
+local Clipboard = require("avante.clipboard")
+local P = require("avante.providers")
+
+---@class AvanteClaudeBaseMessage
+---@field cache_control {type: "ephemeral"}?
+---
+---@class AvanteClaudeTextMessage: AvanteClaudeBaseMessage
+---@field type "text"
+---@field text string
+---
+---@class AvanteClaudeImageMessage: AvanteClaudeBaseMessage
+---@field type "image"
+---@field source {type: "base64", media_type: string, data: string}
+---
+---@class AvanteClaudeMessage
+---@field role "user" | "assistant"
+---@field content [AvanteClaudeTextMessage | AvanteClaudeImageMessage][]
+
+---@class AvanteProviderFunctor
+local M = {}
+
+M.api_key_name = "BEDROCK_KEYS"
+M.use_xml_format = true
+
+M.role_map = {
+  user = "user",
+  assistant = "assistant",
+}
+
+M.parse_messages = function(opts)
+  ---@type AvanteClaudeMessage[]
+  local messages = {}
+
+  ---@type {idx: integer, length: integer}[]
+  local messages_with_length = {}
+  for idx, message in ipairs(opts.messages) do
+    table.insert(messages_with_length, { idx = idx, length = Utils.tokens.calculate_tokens(message.content) })
+  end
+
+  table.sort(messages_with_length, function(a, b) return a.length > b.length end)
+
+  ---@type table<integer, boolean>
+  local top_three = {}
+  for i = 1, math.min(3, #messages_with_length) do
+    top_three[messages_with_length[i].idx] = true
+  end
+
+  for idx, message in ipairs(opts.messages) do
+    table.insert(messages, {
+      role = M.role_map[message.role],
+      content = {
+        {
+          type = "text",
+          text = message.content,
+          cache_control = top_three[idx] and { type = "ephemeral" } or nil,
+        },
+      },
+    })
+  end
+
+  if Clipboard.support_paste_image() and opts.image_paths and #opts.image_paths > 0 then
+    local message_content = messages[#messages].content
+    for _, image_path in ipairs(opts.image_paths) do
+      table.insert(message_content, {
+        type = "image",
+        source = {
+          type = "base64",
+          media_type = "image/png",
+          data = Clipboard.get_base64_content(image_path),
+        },
+      })
+    end
+    messages[#messages].content = message_content
+  end
+
+  return messages
+end
+
+M.parse_response = function(ctx, data_stream, event_state, opts)
+  if event_state == nil then
+    if data_stream:match('"content_block_delta"') then
+      event_state = "content_block_delta"
+    elseif data_stream:match('"message_stop"') then
+      event_state = "message_stop"
+    end
+  end
+  if event_state == "content_block_delta" then
+    local ok, json = pcall(vim.json.decode, data_stream)
+    if not ok then return end
+    opts.on_chunk(json.delta.text)
+  elseif event_state == "message_stop" then
+    opts.on_complete(nil)
+    return
+  elseif event_state == "error" then
+    opts.on_complete(vim.json.decode(data_stream))
+  end
+end
+
+---@param provider AvanteProviderFunctor
+---@param prompt_opts AvantePromptOptions
+---@return table
+M.parse_curl_args = function(provider, prompt_opts)
+  -- 既存の設定を取得
+  local base, body_opts = P.parse_config(provider)
+
+  -- provider.parse_api_key() は "AWS_ACCESS_KEY_ID,AWS_SECRET_ACCESS_KEY,AWS_REGION" の形式で返る
+  local api_key = provider.parse_api_key()
+  local parts = vim.split(api_key, ",")
+  local aws_access_key_id     = parts[1]
+  local aws_secret_access_key = parts[2]
+  local aws_region            = parts[3]
+
+  -- Bedrock用のエンドポイントを組み立てる
+  -- base.model は "anthropic.claude-v2" 等、Bedrockで利用するモデルIDとする
+  local endpoint = string.format("https://bedrock-runtime.%s.amazonaws.com/model/%s/invoke", aws_region, base.model)
+
+  -- ヘッダーは Bedrock では "Content-Type" のみ必要（追加ヘッダーは不要）
+  local headers = {
+    ["Content-Type"] = "application/json",
+  }
+
+  -- ユーザーが作成したメッセージを取得
+  local messages = M.parse_messages(prompt_opts)
+  -- ※必要に応じて system prompt の内容を messages に含める処理をここで追加可能
+
+  -- Bedrock 用のリクエストボディを作成
+  -- ※ここでは "anthropic_version" を Bedrock 固有の値にし、max_tokens は prompt_opts から取得（無ければ 2000 をデフォルト）
+  local body_payload = vim.tbl_deep_extend("force", {
+    anthropic_version = "bedrock-2023-05-31",
+    max_tokens = prompt_opts.max_tokens or 2000,
+    messages = messages,
+  }, body_opts)
+
+  local rawArgs = {
+    "--aws-sigv4", string.format("aws:amz:%s:bedrock", aws_region),
+    "--user", string.format("%s:%s", aws_access_key_id, aws_secret_access_key)
+  }
+
+  -- curl 呼び出し時に必要な AWS シグネチャ情報やユーザー認証情報をフィールドとして追加
+  return {
+    url = endpoint,
+    proxy = base.proxy,
+    insecure = base.allow_insecure,
+    headers = headers,
+    body = body_payload,
+    rawArgs = rawArgs,
+  }
+end
+
+M.on_error = function(result)
+  if not result.body then
+    return Utils.error("API request failed with status " .. result.status, { once = true, title = "Avante" })
+  end
+
+  local ok, body = pcall(vim.json.decode, result.body)
+  if not (ok and body and body.error) then
+    return Utils.error("Failed to parse error response", { once = true, title = "Avante" })
+  end
+
+  local error_msg = body.error.message
+  local error_type = body.error.type
+
+  if error_type == "insufficient_quota" then
+    error_msg = "You don't have any credits or have exceeded your quota. Please check your plan and billing details."
+  elseif error_type == "invalid_request_error" and error_msg:match("temperature") then
+    error_msg = "Invalid temperature value. Please ensure it's between 0 and 1."
+  end
+
+  Utils.error(error_msg, { once = true, title = "Avante" })
+end
+
+return M

--- a/lua/avante/providers/bedrock.lua
+++ b/lua/avante/providers/bedrock.lua
@@ -17,7 +17,7 @@ M.api_key_name = "BEDROCK_KEYS"
 M.use_xml_format = true
 
 M.load_model_handler = function()
-  local base, _ = P.parse_config("bedrock")
+  local base, _ = P.parse_config(P["bedrock"])
   local bedrock_model = base.model
   if base.model:match("anthropic") then
     bedrock_model = "claude"
@@ -53,7 +53,7 @@ M.parse_curl_args = function(provider, prompt_opts)
   local aws_secret_access_key = parts[2]
   local aws_region            = parts[3]
 
-  local endpoint = string.format("https://bedrock-runtime.%s.amazonaws.com/model/%s/invoke", aws_region, base.model)
+  local endpoint = string.format("https://bedrock-runtime.%s.amazonaws.com/model/%s/invoke-with-response-stream", aws_region, base.model)
 
   local headers = {
     ["Content-Type"] = "application/json",

--- a/lua/avante/providers/bedrock.lua
+++ b/lua/avante/providers/bedrock.lua
@@ -41,6 +41,19 @@ M.build_bedrock_payload = function(prompt_opts, body_opts)
   return model_handler.build_bedrock_payload(prompt_opts, body_opts)
 end
 
+M.parse_stream_data = function(data, opts)
+  -- @NOTE: Decode and process Bedrock response
+  -- Each response contains a Base64-encoded `bytes` field, which is decoded into JSON.
+  -- The `type` field in the decoded JSON determines how the response is handled.
+  local bedrock_match = data:gmatch("event(%b{})")
+  for bedrock_data_match in bedrock_match do
+    local data = vim.json.decode(bedrock_data_match)
+    local data_stream = vim.base64.decode(data.bytes)
+    local json = vim.json.decode(data_stream)
+    M.parse_response({}, data_stream, json.type, opts)
+  end
+end
+
 ---@param provider AvanteBedrockProviderFunctor
 ---@param prompt_opts AvantePromptOptions
 ---@return table

--- a/lua/avante/providers/bedrock.lua
+++ b/lua/avante/providers/bedrock.lua
@@ -2,142 +2,70 @@ local Utils = require("avante.utils")
 local Clipboard = require("avante.clipboard")
 local P = require("avante.providers")
 
----@class AvanteClaudeBaseMessage
----@field cache_control {type: "ephemeral"}?
+---@alias AvanteBedrockPayloadBuilder fun(prompt_opts: AvantePromptOptions, body_opts: table<string, any>): table<string, any>
 ---
----@class AvanteClaudeTextMessage: AvanteClaudeBaseMessage
----@field type "text"
----@field text string
----
----@class AvanteClaudeImageMessage: AvanteClaudeBaseMessage
----@field type "image"
----@field source {type: "base64", media_type: string, data: string}
----
----@class AvanteClaudeMessage
----@field role "user" | "assistant"
----@field content [AvanteClaudeTextMessage | AvanteClaudeImageMessage][]
+---@class AvanteBedrockModelHandler
+---@field role_map table<"user" | "assistant", string>
+---@field parse_messages AvanteMessagesParser
+---@field parse_response AvanteResponseParser
+---@field build_bedrock_payload AvanteBedrockPayloadBuilder
 
----@class AvanteProviderFunctor
+---@class AvanteBedrockProviderFunctor
 local M = {}
 
 M.api_key_name = "BEDROCK_KEYS"
 M.use_xml_format = true
 
-M.role_map = {
-  user = "user",
-  assistant = "assistant",
-}
-
-M.parse_messages = function(opts)
-  ---@type AvanteClaudeMessage[]
-  local messages = {}
-
-  ---@type {idx: integer, length: integer}[]
-  local messages_with_length = {}
-  for idx, message in ipairs(opts.messages) do
-    table.insert(messages_with_length, { idx = idx, length = Utils.tokens.calculate_tokens(message.content) })
+M.load_model_handler = function()
+  local base, _ = P.parse_config("bedrock")
+  local bedrock_model = base.model
+  if base.model:match("anthropic") then
+    bedrock_model = "claude"
   end
-
-  table.sort(messages_with_length, function(a, b) return a.length > b.length end)
-
-  ---@type table<integer, boolean>
-  local top_three = {}
-  for i = 1, math.min(3, #messages_with_length) do
-    top_three[messages_with_length[i].idx] = true
+  local ok, model_module = pcall(require, "avante.providers.bedrock." .. bedrock_model)
+  if ok then
+    return model_module
+  else
+    local error_msg = "Bedrock model handler not found: " .. bedrock_model
+    Utils.error(error_msg, { once = true, title = "Avante" })
   end
-
-  for idx, message in ipairs(opts.messages) do
-    table.insert(messages, {
-      role = M.role_map[message.role],
-      content = {
-        {
-          type = "text",
-          text = message.content,
-          cache_control = top_three[idx] and { type = "ephemeral" } or nil,
-        },
-      },
-    })
-  end
-
-  if Clipboard.support_paste_image() and opts.image_paths and #opts.image_paths > 0 then
-    local message_content = messages[#messages].content
-    for _, image_path in ipairs(opts.image_paths) do
-      table.insert(message_content, {
-        type = "image",
-        source = {
-          type = "base64",
-          media_type = "image/png",
-          data = Clipboard.get_base64_content(image_path),
-        },
-      })
-    end
-    messages[#messages].content = message_content
-  end
-
-  return messages
 end
 
 M.parse_response = function(ctx, data_stream, event_state, opts)
-  if event_state == nil then
-    if data_stream:match('"content_block_delta"') then
-      event_state = "content_block_delta"
-    elseif data_stream:match('"message_stop"') then
-      event_state = "message_stop"
-    end
-  end
-  if event_state == "content_block_delta" then
-    local ok, json = pcall(vim.json.decode, data_stream)
-    if not ok then return end
-    opts.on_chunk(json.delta.text)
-  elseif event_state == "message_stop" then
-    opts.on_complete(nil)
-    return
-  elseif event_state == "error" then
-    opts.on_complete(vim.json.decode(data_stream))
-  end
+  local model_handler = M.load_model_handler()
+  return model_handler.parse_response(ctx, data_stream, event_state, opts)
 end
 
----@param provider AvanteProviderFunctor
+M.build_bedrock_payload = function(prompt_opts, body_opts)
+  local model_handler = M.load_model_handler()
+  return model_handler.build_bedrock_payload(prompt_opts, body_opts)
+end
+
+---@param provider AvanteBedrockProviderFunctor
 ---@param prompt_opts AvantePromptOptions
 ---@return table
 M.parse_curl_args = function(provider, prompt_opts)
-  -- 既存の設定を取得
   local base, body_opts = P.parse_config(provider)
 
-  -- provider.parse_api_key() は "AWS_ACCESS_KEY_ID,AWS_SECRET_ACCESS_KEY,AWS_REGION" の形式で返る
   local api_key = provider.parse_api_key()
   local parts = vim.split(api_key, ",")
   local aws_access_key_id     = parts[1]
   local aws_secret_access_key = parts[2]
   local aws_region            = parts[3]
 
-  -- Bedrock用のエンドポイントを組み立てる
-  -- base.model は "anthropic.claude-v2" 等、Bedrockで利用するモデルIDとする
   local endpoint = string.format("https://bedrock-runtime.%s.amazonaws.com/model/%s/invoke", aws_region, base.model)
 
-  -- ヘッダーは Bedrock では "Content-Type" のみ必要（追加ヘッダーは不要）
   local headers = {
     ["Content-Type"] = "application/json",
   }
 
-  -- ユーザーが作成したメッセージを取得
-  local messages = M.parse_messages(prompt_opts)
-  -- ※必要に応じて system prompt の内容を messages に含める処理をここで追加可能
-
-  -- Bedrock 用のリクエストボディを作成
-  -- ※ここでは "anthropic_version" を Bedrock 固有の値にし、max_tokens は prompt_opts から取得（無ければ 2000 をデフォルト）
-  local body_payload = vim.tbl_deep_extend("force", {
-    anthropic_version = "bedrock-2023-05-31",
-    max_tokens = prompt_opts.max_tokens or 2000,
-    messages = messages,
-  }, body_opts)
+  local body_payload = M.build_bedrock_payload(prompt_opts, body_opts)
 
   local rawArgs = {
     "--aws-sigv4", string.format("aws:amz:%s:bedrock", aws_region),
     "--user", string.format("%s:%s", aws_access_key_id, aws_secret_access_key)
   }
 
-  -- curl 呼び出し時に必要な AWS シグネチャ情報やユーザー認証情報をフィールドとして追加
   return {
     url = endpoint,
     proxy = base.proxy,
@@ -160,12 +88,6 @@ M.on_error = function(result)
 
   local error_msg = body.error.message
   local error_type = body.error.type
-
-  if error_type == "insufficient_quota" then
-    error_msg = "You don't have any credits or have exceeded your quota. Please check your plan and billing details."
-  elseif error_type == "invalid_request_error" and error_msg:match("temperature") then
-    error_msg = "Invalid temperature value. Please ensure it's between 0 and 1."
-  end
 
   Utils.error(error_msg, { once = true, title = "Avante" })
 end

--- a/lua/avante/providers/bedrock/claude.lua
+++ b/lua/avante/providers/bedrock/claude.lua
@@ -18,7 +18,7 @@ M.parse_messages = function(opts)
   ---@type AvanteBedrockClaudeMessage[]
   local messages = {}
 
-  for idx, message in ipairs(opts.messages) do
+  for _, message in ipairs(opts.messages) do
     table.insert(messages, {
       role = M.role_map[message.role],
       content = {

--- a/lua/avante/providers/bedrock/claude.lua
+++ b/lua/avante/providers/bedrock/claude.lua
@@ -69,3 +69,5 @@ M.build_bedrock_payload = function(prompt_opts, body_opts)
   }
   return vim.tbl_deep_extend("force", payload, body_opts or {})
 end
+
+return M

--- a/lua/avante/providers/bedrock/claude.lua
+++ b/lua/avante/providers/bedrock/claude.lua
@@ -1,0 +1,71 @@
+---@class AvanteBedrockClaudeTextMessage
+---@field type "text"
+---@field text string
+---
+---@class AvanteBedrockClaudeMessage
+---@field role "user" | "assistant"
+---@field content [AvanteBedrockClaudeTextMessage][]
+
+---@class AvanteBedrockModelHandler
+local M = {}
+
+M.role_map = {
+  user = "user",
+  assistant = "assistant",
+}
+
+M.parse_messages = function(opts)
+  ---@type AvanteBedrockClaudeMessage[]
+  local messages = {}
+
+  for idx, message in ipairs(opts.messages) do
+    table.insert(messages, {
+      role = M.role_map[message.role],
+      content = {
+        {
+          type = "text",
+          text = message.content,
+        },
+      },
+    })
+  end
+
+  return messages
+end
+
+M.parse_response = function(ctx, data_stream, event_state, opts)
+  if event_state == nil then
+    if data_stream:match('"content_block_delta"') then
+      event_state = "content_block_delta"
+    elseif data_stream:match('"message_stop"') then
+      event_state = "message_stop"
+    end
+  end
+  if event_state == "content_block_delta" then
+    local ok, json = pcall(vim.json.decode, data_stream)
+    if not ok then return end
+    opts.on_chunk(json.delta.text)
+  elseif event_state == "message_stop" then
+    opts.on_complete(nil)
+    return
+  elseif event_state == "error" then
+    opts.on_complete(vim.json.decode(data_stream))
+  end
+end
+
+---@param prompt_opts AvantePromptOptions
+---@param body_opts table
+---@return table
+M.build_bedrock_payload = function(prompt_opts, body_opts)
+  local system_prompt = prompt_opts.system_prompt or ""
+  local messages = M.parse_messages(prompt_opts)
+  local max_tokens = body_opts.max_tokens or 2000
+  local temperature = body_opts.temperature or 0.7
+  local payload = {
+    anthropic_version = "bedrock-2023-05-31",
+    max_tokens = max_tokens,
+    messages = messages,
+    system = system_prompt
+  }
+  return vim.tbl_deep_extend("force", payload, body_opts or {})
+end

--- a/lua/avante/providers/bedrock/claude.lua
+++ b/lua/avante/providers/bedrock/claude.lua
@@ -65,7 +65,7 @@ M.build_bedrock_payload = function(prompt_opts, body_opts)
     anthropic_version = "bedrock-2023-05-31",
     max_tokens = max_tokens,
     messages = messages,
-    system = system_prompt
+    system = system_prompt,
   }
   return vim.tbl_deep_extend("force", payload, body_opts or {})
 end

--- a/lua/avante/providers/init.lua
+++ b/lua/avante/providers/init.lua
@@ -87,6 +87,7 @@ local DressingState = { winid = nil, input_winid = nil, input_bufnr = nil }
 ---@field azure AvanteProviderFunctor
 ---@field gemini AvanteProviderFunctor
 ---@field cohere AvanteProviderFunctor
+---@field bedrock AvanteProviderFunctor
 local M = {}
 
 ---@class EnvironmentHandler

--- a/lua/avante/providers/init.lua
+++ b/lua/avante/providers/init.lua
@@ -90,6 +90,8 @@ local DressingState = { winid = nil, input_winid = nil, input_bufnr = nil }
 ---@field use_xml_format boolean
 ---@field model? string
 ---@field parse_api_key fun(): string | nil
+---@field parse_stream_data? AvanteStreamParser
+---@field on_error? fun(result: table<string, any>): nil
 ---@field load_model_handler fun(): AvanteBedrockModelHandler
 ---@field build_bedrock_payload? fun(prompt_opts: AvantePromptOptions, body_opts: table<string, any>): table<string, any>
 ---

--- a/lua/avante/providers/init.lua
+++ b/lua/avante/providers/init.lua
@@ -32,7 +32,7 @@ local DressingState = { winid = nil, input_winid = nil, input_bufnr = nil }
 ---@alias AvanteMessagesParser fun(opts: AvantePromptOptions): AvanteChatMessage[]
 ---
 ---@class AvanteCurlOutput: {url: string, proxy: string, insecure: boolean, body: table<string, any> | string, headers: table<string, string>, rawArgs: string[] | nil}
----@alias AvanteCurlArgsParser fun(opts: AvanteProvider | AvanteProviderFunctor, code_opts: AvantePromptOptions): AvanteCurlOutput
+---@alias AvanteCurlArgsParser fun(opts: AvanteProvider | AvanteProviderFunctor | AvanteBedrockProviderFunctor, code_opts: AvantePromptOptions): AvanteCurlOutput
 ---
 ---@class ResponseParser
 ---@field on_chunk fun(chunk: string): any
@@ -80,6 +80,19 @@ local DressingState = { winid = nil, input_winid = nil, input_bufnr = nil }
 ---@field parse_stream_data? AvanteStreamParser
 ---@field on_error? fun(result: table<string, any>): nil
 ---
+---@class AvanteBedrockProviderFunctor
+---@field parse_response AvanteResponseParser
+---@field parse_curl_args AvanteCurlArgsParser
+---@field setup fun(): nil
+---@field has fun(): boolean
+---@field api_key_name string
+---@field tokenizer_id string | "gpt-4o"
+---@field use_xml_format boolean
+---@field model? string
+---@field parse_api_key fun(): string | nil
+---@field load_model_handler fun(): AvanteBedrockModelHandler
+---@field build_bedrock_payload? fun(prompt_opts: AvantePromptOptions, body_opts: table<string, any>): table<string, any>
+---
 ---@class avante.Providers
 ---@field openai AvanteProviderFunctor
 ---@field claude AvanteProviderFunctor
@@ -87,7 +100,7 @@ local DressingState = { winid = nil, input_winid = nil, input_bufnr = nil }
 ---@field azure AvanteProviderFunctor
 ---@field gemini AvanteProviderFunctor
 ---@field cohere AvanteProviderFunctor
----@field bedrock AvanteProviderFunctor
+---@field bedrock AvanteBedrockProviderFunctor
 local M = {}
 
 ---@class EnvironmentHandler
@@ -97,7 +110,7 @@ local E = {}
 ---@type table<string, string>
 E.cache = {}
 
----@param Opts AvanteSupportedProvider | AvanteProviderFunctor
+---@param Opts AvanteSupportedProvider | AvanteProviderFunctor | AvanteBedrockProviderFunctor
 ---@return string | nil
 E.parse_envvar = function(Opts)
   local api_key_name = Opts.api_key_name
@@ -159,7 +172,7 @@ end
 
 --- initialize the environment variable for current neovim session.
 --- This will only run once and spawn a UI for users to input the envvar.
----@param opts {refresh: boolean, provider: AvanteProviderFunctor}
+---@param opts {refresh: boolean, provider: AvanteProviderFunctor | AvanteBedrockProviderFunctor}
 ---@private
 E.setup = function(opts)
   opts.provider.setup()
@@ -268,7 +281,7 @@ M = setmetatable(M, {
   ---@param t avante.Providers
   ---@param k Provider
   __index = function(t, k)
-    ---@type AvanteProviderFunctor
+    ---@type AvanteProviderFunctor | AvanteBedrockProviderFunctor
     local Opts = M.get_config(k)
 
     ---@diagnostic disable: undefined-field,no-unknown,inject-field
@@ -312,7 +325,7 @@ M = setmetatable(M, {
 M.setup = function()
   vim.g.avante_login = false
 
-  ---@type AvanteProviderFunctor
+  ---@type AvanteProviderFunctor | AvanteBedrockProviderFunctor
   local provider = M[Config.provider]
   local auto_suggestions_provider = M[Config.auto_suggestions_provider]
   E.setup({ provider = provider })
@@ -326,13 +339,13 @@ end
 function M.refresh(provider)
   require("avante.config").override({ provider = provider })
 
-  ---@type AvanteProviderFunctor
+  ---@type AvanteProviderFunctor | AvanteBedrockProviderFunctor
   local p = M[Config.provider]
   E.setup({ provider = p, refresh = true })
   Utils.info("Switch to provider: " .. provider, { once = true, title = "Avante" })
 end
 
----@param opts AvanteProvider | AvanteSupportedProvider | AvanteProviderFunctor
+---@param opts AvanteProvider | AvanteSupportedProvider | AvanteProviderFunctor | AvanteBedrockProviderFunctor
 ---@return AvanteDefaultBaseProvider, table<string, any>
 M.parse_config = function(opts)
   ---@type AvanteDefaultBaseProvider
@@ -357,7 +370,7 @@ end
 
 ---@private
 ---@param provider Provider
----@return AvanteProviderFunctor
+---@return AvanteProviderFunctor | AvanteBedrockProviderFunctor
 M.get_config = function(provider)
   provider = provider or Config.provider
   local cur = Config.get_provider(provider)


### PR DESCRIPTION
## Overview
As mentioned in **#419**, I was also very excited about having support for Amazon Bedrock, so I decided to work on adding it.  
I also referenced **[avante_bedrock.nvim](https://github.com/yuchanns/avante_bedrock.nvim)** for parsing the response. Thank you for the great work!

## Summary of Changes
This PR introduces **support for Amazon Bedrock** as a new provider and adds the necessary implementation to integrate it into Avante.nvim. The key changes are as follows:

### 1. Newly Added Files
- `lua/avante/providers/bedrock.lua`
  - Implements the **entry point for the Bedrock provider**.
  - Handles API request construction and model selection.

- `lua/avante/providers/bedrock/claude.lua`
  - A dedicated handler module for **Claude series** via Bedrock.
  - Formats API parameters and processes responses.

### 2. Modified Existing Files
- `README.md`
  - Added instructions for **setting up Amazon Bedrock**.
  - Explained the usage of the `BEDROCK_KEYS` environment variable.

- `lua/avante/config.lua`
  - Added default settings for the `bedrock` provider.

- `lua/avante/llm.lua`
  - Extended the LLM module to **support Bedrock as a provider**.

- `lua/avante/providers/init.lua`
  - Registered `bedrock.lua` as a provider.

---

## Notes
Amazon Bedrock is a **single provider** that offers **multiple models, each with different request and response formats**.  
To accommodate this, a **new `bedrock/` directory has been introduced** within `providers/`, where each model is handled by its own dedicated module.

### Future Expandability
- **New model handlers can be added inside `bedrock/` to support additional models.**
- For example, to support **Cohere** or **Mistral** via Bedrock, simply adding `bedrock/cohere.lua` or `bedrock/mistral.lua` will make them available.

### Unified Authentication
- To **maintain consistency with other providers** (such as ChatGPT and Gemini), authentication is managed via a **single environment variable (`BEDROCK_KEYS`)**.
- The variable follows a simple format:  
  ```sh
  export BEDROCK_KEYS=aws_access_key_id,aws_secret_access_key,aws_region
  ```

---

## Potential Impact
- A new bedrock configuration block is added to config.lua.
- The providers module now includes bedrock.lua, enabling Bedrock as a supported provider.
- llm.lua and init.lua have been updated accordingly.

## Known Issues
There is a known issue where requests to Amazon Bedrock may fail if curl is outdated.
This issue is discussed in detail in [curl/curl#13754](https://github.com/curl/curl/issues/13754).
If you encounter errors when using Bedrock, please update curl to the latest version and try again.

---

I deeply appreciate the work that has been done on this project, and I hope this contribution aligns with the project's vision.
If there are any issues or suggestions for improvement, I would greatly appreciate your feedback.
Thank you for your time and consideration! 😊🙏