### PR TITLE
fix: custom vendors listed twice in model selection dropdown

### DIFF
--- a/lua/avante/model_selector.lua
+++ b/lua/avante/model_selector.lua
@@ -24,13 +24,6 @@ function M.open()
     if entry then table.insert(models, entry) end
   end
 
-  for provider, cfg in pairs(Config.vendors or {}) do
-    if type(cfg) == "table" then
-      local entry = create_model_entry(provider, cfg)
-      if entry then table.insert(models, entry) end
-    end
-  end
-
   if #models == 0 then
     Utils.warn("No models available in config")
     return


### PR DESCRIPTION
`Config.providers` already includes `Config.vendors` (as per config.lua:453), meaning that the previous logic listed models from custom vendors twice.