### PR TITLE
feat: add custom tools config

### DIFF
--- a/lua/avante/config.lua
+++ b/lua/avante/config.lua
@@ -17,6 +17,7 @@ local Utils = require("avante.utils")
 ---@class avante.CoreConfig: avante.Config
 local M = {}
 ---@class avante.Config
+---@field custom_tools AvanteLLMToolPublic[]
 M._defaults = {
   debug = false,
   ---@alias Provider "claude" | "openai" | "azure" | "gemini" | "vertex" | "cohere" | "copilot" | string
@@ -408,6 +409,8 @@ M._defaults = {
     debounce = 600,
     throttle = 600,
   },
+  ---@type AvanteLLMToolPublic[]
+  custom_tools = {},
 }
 
 ---@type avante.Config

--- a/lua/avante/llm_tools.lua
+++ b/lua/avante/llm_tools.lua
@@ -567,8 +567,10 @@ end
 
 ---@return AvanteLLMTool[]
 function M.get_tools()
+  ---@type AvanteLLMTool[]
+  local unfiltered_tools = vim.list_extend(vim.list_extend({}, M._tools), Config.custom_tools)
   return vim
-    .iter(M._tools)
+    .iter(unfiltered_tools)
     :filter(function(tool)
       if tool.enabled == nil then
         return true

--- a/lua/avante/types.lua
+++ b/lua/avante/types.lua
@@ -329,17 +329,17 @@ vim.g.avante_login = vim.g.avante_login
 ---@field enabled? fun(): boolean
 
 ---@class AvanteLLMToolParam
----@field type string
+---@field type 'table'
 ---@field fields AvanteLLMToolParamField[]
 
 ---@class AvanteLLMToolParamField
 ---@field name string
 ---@field description string
----@field type string
+---@field type 'string' | 'integer'
 ---@field optional? boolean
 
 ---@class AvanteLLMToolReturn
 ---@field name string
 ---@field description string
----@field type string
+---@field type 'string' | 'string[]' | 'boolean'
 ---@field optional? boolean

--- a/lua/avante/types.lua
+++ b/lua/avante/types.lua
@@ -328,6 +328,9 @@ vim.g.avante_login = vim.g.avante_login
 ---@field returns AvanteLLMToolReturn[]
 ---@field enabled? fun(): boolean
 
+---@class AvanteLLMToolPublic : AvanteLLMTool
+---@field func AvanteLLMToolFunc
+
 ---@class AvanteLLMToolParam
 ---@field type 'table'
 ---@field fields AvanteLLMToolParamField[]


### PR DESCRIPTION
With [this PR](https://github.com/yetone/avante.nvim/pull/1428), I've found that the `bash` command does not fit my use case. I need to be able to run some fish functions, and also docker exec before running a command. I have a decent amount of what I feel are reasonable concerns in my comments in the PR, but to save time for the maintainer, would also be open to maintaining my own custom tool, as I have enabled in this PR. A couple of changes to the config and LLM types here are so that the type checking is helpful when calling the `setup` function.

Please do let me know if you prefer another way to support my use case.
