### PR TITLE
fix(rag_service): ignore leading slash gitignore patterns

### DIFF
--- a/py/rag-service/src/main.py
+++ b/py/rag-service/src/main.py
@@ -528,7 +528,7 @@ def scan_directory(directory: Path) -> list[str]:
         if not spec:
             matched_files.extend(file_paths)
             continue
-        matched_files.extend([file for file in file_paths if not spec.match_file(file)])
+        matched_files.extend([file for file in file_paths if not spec.match_file(os.path.relpath(file, directory))])
 
     return matched_files
 


### PR DESCRIPTION
The rag service kept trying to index `node_modules` even though it was ignored by git. Figured that the rag service wasn't ignoring it because it was written `/node_modules/` in the `.gitignore` file.
Without the leading slash it would ignore it just fine.
The fix I found was checking against the relative path, not the full path.