### PR TITLE
fix: correct typo in answer field name in tavily format_response_body…

### DIFF
--- a/lua/avante/config.lua
+++ b/lua/avante/config.lua
@@ -36,7 +36,7 @@ M._defaults = {
           include_answer = "basic",
         },
         ---@type WebSearchEngineProviderResponseBodyFormatter
-        format_response_body = function(body) return body.anwser, nil end,
+        format_response_body = function(body) return body.answer, nil end,
       },
       serpapi = {
         api_key_name = "SERPAPI_API_KEY",


### PR DESCRIPTION
There is a typo in `format_response_body` that prevents wavily from working.