### PR TITLE
feat(sidebar): add sidebar:is_focused() member function

### DIFF
--- a/lua/avante/sidebar.lua
+++ b/lua/avante/sidebar.lua
@@ -1256,6 +1256,20 @@ function Sidebar:initialize()
   return self
 end
 
+function Sidebar:is_focused()
+  if not self:is_open() then return false end
+
+  local current_winid = api.nvim_get_current_win()
+  if self.winids.result_container and self.winids.result_container == current_winid then return true end
+  if self.winids.selected_files_container and self.winids.selected_files_container == current_winid then
+    return true
+  end
+  if self.winids.selected_code_container and self.winids.selected_code_container == current_winid then return true end
+  if self.winids.input_container and self.winids.input_container == current_winid then return true end
+
+  return false
+end
+
 function Sidebar:is_focused_on_result()
   return self:is_open() and self.result_container and self.result_container.winid == api.nvim_get_current_win()
 end


### PR DESCRIPTION
This helps user configs create branching logic depending on sidebar focus.

Concrete example use case: this allows user configs to implement a shortcut that opens/focuses the sidebar if unfocused, but closes sidebar if focused.