### PR TITLE
Fix/when dev icons absent

### DIFF
--- a/lua/avante/health.lua
+++ b/lua/avante/health.lua
@@ -23,9 +23,7 @@ M.check = function()
   end
 
   -- Optional dependencies
-  local has_devicons = Utils.has("nvim-web-devicons")
-  local has_mini_icons = Utils.has("mini.icons") or Utils.has("mini.nvim")
-  if has_devicons or has_mini_icons then
+  if Utils.icons_enabled() then
     H.ok("Found icons plugin (nvim-web-devicons or mini.icons)")
   else
     H.warn("No icons plugin found (nvim-web-devicons or mini.icons). Icons will not be displayed")

--- a/lua/avante/sidebar.lua
+++ b/lua/avante/sidebar.lua
@@ -437,8 +437,10 @@ local function generate_display_content(replacement)
         return string.format("  > %s", line)
       end)
       :totable()
-    local result_lines =
-      vim.list_extend(vim.list_slice(lines, 1, replacement.last_search_tag_start_line), { Utils.icon("🤔 ") .. "Thought content:" })
+    local result_lines = vim.list_extend(
+      vim.list_slice(lines, 1, replacement.last_search_tag_start_line),
+      { Utils.icon("🤔 ") .. "Thought content:" }
+    )
     result_lines = vim.list_extend(result_lines, formatted_thinking_content_lines)
     result_lines = vim.list_extend(result_lines, vim.list_slice(lines, last_think_tag_end_line + 1))
     return table.concat(result_lines, "\n")
@@ -924,7 +926,8 @@ function Sidebar:render_selected_code()
     selected_code_lines_count = #selected_code_lines
   end
 
-  local header_text = Utils.icon(" ") .. "Selected Code"
+  local header_text = Utils.icon(" ")
+    .. "Selected Code"
     .. (
       selected_code_lines_count > selected_code_max_lines_count
         and " (Show only the first " .. tostring(selected_code_max_lines_count) .. " lines)"

--- a/lua/avante/sidebar.lua
+++ b/lua/avante/sidebar.lua
@@ -397,8 +397,8 @@ local function get_searching_hint()
 end
 
 local thinking_spinner_chars = {
-  "🤯",
-  "🙄",
+  Utils.icon("🤯", "?"),
+  Utils.icon("🙄", "¿"),
 }
 local thinking_spinner_index = 1
 
@@ -438,7 +438,7 @@ local function generate_display_content(replacement)
       end)
       :totable()
     local result_lines =
-      vim.list_extend(vim.list_slice(lines, 1, replacement.last_search_tag_start_line), { "🤔 Thought content:" })
+      vim.list_extend(vim.list_slice(lines, 1, replacement.last_search_tag_start_line), { Utils.icon("🤔 ") .. "Thought content:" })
     result_lines = vim.list_extend(result_lines, formatted_thinking_content_lines)
     result_lines = vim.list_extend(result_lines, vim.list_slice(lines, last_think_tag_end_line + 1))
     return table.concat(result_lines, "\n")
@@ -861,7 +861,7 @@ function Sidebar:render_result()
   then
     return
   end
