### PR TITLE
feat: add shell_cmd config for run_command tool

### DIFF
--- a/lua/avante/config.lua
+++ b/lua/avante/config.lua
@@ -388,6 +388,10 @@ M._defaults = {
     --- Disable by setting to -1.
     override_timeoutlen = 500,
   },
+  run_command = {
+    -- Only applies to macOS and Linux
+    shell_cmd = "sh -c",
+  },
   --- @class AvanteHintsConfig
   hints = {
     enabled = true,

--- a/lua/avante/llm_tools.lua
+++ b/lua/avante/llm_tools.lua
@@ -288,7 +288,7 @@ function M.run_command(opts, on_log)
   ---change cwd to abs_path
   local old_cwd = vim.fn.getcwd()
   vim.fn.chdir(abs_path)
-  local res = Utils.shell_run(opts.command)
+  local res = Utils.shell_run(opts.command, Config.run_command.shell_cmd)
   vim.fn.chdir(old_cwd)
   if res.code ~= 0 then
     if res.stdout then return false, "Error: " .. res.stdout .. "; Error code: " .. tostring(res.code) end

--- a/lua/avante/utils/init.lua
+++ b/lua/avante/utils/init.lua
@@ -73,8 +73,9 @@ end
 
 --- This function will run given shell command synchronously.
 ---@param input_cmd string
+---@param shell_cmd string?
 ---@return vim.SystemCompleted
-M.shell_run = function(input_cmd)
+M.shell_run = function(input_cmd, shell_cmd)
   local shell = vim.o.shell:lower()
   ---@type string
   local cmd
@@ -89,7 +90,8 @@ M.shell_run = function(input_cmd)
     cmd = 'powershell.exe -NoProfile -Command "' .. input_cmd:gsub('"', "'") .. '"'
   else
     -- linux and macos we wil just do sh -c
-    cmd = "sh -c " .. fn.shellescape(input_cmd)
+    shell_cmd = shell_cmd or "sh -c"
+    cmd = shell_cmd .. " " .. fn.shellescape(input_cmd)
   end
 
   local output = fn.system(cmd)

--- a/tests/llm_tools_spec.lua
+++ b/tests/llm_tools_spec.lua
@@ -1,6 +1,7 @@
 local mock = require("luassert.mock")
 local stub = require("luassert.stub")
 local LlmTools = require("avante.llm_tools")
+local Config = require("avante.config")
 local Utils = require("avante.utils")
 
 LlmTools.confirm = function(msg) return true end
@@ -10,6 +11,7 @@ describe("llm_tools", function()
   local test_file = test_dir .. "/test.txt"
 
   before_each(function()
+    Config.setup()
     -- 创建测试目录和文件
     os.execute("mkdir -p " .. test_dir)
     local file = io.open(test_file, "w")


### PR DESCRIPTION
I have some fish functions that I would like to be callable from the `run_command` llm tool and would prefer not to have to prompt it to use the tool or have it clutter up the confirmation dialog. Thus I add a config here to set the default shell command to be used, which was previously `sh -c`. It can be set like so:

```lua
{
  run_command = {
    shell_cmd = "fish -c",
  },
}
```

I'd imagine this could also be used for making sure a command gets called within container which also seems useful, but worth considering if this would be the way to go about it.
