### PR TITLE
feat: add Windows support for git directory scanning

### DIFF
--- a/lua/avante/utils/init.lua
+++ b/lua/avante/utils/init.lua
@@ -715,14 +715,27 @@ function M.scan_directory(options)
   if not cmd then
     local p = Path:new(options.directory)
     if p:joinpath(".git"):exists() and vim.fn.executable("git") == 1 then
-      cmd = {
-        "bash",
-        "-c",
-        string.format(
-          "cd %s && cat <(git ls-files --exclude-standard) <(git ls-files --exclude-standard --others)",
-          options.directory
-        ),
-      }
+      if vim.fn.has("win32") == 1 then
+        cmd = {
+          "powershell",
+          "-NoProfile",
+          "-NonInteractive",
+          "-Command",
+          string.format(
+            "Push-Location '%s'; (git ls-files --exclude-standard), (git ls-files --exclude-standard --others)",
+            options.directory:gsub("/", "\\")
+          ),
+        }
+      else
+        cmd = {
+          "bash",
+          "-c",
+          string.format(
+            "cd %s && cat <(git ls-files --exclude-standard) <(git ls-files --exclude-standard --others)",
+            options.directory
+          ),
+        }
+      end
       cmd_supports_max_depth = false
     else
       M.error("No search command found")


### PR DESCRIPTION
feat: add Windows support for git directory scanning

Add PowerShell command for scanning git directories on Windows systems while
maintaining the existing bash command for Unix-like systems. This allows the
directory scanner to work properly across different platforms.

Hanchin Hsieh <me@yuchanns.xyz>