### PR TITLE
suggestion: dual-boost-only-in-planning-mode

### DIFF
--- a/lua/avante/llm.lua
+++ b/lua/avante/llm.lua
@@ -449,7 +449,7 @@ M.stream = function(opts)
       return original_on_stop(stop_opts)
     end)
   end
-  if Config.dual_boost.enabled then
+  if Config.dual_boost.enabled and opts.mode == "planning" then
     M._dual_boost_stream(opts, P[Config.dual_boost.first_provider], P[Config.dual_boost.second_provider])
   else
     M._stream(opts)


### PR DESCRIPTION
I've been using avante in dual boost lately and I think it can yield better results but, i just notice that when i enable the auto suggestion the times have gone crazy with 40s waiting to get a response. I notice its bc suggestion mode was using also the dual boost

This is a small change that will only enable the dual bost when in planning mode. Since I think that mode is the one that could benefit of that mode bc of higher response times but i think when you open the planner you're willing to spent time waiting for the AI to give best results, where in edit and suggest mode you want the ai to do a simple thing and do it fast