### PR TITLE
docs: Add reasoning_effort docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,6 +60,7 @@ For building binary if you wish to build from source, then `cargo` is required. 
       timeout = 30000, -- timeout in milliseconds
       temperature = 0, -- adjust if needed
       max_tokens = 4096,
+      reasoning_effort = "high" -- only supported for "o" models
     },
   },
   -- if you want to build from source then do `make BUILD_FROM_SOURCE=true`

--- a/lua/avante/providers/init.lua
+++ b/lua/avante/providers/init.lua
@@ -64,6 +64,7 @@ local DressingState = { winid = nil, input_winid = nil, input_bufnr = nil }
 ---@field __inherited_from? string
 ---@field temperature? number
 ---@field max_tokens? number
+---@field reasoning_effort? string
 ---
 ---@class AvanteLLMUsage
 ---@field input_tokens number


### PR DESCRIPTION
I believe `reasoning_effort` is already supported but it's not documented. I'm hoping this could be helpful for the people using the `o` models