### PR TITLE
feat: bedrock temporary credentials support

### DIFF
--- a/README.md
+++ b/README.md
@@ -471,8 +471,10 @@ Given its early stage, `avante.nvim` currently supports the following basic func
 > For Amazon Bedrock:
 >
 > ```sh
-> export BEDROCK_KEYS=aws_access_key_id,aws_secret_access_key,aws_region
+> export BEDROCK_KEYS=aws_access_key_id,aws_secret_access_key,aws_region[,aws_session_token]
+>
 > ```
+> Note: The aws_session_token is optional and only needed when using temporary AWS credentials
 
 1. Open a code file in Neovim.
 2. Use the `:AvanteAsk` command to query the AI about the code.

--- a/lua/avante/providers/bedrock.lua
+++ b/lua/avante/providers/bedrock.lua
@@ -64,6 +64,7 @@ M.parse_curl_args = function(provider, prompt_opts)
   local aws_access_key_id = parts[1]
   local aws_secret_access_key = parts[2]
   local aws_region = parts[3]
+  local aws_session_token = parts[4]
 
   local endpoint = string.format(
     "https://bedrock-runtime.%s.amazonaws.com/model/%s/invoke-with-response-stream",
@@ -74,6 +75,10 @@ M.parse_curl_args = function(provider, prompt_opts)
   local headers = {
     ["Content-Type"] = "application/json",
   }
+
+  if aws_session_token and aws_session_token ~= "" then
+    headers["x-amz-security-token"] = aws_session_token
+  end
 
   local body_payload = M.build_bedrock_payload(prompt_opts, body_opts)
 


### PR DESCRIPTION
Adds optional suport for including AWS session tokens, so that we can use temporary AWS credentials to access bedrock models.

