### PR TITLE
[Fix]:Rename llm-tool

### DIFF
--- a/lua/avante/llm_tools.lua
+++ b/lua/avante/llm_tools.lua
@@ -69,7 +69,7 @@ function M.search_files(opts, on_log)
 end
 
 ---@type AvanteLLMToolFunc<{ rel_path: string, keyword: string }>
-function M.search(opts, on_log)
+function M.search_keyword(opts, on_log)
   local abs_path = get_abs_path(opts.rel_path)
   if not has_permission_to_access(abs_path) then return "", "No permission to access path: " .. abs_path end
   if not Path:new(abs_path):exists() then return "", "No such file or directory: " .. abs_path end
@@ -738,7 +738,7 @@ M._tools = {
     },
   },
   {
-    name = "search",
+    name = "search_keyword",
     description = "Search for a keyword in a directory",
     param = {
       type = "table",

--- a/tests/llm_tools_spec.lua
+++ b/tests/llm_tools_spec.lua
@@ -124,7 +124,7 @@ describe("llm_tools", function()
     end)
   end)
 
-  describe("search", function()
+  describe("search_keyword", function()
     local original_exepath = vim.fn.exepath
 
     after_each(function() vim.fn.exepath = original_exepath end)
@@ -147,7 +147,7 @@ describe("llm_tools", function()
       file:write("this is nothing")
       file:close()
 
-      local result, err = LlmTools.search({ rel_path = ".", keyword = "searchable" })
+      local result, err = LlmTools.search_keyword({ rel_path = ".", keyword = "searchable" })
       assert.is_nil(err)
       assert.truthy(result:find("searchable.txt"))
       assert.falsy(result:find("nothing.txt"))
@@ -166,7 +166,7 @@ describe("llm_tools", function()
       file:write("content for ag test")
       file:close()
 
-      local result, err = LlmTools.search({ rel_path = ".", keyword = "ag test" })
+      local result, err = LlmTools.search_keyword({ rel_path = ".", keyword = "ag test" })
       assert.is_nil(err)
       assert.is_string(result)
       assert.truthy(result:find("ag_test.txt"))
@@ -179,7 +179,7 @@ describe("llm_tools", function()
         return ""
       end
 
-      local result, err = LlmTools.search({ rel_path = ".", keyword = "test" })
+      local result, err = LlmTools.search_keyword({ rel_path = ".", keyword = "test" })
       assert.is_nil(err)
       assert.truthy(result:find("test.txt"))
     end)
@@ -188,18 +188,18 @@ describe("llm_tools", function()
       -- Mock exepath to return nothing
       vim.fn.exepath = function() return "" end
 
-      local result, err = LlmTools.search({ rel_path = ".", keyword = "test" })
+      local result, err = LlmTools.search_keyword({ rel_path = ".", keyword = "test" })
       assert.equals("", result)
       assert.equals("No search command found", err)
     end)
 
     it("should respect path permissions", function()
-      local result, err = LlmTools.search({ rel_path = "../outside_project", keyword = "test" })
+      local result, err = LlmTools.search_keyword({ rel_path = "../outside_project", keyword = "test" })
       assert.truthy(err:find("No permission to access path"))
     end)
 
     it("should handle non-existent paths", function()
-      local result, err = LlmTools.search({ rel_path = "non_existent_dir", keyword = "test" })
+      local result, err = LlmTools.search_keyword({ rel_path = "non_existent_dir", keyword = "test" })
       assert.equals("", result)
       assert.truthy(err)
       assert.truthy(err:find("No such file or directory"))


### PR DESCRIPTION
Rename llm tool "search" to "search_keyword" as some llm provider(for example tongyi.aliyun) block the tool name "search" for some reason. 