### PR TITLE
fix(suggestions): make history more faithful to future input

### DIFF
--- a/lua/avante/suggestion.lua
+++ b/lua/avante/suggestion.lua
@@ -95,7 +95,7 @@ L5:     pass
     },
     {
       role = "user",
-      content = '<question>{"insertSpaces":true,"tabSize":4,"indentSize":4,"position":{"row":1,"col":2}}</question>',
+      content = '<question>{"insertSpaces":true,"tabSize":4,"indentSize":4,"position":{"row":1,"col":7}}</question>',
     },
     {
       role = "assistant",

--- a/lua/avante/suggestion.lua
+++ b/lua/avante/suggestion.lua
@@ -84,8 +84,8 @@ function Suggestion:suggest()
 L1: def fib
 L2:
 L3: if __name__ == "__main__":
-L4:    # just pass
-L5:    pass
+L4:     # just pass
+L5:     pass
 </code>
       ]],
     },
@@ -95,7 +95,7 @@ L5:    pass
     },
     {
       role = "user",
-      content = '<question>{ "indentSize": 4, "position": { "row": 1, "col": 2 } }</question>',
+      content = '<question>{"insertSpaces":true,"tabSize":4,"indentSize":4,"position":{"row":1,"col":2}}</question>',
     },
     {
       role = "assistant",


### PR DESCRIPTION
Makes the provided suggestion history more faithful to future queries.
1. Fixes wrong indentation in the sample history
2. Adds insertSpaces and tabSize parameters to the sample history

In the future, it might make sense to also add an example with tabs to the history. When I work on a project with tab indentation, auto suggest frequently messes up while spaces seem to be fairly reliable.