### PR TITLE
feat(file_selector): support customized filepaths resolver

### DIFF
--- a/README.md
+++ b/README.md
@@ -416,6 +416,24 @@ To create a customized file_selector, you can specify a customized function to l
             end
           })
         end,
+        ---below is optional
+        provider_opts = {
+          ---@param params avante.file_selector.opts.IGetFilepathsParams
+          get_filepaths = function(params)
+            local cwd = params.cwd ---@type string
+            local selected_filepaths = params.selected_filepaths ---@type string[]
+            local cmd = string.format("fd --base-directory '%s' --hidden", vim.fn.fnameescape(cwd))
+            local output = vim.fn.system(cmd)
+            local filepaths = vim.split(output, "\n", { trimempty = true })
+            return vim
+              .iter(filepaths)
+              :filter(function(filepath)
+                return not vim.tbl_contains(selected_filepaths, filepath)
+              end)
+              :totable()
+          end
+        }
+        end
       }
 ```
 

--- a/lua/avante/config.lua
+++ b/lua/avante/config.lua
@@ -10,6 +10,10 @@ local Utils = require("avante.utils")
 ---@field public filepaths  string[]
 ---@field public handler    fun(filepaths: string[]|nil): nil
 
+---@class avante.file_selector.opts.IGetFilepathsParams
+---@field public cwd                string
+---@field public selected_filepaths string[]
+
 ---@class avante.CoreConfig: avante.Config
 local M = {}
 ---@class avante.Config

--- a/lua/avante/file_selector.lua
+++ b/lua/avante/file_selector.lua
@@ -166,6 +166,15 @@ end
 function FileSelector:open() self:show_select_ui() end
 
 function FileSelector:get_filepaths()
+  if type(Config.file_selector.provider_opts.get_filepaths) == "function" then
+    ---@type avante.file_selector.opts.IGetFilepathsParams
+    local params = {
+      cwd = Utils.get_project_root(),
+      selected_filepaths = self.selected_filepaths,
+    }
+    return Config.file_selector.provider_opts.get_filepaths(params)
+  end
+
   local filepaths = get_project_filepaths()
 
   table.sort(filepaths, function(a, b)


### PR DESCRIPTION
Since the `rg` / `fd` can get better performance to scan directory, I think it's better to provider a customized option for user to resolver the filepaths manually.

* fix #1276 
* fix: seems the `.gitignore` not works anymore