### PR TITLE
feat: expose whether the llm is currently generating content

### DIFF
--- a/lua/avante/sidebar.lua
+++ b/lua/avante/sidebar.lua
@@ -57,6 +57,7 @@ function Sidebar:new(id)
     selected_files_container = nil,
     input_container = nil,
     file_selector = FileSelector:new(id),
+    is_generating = false,
   }, { __index = self })
 end
 
@@ -1836,6 +1837,8 @@ function Sidebar:create_input_container(opts)
 
     ---@type AvanteLLMChunkCallback
     local on_chunk = function(chunk)
+      self.is_generating = true
+
       original_response = original_response .. chunk
 
       local selected_files = self.file_selector:get_selected_files_contents()
@@ -1870,6 +1873,8 @@ function Sidebar:create_input_container(opts)
 
     ---@type AvanteLLMStopCallback
     local on_stop = function(stop_opts)
+      self.is_generating = false
+
       pcall(function()
         ---remove keymaps
         vim.keymap.del("n", "j", { buffer = self.result_container.bufnr })


### PR DESCRIPTION
This PR adds a member variable to the sidebar, denoting whether the LLM is currently generating a response.

The main use case I have in mind is to allow users to disable treesitter highlighting in the sidebar while generation is ongoing. Treesitter highlighting can be very expensive, to the point where it bottlenecks (relatively powerful) CPUs, even when history is relatively short, if the LLM is fast.

Anyway, I figured a general, minimal feature like this one would be preferable over a larger pull request that incorporates treesitter logic directly into avante. Users can query for the member variable in order to configure their plugins. Here is an example of how treesitter highlighting can be disabled during generation if this PR is merged:
```lua
{
  "nvim-treesitter/nvim-treesitter",
  opts = {
    highlight = {
      disable = function(_, buf)
        if vim.bo[buf].filetype == "Avante" then
          local sidebar = require("avante").get()
          if sidebar and sidebar.is_generating then
            return true
          end
        end
        -- other disabling logic
        return false
      end,
    }
  }
}
```

If there is a different approach you would like this PR to take, please let me know and I'm happy to adjust.

