### PR TITLE
feat(file_selector): support customized file selector method

### DIFF
--- a/lua/avante/config.lua
+++ b/lua/avante/config.lua
@@ -5,6 +5,11 @@
 
 local Utils = require("avante.utils")
 
+---@class avante.file_selector.IParams
+---@field public title      string
+---@field public filepaths  string[]
+---@field public handler    fun(filepaths: string[]|nil): nil
+
 ---@class avante.CoreConfig: avante.Config
 local M = {}
 ---@class avante.Config
@@ -302,7 +307,7 @@ M._defaults = {
   },
   --- @class AvanteFileSelectorConfig
   file_selector = {
-    --- @alias FileSelectorProvider "native" | "fzf" | "mini.pick" | "snacks" | "telescope" | string
+    --- @alias FileSelectorProvider "native" | "fzf" | "mini.pick" | "snacks" | "telescope" | string | fun(params: avante.file_selector.IParams): nil
     provider = "native",
     -- Options override for custom providers
     provider_opts = {},

--- a/lua/avante/file_selector.lua
+++ b/lua/avante/file_selector.lua
@@ -330,6 +330,11 @@ function FileSelector:show_select_ui()
       self:snacks_picker_ui(handler)
     elseif Config.file_selector.provider == "telescope" then
       self:telescope_ui(handler)
+    elseif type(Config.file_selector.provider) == "function" then
+      local title = string.format("%s:", PROMPT_TITLE) ---@type string
+      local filepaths = self:get_filepaths() ---@type string[]
+      local params = { title = title, filepaths = filepaths, handler = handler } ---@type avante.file_selector.IParams
+      Config.file_selector.provider(params)
     else
       Utils.error("Unknown file selector provider: " .. Config.file_selector.provider)
     end


### PR DESCRIPTION
This pull request introduces enhancements to the file selector functionality in the `avante` module. The changes include defining a new interface for file selector parameters, updating the file selector provider type alias, and adding support for custom provider functions in the `FileSelector` class.

Key changes:

### Enhancements to file selector functionality:

* [`lua/avante/config.lua`](diffhunk://#diff-4f9ab2121e449ed4df68152ef7ca083a1cc5eaf429c39348f73119abd75a6edbR8-R12): Added a new class `avante.file_selector.IParams` to define the structure of parameters for file selector providers.
* [`lua/avante/config.lua`](diffhunk://#diff-4f9ab2121e449ed4df68152ef7ca083a1cc5eaf429c39348f73119abd75a6edbL305-R310): Updated the `FileSelectorProvider` type alias to include a function type that accepts `avante.file_selector.IParams` as a parameter.

### Support for custom provider functions:

* [`lua/avante/file_selector.lua`](diffhunk://#diff-47b38fc9085b1261b91185df9257af6e78f88b834acbf7936344f3c01076fb9fR333-R337): Modified the `show_select_ui` method in the `FileSelector` class to handle custom provider functions by creating and passing an `IParams` object.