### PR TITLE
[Azure Provider] Support Microsoft Entra ID Authentication

### DIFF
--- a/lua/avante/config.lua
+++ b/lua/avante/config.lua
@@ -462,6 +462,7 @@ M.BASE_PROVIDER_KEYS = {
   "role_map",
   "__inherited_from",
   "disable_tools",
+  "entra",
 }
 
 return M

--- a/lua/avante/providers/azure.lua
+++ b/lua/avante/providers/azure.lua
@@ -23,7 +23,14 @@ M.parse_curl_args = function(provider, prompt_opts)
   local headers = {
     ["Content-Type"] = "application/json",
   }
-  if P.env.require_api_key(provider_conf) then headers["api-key"] = provider.parse_api_key() end
+
+  if P.env.require_api_key(provider_conf) then
+    if provider_conf.entra then
+      headers["Authorization"] = "Bearer " .. provider.parse_api_key()
+    else
+      headers["api-key"] = provider.parse_api_key()
+    end
+  end
 
   -- NOTE: When using "o" series set the supported parameters only
   if O.is_o_series_model(provider_conf.model) then


### PR DESCRIPTION
The Azure extension for OpenAI-API has [two authentication methods](https://learn.microsoft.com/en-us/azure/ai-services/openai/reference#authentication), the standard `api-key` header, and an `Authorization` header for Microsoft Entra ID.  This PR adds the option to switch between the two.

I did not see a way to add a test for the provider options, but if you have one, happy add that!

Great project, thank you!