### PR TITLE
fix(sidebar): fix various focus errors

### DIFF
--- a/lua/avante/sidebar.lua
+++ b/lua/avante/sidebar.lua
@@ -66,9 +66,24 @@ function Sidebar:delete_autocmds()
 end
 
 function Sidebar:reset()
+  -- clean up event handlers
+  if self.augroup then
+    api.nvim_del_augroup_by_id(self.augroup)
+    self.augroup = nil
+  end
+
+  -- clean up keymaps
   self:unbind_apply_key()
   self:unbind_sidebar_keys()
-  self:delete_autocmds()
+
+  -- clean up file selector events
+  if self.file_selector then self.file_selector:off("update") end
+
+  if self.result_container then self.result_container:unmount() end
+  if self.selected_code_container then self.selected_code_container:unmount() end
+  if self.selected_files_container then self.selected_files_container:unmount() end
+  if self.input_container then self.input_container:unmount() end
+
   self.code = { bufnr = 0, winid = 0, selection = nil }
   self.winids =
     { result_container = 0, selected_files_container = 0, selected_code_container = 0, input_container = 0 }


### PR DESCRIPTION
This fixes a bunch of errors I was getting when switching away from the avante sidebar and then back. Sometimes the sidebar would lose track of the various windows, and you'd get errors like this:

```
|| stack traceback:
|| 	...local/share/nvim/lazy/avante.nvim/lua/avante/sidebar.lua:2350: in function <...local/share/nvim/lazy/avante.nvim/lua/avante/sidebar.lua:2349>
|| Error detected while processing BufLeave Autocommands for "<buffer=294>":
|| Error executing lua callback: ...local/share/nvim/lazy/avante.nvim/lua/avante/sidebar.lua:2398: attempt to index field 'selected_files_container' (a nil value)
```

Or this one:

```
|| stack traceback:
|| 	...local/share/nvim/lazy/avante.nvim/lua/avante/sidebar.lua:2350: in function <...local/share/nvim/lazy/avante.nvim/lua/avante/sidebar.lua:2349>
|| Error detected while processing BufLeave Autocommands for "<buffer=294>":
|| Error executing lua callback: ...local/share/nvim/lazy/avante.nvim/lua/avante/sidebar.lua:2398: attempt to index field 'selected_files_container' (a nil value)
```

This change does the following:

1. Proper order of cleanup in `reset()`
2. Proper cleanup in `create_selected_files_container()`