### PR TITLE
feat: disable tools with config

### DIFF
--- a/lua/avante/config.lua
+++ b/lua/avante/config.lua
@@ -408,6 +408,7 @@ M._defaults = {
     debounce = 600,
     throttle = 600,
   },
+  disabled_tools = {}, ---@type string[]
 }
 
 ---@type avante.Config

--- a/lua/avante/llm_tools.lua
+++ b/lua/avante/llm_tools.lua
@@ -569,7 +569,9 @@ end
 function M.get_tools()
   return vim
     .iter(M._tools)
-    :filter(function(tool)
+    :filter(function(tool) ---@param tool AvanteLLMTool
+      -- Always disable tools that are explicitly disabled
+      if vim.tbl_contains(Config.disabled_tools, tool.name) then return false end
       if tool.enabled == nil then
         return true
       else

--- a/lua/avante/sidebar.lua
+++ b/lua/avante/sidebar.lua
@@ -2317,8 +2317,7 @@ function Sidebar:create_input_container(opts)
   table.insert(tools, {
     name = "remove_file_from_context",
     description = "Remove a file from the context",
-    ---@param input { rel_path: string }
-    ---@type AvanteLLMToolFunc
+    ---@type AvanteLLMToolFunc<{ rel_path: string }>
     func = function(input)
       self.file_selector:remove_selected_file(input.rel_path)
       return "Removed file from context", nil


### PR DESCRIPTION
Since the claude endpoint really likes to call the python tool, I've preferred to just completely disable it since it's not proved very useful for me. I've added a config to disable tools by name, which will allow me to disable the python tool. I also imagine a workflow where you add overrides to disable particular tools to be focused on particular tasks that are known, but good for LLMs to handle, e.g. refactoring across many files only really needs the rag tool, maybe some of the file search tools and the write_file tool.

closes: #1447