### PR TITLE
Feat: Add file selector ignore patterns

### DIFF
--- a/lua/avante/config.lua
+++ b/lua/avante/config.lua
@@ -370,6 +370,9 @@ M._defaults = {
     provider = "native",
     -- Options override for custom providers
     provider_opts = {},
+
+    ignore_patterns = {
+    }
   },
   suggestion = {
     debounce = 600,


### PR DESCRIPTION
Adding a file selector option to ignore some path such `.git`. Just did this to unlock myself but I could elaborate it more if it looks useful for you. 

Without the filter
![image](https://github.com/user-attachments/assets/7bd92923-2cbd-4078-a451-3c006c9d0113)

With the filter:
![image](https://github.com/user-attachments/assets/4e3ae8f0-d947-45e1-bd5c-fabc8119f657)

<img width="294" alt="image" src="https://github.com/user-attachments/assets/4bc852e9-151d-47c3-81b2-dadf3412a322" />


