### PR TITLE
fix: python tool message formatting and check for docker

### DIFF
--- a/lua/avante/llm_tools.lua
+++ b/lua/avante/llm_tools.lua
@@ -507,17 +507,19 @@ function M.python(opts, on_log)
   if not Path:new(abs_path):exists() then return nil, "Path not found: " .. abs_path end
   if on_log then on_log("cwd: " .. abs_path) end
   if on_log then on_log("code: " .. opts.code) end
+  local container_image = opts.container_image or "python:3.11-slim-bookworm"
   if
     not M.confirm(
-      "Are you sure you want to run the python code in the contianer in the directory: `"
+      "Are you sure you want to run the following python code in the `"
+        .. container_image
+        .. "` container, in the directory: `"
         .. abs_path
-        .. "`? code: "
+        .. "`?\n"
         .. opts.code
     )
   then
     return nil, "User canceled"
   end
-  local container_image = opts.container_image or "python:3.11-slim-bookworm"
   ---change cwd to abs_path
   local old_cwd = vim.fn.getcwd()
 

--- a/lua/avante/llm_tools.lua
+++ b/lua/avante/llm_tools.lua
@@ -506,7 +506,7 @@ function M.python(opts, on_log)
   if not has_permission_to_access(abs_path) then return nil, "No permission to access path: " .. abs_path end
   if not Path:new(abs_path):exists() then return nil, "Path not found: " .. abs_path end
   if on_log then on_log("cwd: " .. abs_path) end
-  if on_log then on_log("code: " .. opts.code) end
+  if on_log then on_log("code:\n" .. opts.code) end
   local container_image = opts.container_image or "python:3.11-slim-bookworm"
   if
     not M.confirm(

--- a/lua/avante/llm_tools.lua
+++ b/lua/avante/llm_tools.lua
@@ -520,6 +520,7 @@ function M.python(opts, on_log)
   then
     return nil, "User canceled"
   end
+  if vim.fn.executable("docker") == 0 then return nil, "Python tool is not available to execute any code" end
   ---change cwd to abs_path
   local old_cwd = vim.fn.getcwd()
 


### PR DESCRIPTION
I encountered a couple of different issues with the python tool:
1. There was a typo in the confirm message and it is a bit unclear.
2. When docker is not installed, the tool fails and the response does not finish.

I have fixed the first issue by fixing the typo, listing out the container name, and making sure that the code starts on a new line.
The second issue was fixed by first checking if docker is installed, and if not, sending back a message to the LLM to make it clear that the Python tool should not be used. I had a bit of prompt engineering here since a simple error message here made the LLM try the python tool again with simpler python scripts.
