### PR TITLE
fix: claude bedrock content_block initiation

### DIFF
--- a/lua/avante/providers/bedrock.lua
+++ b/lua/avante/providers/bedrock.lua
@@ -29,15 +29,18 @@ function M.build_bedrock_payload(prompt_opts, body_opts)
 end
 
 function M.parse_stream_data(data, opts)
-  -- @NOTE: Decode and process Bedrock response
-  -- Each response contains a Base64-encoded `bytes` field, which is decoded into JSON.
-  -- The `type` field in the decoded JSON determines how the response is handled.
+  -- Create a context object if it doesn't exist in opts
+  if not opts.ctx then opts.ctx = {
+    content_blocks = {},
+  } end
+
   local bedrock_match = data:gmatch("event(%b{})")
   for bedrock_data_match in bedrock_match do
     local jsn = vim.json.decode(bedrock_data_match)
     local data_stream = vim.base64.decode(jsn.bytes)
     local json = vim.json.decode(data_stream)
-    M.parse_response({}, data_stream, json.type, opts)
+    -- Pass the context object to parse_response
+    M.parse_response(opts.ctx, data_stream, json.type, opts)
   end
 end
 

--- a/lua/avante/providers/claude.lua
+++ b/lua/avante/providers/claude.lua
@@ -165,6 +165,16 @@ function M.parse_response(ctx, data_stream, event_state, opts)
   elseif event_state == "content_block_delta" then
     local ok, jsn = pcall(vim.json.decode, data_stream)
     if not ok then return end
+
+    -- Ensure the index exists in the content_blocks array
+    if not ctx.content_blocks[jsn.index + 1] then
+      ctx.content_blocks[jsn.index + 1] = {
+        text = "",
+        thinking = "",
+        input_json = "",
+        -- Add other fields as needed
+      }
+    end
     local content_block = ctx.content_blocks[jsn.index + 1]
     if jsn.delta.type == "input_json_delta" then
       if not content_block.input_json then content_block.input_json = "" end


### PR DESCRIPTION
The bedrock requests were failing saying: 
Error executing vim.schedule lua callback: ...re/nvim/lazy/avante.nvim/lua/avante/providers/claude.lua:182: attempt to index local 'content_block' (a nil value)