### PR TITLE
Add o3-mini provider for copilot

### DIFF
--- a/lua/avante/config.lua
+++ b/lua/avante/config.lua
@@ -244,6 +244,14 @@ M._defaults = {
       temperature = 0,
       max_tokens = 8000,
     },
+    ---@type AvanteSupportedProvider
+    ["copilot-o3-mini"] = {
+      __inherited_from = "copilot",
+      model = "o3-mini",
+      timeout = 30000, -- Timeout in milliseconds
+      temperature = 0,
+      max_tokens = 4096,
+    },
   },
   ---Specify the special dual_boost mode
   ---1. enabled: Whether to enable dual_boost mode. Default to false.


### PR DESCRIPTION
I am very new to this codebase, but when I was debugging the `parse_curl_args` and see that it is in fact passing `o3-mini` to the api, but that seemed to easy. If I did something wrong if you could pass me in the right direction