### PR TITLE
fix: dualboost error with invalid capture

### DIFF
--- a/lua/avante/llm.lua
+++ b/lua/avante/llm.lua
@@ -324,8 +324,8 @@ end
 local function _merge_response(first_response, second_response, opts)
   local prompt = "\n" .. Config.dual_boost.prompt
   prompt = prompt
-    :gsub("{{[%s]*provider1_output[%s]*}}", first_response)
-    :gsub("{{[%s]*provider2_output[%s]*}}", second_response)
+    :gsub("{{[%s]*provider1_output[%s]*}}", function() return first_response end)
+    :gsub("{{[%s]*provider2_output[%s]*}}", function() return second_response end)
 
   prompt = prompt .. "\n"
 


### PR DESCRIPTION
The % is considered an scape charater in gsub

Sometimes, when the providers AIs response with code that includes the % it mess with the gsub method bc it thinks its a capture group. I change the gsub replace str to be function because when gsub is provided with a function it no longer looks for scape characters