### PR TITLE
docs: update lazy config

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,7 +66,7 @@ For building binary if you wish to build from source, then `cargo` is required. 
       timeout = 30000, -- timeout in milliseconds
       temperature = 0, -- adjust if needed
       max_tokens = 4096,
-      reasoning_effort = "high" -- only supported for "o" models
+      -- reasoning_effort = "high" -- only supported for reasoning models (o1, etc.)
     },
   },
   -- if you want to build from source then do `make BUILD_FROM_SOURCE=true`


### PR DESCRIPTION
## Overview

This PR comments out the `reasoning_effort` parameter with the default lazy config in the README. Otherwise, OpenAI responds with a `400` error as the `reasoning_effort` parameter is not available with the `gpt-4o` model.

For example:

<img width="1680" alt="Screenshot 2025-02-22 at 1 14 06 PM" src="https://github.com/user-attachments/assets/06fa5513-e9c2-4faf-a153-ffb6292382c7" />

### Sources
* https://platform.openai.com/docs/guides/reasoning
* [https://community.openai.com/t/o1s-reasoning-effort-parameter/1062308](https://community.openai.com/t/o1s-reasoning-effort-parameter/1062308/10)