### PR TITLE
Reduces the impact of the shade function when in light mode

### DIFF
--- a/lua/avante/highlights.lua
+++ b/lua/avante/highlights.lua
@@ -124,7 +124,7 @@ H.alter = function(attr, percent) return math.floor(attr * (100 + percent) / 100
 
 ---@source https://stackoverflow.com/q/5560248
 ---@see https://stackoverflow.com/a/37797380
----Darken a specified hex color
+---Lighten a specified hex color
 ---@param color number
 ---@param percent number
 ---@return string

--- a/lua/avante/highlights.lua
+++ b/lua/avante/highlights.lua
@@ -129,6 +129,7 @@ H.alter = function(attr, percent) return math.floor(attr * (100 + percent) / 100
 ---@param percent number
 ---@return string
 H.shade_color = function(color, percent)
+  percent = vim.opt.background:get() == "light" and percent / 10 or percent
   local rgb = H.decode_24bit_rgb(color)
   if not rgb.r or not rgb.g or not rgb.b then return "NONE" end
   local r, g, b = H.alter(rgb.r, percent), H.alter(rgb.g, percent), H.alter(rgb.b, percent)


### PR DESCRIPTION
## High level issues

- When using a light theme, the shade function effectively converts colours to white, which can look jarring (**fixed**)
- The shade function lightens rather than darkens the colour (**partially improved** by changing a comment)
- The shade function is possibly poorly named, and should really lighten a dark colour and darken a light colour, or vice versa (**not fixed** in this PR). See suggestions below.

## Current situation

When using a light `colorscheme`, the shade function effectively converts every colour passed to it to white. Here is a screenshot of it before the fix in this PR:

![shade-60](https://github.com/user-attachments/assets/36f4011c-d3fa-4ad0-8453-e86b223bbaa4)

I'm not sure what the intent of the `shade` function was meant to be, so have not fixed it to actually darken rather than lighten in this PR. Users using dark themes should not see any changes after this PR is merged.

Instead, I have reduced the effect of the shade function when using a light theme to 10% of what it was thereby preventing a lot of colours from becoming white. This table demonstrates the difference between how much change 60% (the amount being passed to it) can do:

Amount of shading  | 60 | 6
-- | -- | --
Input | Output for dark theme | Output for light theme
0 | 0 | 0
16 | 25 | 16
32 | 51 | 33
48 | 76 | 50
64 | 102 | 67
80 | 128 | 84
96 | 153 | 101
112 | 179 | 118
128 | 204 | 135
144 | 230 | 152
160 | 255 | 169
176 | 255 | 186
192 | 255 | 203
208 | 255 | 220
224 | 255 | 237
240 | 255 | 254
256 | 255 | 255

See how much nicer this looks:

![shade-5](https://github.com/user-attachments/assets/63acf72b-1797-4ac3-9155-25c67fa52a3b)

## Other changes

I think this function could be improved much more. Really, what we should be doing here is make a decision on:
- If we really meant to lighten or darken it.
- Whether we lighten it for dark themes and darken it for light themes.
- Or vice versa.