### PR TITLE
feat(file_selector): add @buffers mention to add open buffers to chat context

### DIFF
--- a/lua/avante/file_selector.lua
+++ b/lua/avante/file_selector.lua
@@ -404,4 +404,18 @@ function FileSelector:add_quickfix_files()
   end
 end
 
+---@return nil
+function FileSelector:add_buffer_files()
+  local buffers = vim.api.nvim_list_bufs()
+  for _, bufnr in ipairs(buffers) do
+    if vim.api.nvim_buf_is_loaded(bufnr) then
+      local filepath = vim.api.nvim_buf_get_name(bufnr)
+      if filepath and filepath ~= "" and not vim.startswith(filepath, "avante://") then
+        local relative_path = Utils.relative_path(filepath)
+        self:add_selected_file(relative_path)
+      end
+    end
+  end
+end
+
 return FileSelector

--- a/lua/avante/sidebar.lua
+++ b/lua/avante/sidebar.lua
@@ -2467,6 +2467,13 @@ function Sidebar:create_input_container(opts)
           callback = function() self.file_selector:add_quickfix_files() end,
         })
 
+        table.insert(mentions, {
+          description = "buffers",
+          command = "buffers",
+          details = "add open buffers to the chat context",
+          callback = function() self.file_selector:add_buffer_files() end,
+        })
+
         cmp.register_source(
           "avante_commands",
           require("cmp_avante.commands"):new(self:get_commands(), self.input_container.bufnr)


### PR DESCRIPTION
I often find myself wanting to add my open buffers to the context instead of populating a quickfix and using @quickfix