### PR TITLE
fix: do not change cwd for async bash command

### DIFF
--- a/lua/avante/llm_tools.lua
+++ b/lua/avante/llm_tools.lua
@@ -249,14 +249,11 @@ function M.bash(opts, on_log, on_complete)
     return false, "User canceled"
   end
   ---change cwd to abs_path
-  local old_cwd = vim.fn.getcwd()
-  vim.fn.chdir(abs_path)
   ---@param output string
   ---@param exit_code integer
   ---@return string | boolean | nil result
   ---@return string | nil error
   local function handle_result(output, exit_code)
-    vim.fn.chdir(old_cwd)
     if exit_code ~= 0 then
       if output then return false, "Error: " .. output .. "; Error code: " .. tostring(exit_code) end
       return false, "Error code: " .. tostring(exit_code)
@@ -267,10 +264,13 @@ function M.bash(opts, on_log, on_complete)
     Utils.shell_run_async(opts.command, "bash -c", function(output, exit_code)
       local result, err = handle_result(output, exit_code)
       on_complete(result, err)
-    end)
+    end, abs_path)
     return nil, nil
   end
+  local old_cwd = vim.fn.getcwd()
+  vim.fn.chdir(abs_path)
   local res = Utils.shell_run(opts.command, "bash -c")
+  vim.fn.chdir(old_cwd)
   return handle_result(res.stdout, res.code)
 end
 

--- a/lua/avante/utils/init.lua
+++ b/lua/avante/utils/init.lua
@@ -112,7 +112,8 @@ end
 ---@param input_cmd string
 ---@param shell_cmd string?
 ---@param on_complete fun(output: string, code: integer)
-function M.shell_run_async(input_cmd, shell_cmd, on_complete)
+---@param cwd? string
+function M.shell_run_async(input_cmd, shell_cmd, on_complete, cwd)
   local cmd = get_cmd_for_shell(input_cmd, shell_cmd)
   ---@type string[]
   local output = {}
@@ -126,6 +127,7 @@ function M.shell_run_async(input_cmd, shell_cmd, on_complete)
       vim.list_extend(output, data)
     end,
     on_exit = function(_, exit_code) on_complete(table.concat(output, "\n"), exit_code) end,
+    cwd = cwd,
   })
 end
 


### PR DESCRIPTION
Since the bash command was made async, changing directory via `vim.fn.chdir` caused pretty destructive behavior, e.g. buffers using relative paths would suddenly have empty contents. Thus we convert to using the `cwd` option to `vim.fn.jobstart` so that the working directory is only set for the command, but not for the editor.
