### PR TITLE
Improve responsiveness while streaming generations.

### DIFF
--- a/lua/avante/utils/init.lua
+++ b/lua/avante/utils/init.lua
@@ -405,7 +405,6 @@ function M.unlock_buf(bufnr)
 end
 
 function M.lock_buf(bufnr)
-  vim.cmd("stopinsert")
   vim.bo[bufnr].modified = false
   vim.bo[bufnr].modifiable = false
 end


### PR DESCRIPTION
This remove stopinsert from lock_buf. 
This makes my neovim usable while we're receiving results. Otherwise it would lag and be generally unusable.