### PR TITLE
fix(sidebar): reset cursor to beginning of prompt on submit

### DIFF
--- a/lua/avante/sidebar.lua
+++ b/lua/avante/sidebar.lua
@@ -1983,6 +1983,7 @@ function Sidebar:create_input_container(opts)
     local request = table.concat(lines, "\n")
     if request == "" then return end
     api.nvim_buf_set_lines(self.input_container.bufnr, 0, -1, false, {})
+    api.nvim_win_set_cursor(self.input_container.winid, { 1, 0 })
     handle_submit(request)
   end
 


### PR DESCRIPTION
This fix is required for users with vim.o.virtualedit="all". Otherwise, the cursor remains at the end of the prompt and has to be manually moved back before entering the next prompt.