### PR TITLE
fix(utils): get non-nil filetype

### DIFF
--- a/lua/avante/utils/init.lua
+++ b/lua/avante/utils/init.lua
@@ -895,7 +895,7 @@ function M.get_filetype(filepath)
   -- https://github.com/neovim/neovim/issues/27265
 
   local buf = vim.api.nvim_create_buf(false, true)
-  local filetype = vim.filetype.match({ filename = filepath, buf = buf })
+  local filetype = vim.filetype.match({ filename = filepath, buf = buf }) or ""
   vim.api.nvim_buf_delete(buf, { force = true })
 
   return filetype


### PR DESCRIPTION
Sometimes the utility fails to identify the file type, leading to Rust serde deserialization errors. Therefore, we ensure it returns a non-nil file type.