### PR TITLE
feature model selection custom display name

### DIFF
--- a/lua/avante/config.lua
+++ b/lua/avante/config.lua
@@ -509,6 +509,7 @@ M.BASE_PROVIDER_KEYS = {
   "allow_insecure",
   "api_key_name",
   "timeout",
+  "display_name",
   -- internal
   "local",
   "_shellenv",

--- a/lua/avante/model_selector.lua
+++ b/lua/avante/model_selector.lua
@@ -9,7 +9,7 @@ local M = {}
 ---@return table?
 local function create_model_entry(provider, cfg)
   return cfg.model and {
-    name = provider .. "/" .. cfg.model,
+    name = cfg.display_name or (provider .. "/" .. cfg.model),
     provider = provider,
     model = cfg.model,
   }

--- a/lua/avante/model_selector.lua
+++ b/lua/avante/model_selector.lua
@@ -8,11 +8,12 @@ local M = {}
 ---@param cfg table
 ---@return table?
 local function create_model_entry(provider, cfg)
-  return cfg.model and {
-    name = cfg.display_name or (provider .. "/" .. cfg.model),
-    provider = provider,
-    model = cfg.model,
-  }
+  return cfg.model
+    and {
+      name = cfg.display_name or (provider .. "/" .. cfg.model),
+      provider = provider,
+      model = cfg.model,
+    }
 end
 
 function M.open()

--- a/lua/avante/types.lua
+++ b/lua/avante/types.lua
@@ -215,6 +215,7 @@ vim.g.avante_login = vim.g.avante_login
 ---@field temperature? number
 ---@field max_tokens? number
 ---@field reasoning_effort? string
+---@field display_name? string
 ---
 ---@class AvanteLLMUsage
 ---@field input_tokens number


### PR DESCRIPTION
Added an option for a custom display name
I had the need for this option for multiple similar custom model configurations where I wanted to have more indicative titles.

## Designed for cases like this

```lua
  vendors = {
    ["claude_37_tools_think"] = {
      __inherited_from = "claude",
      model = "claude-3-7-sonnet-latest",
      display_name = "Claude 3.7 (Sonnet) with tools and thinking",
      thinking = {
        type = "enabled",
        budget_tokens = 2048,
      },
      disable_tools = false,
      temperature = 1,
    },
    ["claude_37"] = {
      __inherited_from = "claude",
      model = "claude-3-7-sonnet-latest",
      display_name = "Claude 3.7 (Sonnet)",
      thinking = {
        type = "disabled",
      },
      disable_tools = true,
    },
    ["claude_haiku_tools"] = {
      __inherited_from = "claude",
      model = "claude-3-5-haiku-latest",
      display_name = "Claude 3.5 (Haiku) with tools",
      disable_tools = false,
    },
    ["claude_haiku"] = {
      __inherited_from = "claude",
      model = "claude-3-5-haiku-latest",
      display_name = "Claude 3.5 (Haiku)",
      disable_tools = true,
    },
  },
```

## To achieve this:

<img width="560" alt="image" src="https://github.com/user-attachments/assets/91c3a050-862b-480d-8af1-173219603f6b" />