-  local header_text = "󰭻 Avante"
+  local header_text = Utils.icon("󰭻 ") .. "Avante"
   self:render_header(
     self.result_container.winid,
     self.result_container.bufnr,
@@ -883,13 +883,15 @@ function Sidebar:render_input(ask)
   end
 
   local header_text = string.format(
-    "󱜸 %s (" .. Config.mappings.sidebar.switch_windows .. ": switch focus)",
+    "%s%s (" .. Config.mappings.sidebar.switch_windows .. ": switch focus)",
+    Utils.icon("󱜸 "),
     ask and "Ask" or "Chat with"
   )
 
   if self.code.selection ~= nil then
     header_text = string.format(
-      "󱜸 %s (%d:%d) (<Tab>: switch focus)",
+      "%s%s (%d:%d) (<Tab>: switch focus)",
+      Utils.icon("󱜸 "),
       ask and "Ask" or "Chat with",
       self.code.selection.range.start.lnum,
       self.code.selection.range.finish.lnum
@@ -922,7 +924,7 @@ function Sidebar:render_selected_code()
     selected_code_lines_count = #selected_code_lines
   end
 
-  local header_text = " Selected Code"
+  local header_text = Utils.icon(" ") .. "Selected Code"
     .. (
       selected_code_lines_count > selected_code_max_lines_count
         and " (Show only the first " .. tostring(selected_code_max_lines_count) .. " lines)"
@@ -2330,7 +2332,7 @@ function Sidebar:create_selected_files_container()
     self:render_header(
       self.selected_files_container.winid,
       selected_files_buf,
-      " Selected Files",
+      Utils.icon(" ") .. "Selected Files",
       Highlights.SUBTITLE,
       Highlights.REVERSED_SUBTITLE
     )

--- a/lua/avante/utils/init.lua
+++ b/lua/avante/utils/init.lua
@@ -922,4 +922,18 @@ end
 ---@return boolean
 M.icons_enabled = function() return M.has("nvim-web-devicons") or M.has("mini.icons") or M.has("mini.nvim") end
 
+---Display an string with icon, if an icon plugin is available.
+---Dev icons are an optional install for avante, this function prevents ugly chars
+---being displayed by displaying fallback options or nothing at all.
+---@param string_with_icon string
+---@param utf8_fallback string|nil
+---@return string
+M.icon = function(string_with_icon, utf8_fallback)
+  if M.icons_enabled() then
+    return string_with_icon
+  else
+    return utf8_fallback or ""
+  end
+end
+
 return M

--- a/lua/avante/utils/init.lua
+++ b/lua/avante/utils/init.lua
@@ -918,4 +918,8 @@ function M.read_file_from_buf_or_disk(file_path)
   end
 end
 
+---Check if an icon plugin is installed
+---@return boolean
+M.icons_enabled = function() return M.has("nvim-web-devicons") or M.has("mini.icons") or M.has("mini.nvim") end
+
 return M


### PR DESCRIPTION
This PR adds a util function to use with dev icons. Because dev icons are optional to this project, we should provide an ASCII fallback for chars used as icons so that ugly artefacts are not rendered. Screenshot ugly chars (or beautiful icons, depending on your perspective) found in the codebase below.

To decide which lines I should update, I:
- Reviewed all chars in the codebase outside the ASCII range.
- Ignored tests.
- Since rounded text relies on dev icons, I ignored that too.
- Excluded spinner_chars in the sidebar, since most fonts include braille chars


Here is grep of the codebase seeking all non-ASCII chars, so that you can see what I have not changed based on the rules above.


<details>
<summary>Grep output</summary>

```
$ grep -P -r -n --include="*.lua" "[\x{00007f}-\x{10FFFF}]" . | tac

./tests/llm_tools_spec.lua:26:    -- 恢复 mock
./tests/llm_tools_spec.lua:24:    -- 清理测试目录
./tests/llm_tools_spec.lua:13:    -- 创建测试目录和文件
./lua/avante/sidebar.lua:2335:      Utils.icon(" ") .. "Selected Files",
./lua/avante/sidebar.lua:927:  local header_text = Utils.icon(" ") .. "Selected Code"
./lua/avante/sidebar.lua:894:      Utils.icon("󱜸 "),
./lua/avante/sidebar.lua:887:    Utils.icon("󱜸 "),
./lua/avante/sidebar.lua:864:  local header_text = Utils.icon("󰭻 ") .. "Avante"
./lua/avante/sidebar.lua:850:  if Config.windows.sidebar_header.rounded then winbar_text = winbar_text .. "%#" .. reverse_hl .. "#" end
./lua/avante/sidebar.lua:845:    winbar_text = winbar_text .. "%#" .. reverse_hl .. "#" .. "" .. "%#" .. hl .. "#"
./lua/avante/sidebar.lua:441:      vim.list_extend(vim.list_slice(lines, 1, replacement.last_search_tag_start_line), { Utils.icon("🤔 ") .. "Thought content:" })
./lua/avante/sidebar.lua:401:  Utils.icon("🙄", "¿ "),
./lua/avante/sidebar.lua:400:  Utils.icon("🤯", "? "),
./lua/avante/sidebar.lua:389:  "⣀",
./lua/avante/sidebar.lua:388:  "⣤",
./lua/avante/sidebar.lua:387:  "⣶",
./lua/avante/sidebar.lua:386:  "⣿",
./lua/avante/sidebar.lua:385:  "⢿",
./lua/avante/sidebar.lua:384:  "⣻",
./lua/avante/sidebar.lua:383:  "⢻",
./lua/avante/sidebar.lua:382:  "⢽",
./lua/avante/sidebar.lua:381:  "⣹",
./lua/avante/sidebar.lua:380:  "⢹",
./lua/avante/sidebar.lua:379:  "⢺",
./lua/avante/sidebar.lua:378:  "⢼",
./lua/avante/sidebar.lua:377:  "⣸",
./lua/avante/sidebar.lua:376:  "⢸",
./lua/avante/sidebar.lua:375:  "⢱",
./lua/avante/sidebar.lua:374:  "⢲",
./lua/avante/sidebar.lua:373:  "⢴",
./lua/avante/sidebar.lua:372:  "⣰",
./lua/avante/sidebar.lua:371:  "⢰",
./lua/avante/sidebar.lua:370:  "⢨",
./lua/avante/sidebar.lua:369:  "⢡",
./lua/avante/sidebar.lua:368:  "⢢",
./lua/avante/sidebar.lua:367:  "⢤",
./lua/avante/sidebar.lua:366:  "⣠",
./lua/avante/sidebar.lua:365:  "⢠",
./lua/avante/sidebar.lua:364:  "⢐",
./lua/avante/sidebar.lua:363:  "⢈",
./lua/avante/sidebar.lua:362:  "⢁",
./lua/avante/sidebar.lua:361:  "⢂",
./lua/avante/sidebar.lua:360:  "⢄",
./lua/avante/sidebar.lua:359:  "⣀",
./lua/avante/sidebar.lua:358:  "⢀",
./lua/avante/sidebar.lua:357:  "⠠",
./lua/avante/sidebar.lua:356:  "⠐",
./lua/avante/sidebar.lua:355:  "⠈",
./lua/avante/sidebar.lua:354:  "⠁",
./lua/avante/sidebar.lua:353:  "⠂",
./lua/avante/sidebar.lua:352:  "⠄",
./lua/avante/sidebar.lua:351:  "⡀",
./lua/avante/prompt_input.lua:82:    "⣀",
./lua/avante/prompt_input.lua:81:    "⣤",
./lua/avante/prompt_input.lua:80:    "⣶",
./lua/avante/prompt_input.lua:79:    "⣿",
./lua/avante/prompt_input.lua:78:    "⢿",
./lua/avante/prompt_input.lua:77:    "⣻",
./lua/avante/prompt_input.lua:76:    "⢻",
./lua/avante/prompt_input.lua:75:    "⢽",
./lua/avante/prompt_input.lua:74:    "⣹",
./lua/avante/prompt_input.lua:73:    "⢹",
./lua/avante/prompt_input.lua:72:    "⢺",
./lua/avante/prompt_input.lua:71:    "⢼",
./lua/avante/prompt_input.lua:70:    "⣸",
./lua/avante/prompt_input.lua:69:    "⢸",
./lua/avante/prompt_input.lua:68:    "⢱",
./lua/avante/prompt_input.lua:67:    "⢲",
./lua/avante/prompt_input.lua:66:    "⢴",
./lua/avante/prompt_input.lua:65:    "⣰",
./lua/avante/prompt_input.lua:64:    "⢰",
./lua/avante/prompt_input.lua:63:    "⢨",
./lua/avante/prompt_input.lua:62:    "⢡",
./lua/avante/prompt_input.lua:61:    "⢢",
./lua/avante/prompt_input.lua:60:    "⢤",
./lua/avante/prompt_input.lua:59:    "⣠",
./lua/avante/prompt_input.lua:58:    "⢠",
./lua/avante/prompt_input.lua:57:    "⢐",
./lua/avante/prompt_input.lua:56:    "⢈",
./lua/avante/prompt_input.lua:55:    "⢁",
./lua/avante/prompt_input.lua:54:    "⢂",
./lua/avante/prompt_input.lua:53:    "⢄",
./lua/avante/prompt_input.lua:52:    "⣀",
./lua/avante/prompt_input.lua:51:    "⢀",
./lua/avante/prompt_input.lua:50:    "⠠",
./lua/avante/prompt_input.lua:49:    "⠐",
./lua/avante/prompt_input.lua:48:    "⠈",
./lua/avante/prompt_input.lua:47:    "⠁",
./lua/avante/prompt_input.lua:46:    "⠂",
./lua/avante/prompt_input.lua:45:    "⠄",
./lua/avante/prompt_input.lua:44:    "⡀",
```

</details>

Let me know if you want me to update anything I have chosen to ignore.

Here is an example of badly rendered icons in a term:
![2025-02-07-122106_1044x230_scrot](https://github.com/user-attachments/assets/4064d0e6-ee18-4271-bd89-29166196c6fc)

Here is an example of avante.nvim without the offending chars:
![2025-02-07-122306_234x465_scrot](https://github.com/user-attachments/assets/5de29c8b-d86b-4d61-a32a-26be0f168f48)
