### PR TITLE
Fix: musl build error

### DIFF
--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -3,3 +3,6 @@ rustflags = ["-C", "link-arg=-undefined", "-C", "link-arg=dynamic_lookup"]
 
 [target.aarch64-apple-darwin]
 rustflags = ["-C", "link-arg=-undefined", "-C", "link-arg=dynamic_lookup"]
+
+[target.x86_64-unknown-linux-musl]
+rustflags = ["-C", "target-feature=-crt-static"]


### PR DESCRIPTION
I am on a musl system and i get this error when building (due to static linking) when running `make BUILD_FROM_SOURCE=true`. 
 Adding `-crt-static"` for linux-musl targets in `.cargo/config.toml` fixes this.
 
This is the error:
 ```
error: cannot produce cdylib for `avante-tokenizers v0.1.0 (/home/giuseppe/.local/share/nvim/lazy/avante.nvim/crates/avante-tokenizers)` as the target `x86_64-unknown-linux-musl` does not support these crate types
```