### PR TITLE
fix(tavily): remove time restriction of 1 day

### DIFF
--- a/lua/avante/config.lua
+++ b/lua/avante/config.lua
@@ -33,7 +33,6 @@ M._defaults = {
       tavily = {
         api_key_name = "TAVILY_API_KEY",
         extra_request_body = {
-          time_range = "d",
           include_answer = "basic",
         },
         ---@type WebSearchEngineProviderResponseBodyFormatter


### PR DESCRIPTION
Without this fix, tavily only searches for web content from the last 24h (without any savings in credits).

If tavily's API had an option like `time_range = "indefinite"` or similar, this wouldn't be a problem and the user could override the setting in their config... but as it stands, that's not the case. The best a user can do right now is 1 year (`time_range = "y"`), so I think it's better to remove the default config entry entirely and have the user add one if they need any time restriction.