### PR TITLE
fix(file_selector): handle absolute and relative filepaths

### DIFF
--- a/lua/avante/file_selector.lua
+++ b/lua/avante/file_selector.lua
@@ -89,7 +89,8 @@ end
 function FileSelector:add_selected_file(filepath)
   if not filepath or filepath == "" then return end
 
-  local absolute_path = Path:new(Utils.get_project_root()):joinpath(filepath):absolute()
+  local absolute_path = filepath:sub(1, 1) == "/" and filepath
+    or Path:new(Utils.get_project_root()):joinpath(filepath):absolute()
   local stat = vim.loop.fs_stat(absolute_path)
 
   if stat and stat.type == "directory" then


### PR DESCRIPTION
# Support absolute paths in file selector

## Changes
- Modified `add_selected_file` to handle absolute file paths
- Checks if path starts with "/" to determine if it's absolute
- Falls back to existing project-relative path logic if path is not absolute

## Why
Previously, all paths were assumed to be relative to the project root, which prevented selecting files using absolute paths. This change allows users to select files from anywhere in the filesystem while maintaining backward compatibility for project-relative paths.

