### PR TITLE
Revert "Fix Makefile shell usage"

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -36,7 +36,7 @@ else
 endif
 else
 $1:
-	$(shell LUA_VERSION=$1 bash ./build.sh)
+	LUA_VERSION=$1 bash ./build.sh
 endif
 endef
 


### PR DESCRIPTION
Reverts yetone/avante.nvim#1155

@alexbalonperin Sorry, I will reverte this PR as it cause error to bash
```
❯ make
avante_html2md.so avante_repo_map.so avante_templates.so avante_tokenizers.so
make: avante_html2md.so: No such file or directory
make: *** [Makefile:43: luajit] Error 127

```