### PR TITLE
fix(llm_tools): fix permission checking to use relative path

### DIFF
--- a/lua/avante/llm_tools.lua
+++ b/lua/avante/llm_tools.lua
@@ -30,7 +30,12 @@ local function has_permission_to_access(abs_path)
   if abs_path:sub(1, #project_root) ~= project_root then return false end
   local gitignore_path = project_root .. "/.gitignore"
   local gitignore_patterns, gitignore_negate_patterns = Utils.parse_gitignore(gitignore_path)
-  return not Utils.is_ignored(abs_path, gitignore_patterns, gitignore_negate_patterns)
+  -- The checker should only take care of the path inside the project root
+  -- Specifically, it should not check the project root itself
+  -- Otherwise if the binary is named the same as the project root (such as Go binary), any paths
+  -- insde the project root will be ignored
+  local rel_path = Path:new(abs_path):make_relative(project_root)
+  return not Utils.is_ignored(rel_path, gitignore_patterns, gitignore_negate_patterns)
 end
 
 ---@type AvanteLLMToolFunc<{ rel_path: string, max_depth?: integer }>


### PR DESCRIPTION
In projects such as Go, the output binary artifacts are automatically named after the project; for instance, the binary of a project called "go-project" is also referred to as "go-project." Users generally add the project name to .gitignore to prevent these artifacts from being submitted.

Currently, the method used to check .gitignore relies on absolute paths and fuzzy matching, which can result in files being incorrectly identified as ignored:

```lua
print(("/root/go-project/aaa/bbb/ccc.go"):match("go%-project")) -- print "go-project"
```

IMO the checker should only take care of the path inside the project root