### PR TITLE
fix: pass context to provider for stream data parsing

### DIFF
--- a/lua/avante/llm.lua
+++ b/lua/avante/llm.lua
@@ -154,6 +154,8 @@ end
 function M._stream(opts)
   local provider = opts.provider or Providers[Config.provider]
 
+  ---@cast provider AvanteProviderFunctor
+
   local prompt_opts = M.generate_prompts(opts)
 
   ---@type string

--- a/lua/avante/llm.lua
+++ b/lua/avante/llm.lua
@@ -285,10 +285,10 @@ function M._stream(opts)
               { once = true }
             )
           end
-          provider.parse_stream_data(data, handler_opts)
+          provider.parse_stream_data(resp_ctx, data, handler_opts)
         else
           if provider.parse_stream_data ~= nil then
-            provider.parse_stream_data(data, handler_opts)
+            provider.parse_stream_data(resp_ctx, data, handler_opts)
           else
             parse_stream_data(data)
           end

--- a/lua/avante/providers/bedrock.lua
+++ b/lua/avante/providers/bedrock.lua
@@ -28,7 +28,7 @@ function M.build_bedrock_payload(prompt_opts, body_opts)
   return model_handler.build_bedrock_payload(prompt_opts, body_opts)
 end
 
-function M.parse_stream_data(data, opts)
+function M.parse_stream_data(ctx, data, opts)
   -- @NOTE: Decode and process Bedrock response
   -- Each response contains a Base64-encoded `bytes` field, which is decoded into JSON.
   -- The `type` field in the decoded JSON determines how the response is handled.
@@ -37,7 +37,7 @@ function M.parse_stream_data(data, opts)
     local jsn = vim.json.decode(bedrock_data_match)
     local data_stream = vim.base64.decode(jsn.bytes)
     local json = vim.json.decode(data_stream)
-    M.parse_response({}, data_stream, json.type, opts)
+    M.parse_response(ctx, data_stream, json.type, opts)
   end
 end
 

--- a/lua/avante/providers/cohere.lua
+++ b/lua/avante/providers/cohere.lua
@@ -57,7 +57,7 @@ function M.parse_messages(opts)
   return { messages = messages }
 end
 
-function M.parse_stream_data(data, opts)
+function M.parse_stream_data(ctx, data, opts)
   ---@type CohereChatResponse
   local json = vim.json.decode(data)
   if json.type ~= nil then

--- a/lua/avante/types.lua
+++ b/lua/avante/types.lua
@@ -239,7 +239,7 @@ vim.g.avante_login = vim.g.avante_login
 ---@field tool_use_list? AvanteLLMToolUse[]
 ---@field retry_after? integer
 ---
----@alias AvanteStreamParser fun(line: string, handler_opts: AvanteHandlerOptions): nil
+---@alias AvanteStreamParser fun(ctx: any, line: string, handler_opts: AvanteHandlerOptions): nil
 ---@alias AvanteLLMStartCallback fun(opts: AvanteLLMStartCallbackOptions): nil
 ---@alias AvanteLLMChunkCallback fun(chunk: string): any
 ---@alias AvanteLLMStopCallback fun(opts: AvanteLLMStopCallbackOptions): nil


### PR DESCRIPTION
Fix bedrock error on parsing

    Error executing vim.schedule lua callback: ...re/nvim/lazy/avante.nvim/lua/avante/providers/claude.lua:177: attempt to index local 'content_block' (a nil value)
    stack traceback:
        ...re/nvim/lazy/avante.nvim/lua/avante/providers/claude.lua:177: in function 'parse_response'
        ...e/nvim/lazy/avante.nvim/lua/avante/providers/bedrock.lua:40: in function 'parse_stream_data'
        ...ng/.local/share/nvim/lazy/avante.nvim/lua/avante/llm.lua:291: in function <...ng/.local/share/nvim/lazy/avante.nvim/lua/avante/llm.lua:280>
    Error executing vim.schedule lua callback: ...re/nvim/lazy/avante.nvim/lua/avante/providers/claude.lua:177: attempt to index local 'content_block' (a nil value)
    stack traceback:
        ...re/nvim/lazy/avante.nvim/lua/avante/providers/claude.lua:177: in function 'parse_response'
        ...e/nvim/lazy/avante.nvim/lua/avante/providers/bedrock.lua:40: in function 'parse_stream_data'
        ...ng/.local/share/nvim/lazy/avante.nvim/lua/avante/llm.lua:291: in function <...ng/.local/share/nvim/lazy/avante.nvim/lua/avante/llm.lua:280>

We need pass response context to the provider to parse stream data.