### PR TITLE
fix(copilot): fail to decode the empty token file

### DIFF
--- a/lua/avante/providers/copilot.lua
+++ b/lua/avante/providers/copilot.lua
@@ -284,7 +284,10 @@ function M.setup_file_watcher()
     {},
     vim.schedule_wrap(function()
       -- Reload token from file
-      if copilot_token_file:exists() then M.state.github_token = vim.json.decode(copilot_token_file:read()) end
+      if copilot_token_file:exists() then
+        local ok, token = pcall(vim.json.decode, copilot_token_file:read())
+        if ok then M.state.github_token = token end
+      end
     end)
   )
 end


### PR DESCRIPTION
The race condition may occur between file creation and the writing process, as both token file refreshing and watching are asynchronous operations.

```
 ...e/nvim/lazy/avante.nvim/lua/avante/providers/copilot.lua:317: Expected value but found T_END at character 1
stack traceback:
        [C]: in function 'decode'
        ...e/nvim/lazy/avante.nvim/lua/avante/providers/copilot.lua:317: in function ''
        vim/_editor.lua: in function <vim/_editor.lua:0>
```