### PR TITLE
fix: invalid default model name for `vertex` provider

### DIFF
--- a/lua/avante/config.lua
+++ b/lua/avante/config.lua
@@ -208,7 +208,7 @@ M._defaults = {
   ---@type AvanteSupportedProvider
   vertex = {
     endpoint = "https://LOCATION-aiplatform.googleapis.com/v1/projects/PROJECT_ID/locations/LOCATION/publishers/google/models",
-    model = "gemini-1.5-flash-latest",
+    model = "gemini-1.5-flash-002",
     timeout = 30000, -- Timeout in milliseconds
     temperature = 0,
     max_tokens = 4096,


### PR DESCRIPTION
Users using the `vertex` configuration defaults, after correctly setting `PROJECT_ID` and `REGION` in their environment variables, currently receive the following error in Avante:
```
Error: "API request failed with status 404. Body: '{\\n  \"error\": {\\n    \"code\": 404,\\n    \"message\": \"Publisher Model `projects/${PROJECT_ID}/locations/${REGION}/publishers/google/models/gemini-1.5-flash-latest` not found.\",\\n    \"status\": \"NOT_FOUND\"\\n  }\\n}'"
```

This pull requests updates the default `model` for `vertex` to use latest Gemini 1.5 Flash version `gemini-1.5-flash-002` as, unlike Gemini via Gemini API, Gemini via Vertex AI does not support the `-latest` alias. For more information, see here: https://cloud.google.com/vertex-ai/generative-ai/docs/learn/model-versions.

