### PR TITLE
:memo: docs(README): update customized file_selector example

### DIFF
--- a/README.md
+++ b/README.md
@@ -380,12 +380,44 @@ This is achieved by emulating nvim-cmp using blink.compat
 
 ```lua
       file_selector = {
-        --- @alias FileSelectorProvider "native" | "fzf" | "mini.pick" | "snacks" | "telescope" | string
+        --- @alias FileSelectorProvider "native" | "fzf" | "mini.pick" | "snacks" | "telescope" | string | fun(params: avante.file_selector.IParams): nil
         provider = "fzf",
         -- Options override for custom providers
         provider_opts = {},
       }
 ```
+
+To create a customized file_selector, you can specify a customized function to launch a picker to select items and pass the selected items to the `handler` callback.
+
+```lua
+      file_selector = {
+        ---@param params avante.file_selector.IParams
+        provider = function(params)
+          local filepaths = params.filepaths ---@type string[]
+          local title = params.title ---@type string
+          local handler = params.handler ---@type fun(selected_filepaths: string[]): nil
+
+          -- Launch your customized picker with the items built from `filepaths`, then in the `on_confirm` callback,
+          -- pass the selected items (convert back to file paths) to the `handler` function.
+
+          local items = __your_items_formatter__(filepaths)
+          __your_picker__({
+            items = items,
+            on_cancel = function()
+              handler(nil)
+            end,
+            on_confirm = function(selected_items)
+              local selected_filepaths = {}
+              for _, item in ipairs(selected_items) do
+                table.insert(selected_filepaths, item.filepath)
+              end
+              handler(selected_filepaths)
+            end
+          })
+        end,
+      }
+```
+
 Choose a selector other that native, the default as that currently has an issue
 For lazyvim users copy the full config for blink.cmp from the website or extend the options
 ```lua

--- a/README.md
+++ b/README.md
@@ -380,7 +380,7 @@ This is achieved by emulating nvim-cmp using blink.compat
 
 ```lua
       file_selector = {
-        --- @alias FileSelectorProvider "native" | "fzf" | "mini.pick" | "snacks" | "telescope" | string | fun(params: avante.file_selector.IParams): nil
+        --- @alias FileSelectorProvider "native" | "fzf" | "mini.pick" | "snacks" | "telescope" | string | fun(params: avante.file_selector.IParams|nil): nil
         provider = "fzf",
         -- Options override for custom providers
         provider_opts = {},
@@ -395,7 +395,7 @@ To create a customized file_selector, you can specify a customized function to l
         provider = function(params)
           local filepaths = params.filepaths ---@type string[]
           local title = params.title ---@type string
-          local handler = params.handler ---@type fun(selected_filepaths: string[]): nil
+          local handler = params.handler ---@type fun(selected_filepaths: string[]|nil): nil
 
           -- Launch your customized picker with the items built from `filepaths`, then in the `on_confirm` callback,
           -- pass the selected items (convert back to file paths) to the `handler` function.

--- a/lua/avante/config.lua
+++ b/lua/avante/config.lua
@@ -332,7 +332,7 @@ M._defaults = {
   },
   --- @class AvanteFileSelectorConfig
   file_selector = {
-    --- @alias FileSelectorProvider "native" | "fzf" | "mini.pick" | "snacks" | "telescope" | string | fun(params: avante.file_selector.IParams): nil
+    --- @alias FileSelectorProvider "native" | "fzf" | "mini.pick" | "snacks" | "telescope" | string | fun(params: avante.file_selector.IParams|nil): nil
     provider = "native",
     -- Options override for custom providers
     provider_opts = {},


### PR DESCRIPTION
This pull request includes updates to the `README.md` file to enhance the documentation for customizing the `file_selector` in Lua. The most important changes include adding a new alias to the `FileSelectorProvider` type and providing a detailed example of how to create a customized file selector function.

Documentation updates:

* [`README.md`](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L383-R420): Added a new alias `fun(params: avante.file_selector.IParams): nil` to the `FileSelectorProvider` type.
* [`README.md`](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L383-R420): Included a comprehensive example demonstrating how to specify a custom function for the `file_selector` to launch a picker and handle selected items.