### PR TITLE
Added Packer to README and fixed vim-plug imports

### DIFF
--- a/README.md
+++ b/README.md
@@ -117,6 +117,7 @@ For building binary if you wish to build from source, then `cargo` is required. 
 Plug 'stevearc/dressing.nvim'
 Plug 'nvim-lua/plenary.nvim'
 Plug 'MunifTanjim/nui.nvim'
+Plug 'MeanderingProgrammer/render-markdown.nvim'
 
 " Optional deps
 Plug 'hrsh7th/nvim-cmp'
@@ -165,6 +166,38 @@ later(function()
   require("copilot").setup({...}) -- setup copilot to your liking
   require("avante").setup({...}) -- config for avante.nvim
 end)
+```
+
+</details>
+
+<details>
+
+  <summary><a href="https://github.com/wbthomason/packer.nvim">Packer</a></summary>
+
+```vim
+
+  -- Required plugins
+  use 'stevearc/dressing.nvim'
+  use 'nvim-lua/plenary.nvim'
+  use 'MunifTanjim/nui.nvim'
+  use 'MeanderingProgrammer/render-markdown.nvim'
+
+  -- Optional dependencies
+  use 'hrsh7th/nvim-cmp'
+  use 'nvim-tree/nvim-web-devicons' -- or use 'echasnovski/mini.icons'
+  use 'HakonHarnes/img-clip.nvim'
+  use 'zbirenbaum/copilot.lua'
+
+  -- Avante.nvim with build process
+  use {
+    'yetone/avante.nvim',
+    branch = 'main',
+    run = 'make',
+    config = function()
+      require('avante_lib').load()
+      require('avante').setup()
+    end
+  }
 ```
 
 </details>


### PR DESCRIPTION
Hi!

I have added Packer import to the README (and tested it since I use it) and fixed the vim-plug imports because if we don't have "Plug 'MeanderingProgrammer/render-markdown.nvim'" avante won't work properly.

Thanks for the project, it helps a ton!

Let me know if i can help in any other way :)