### PR TITLE
fix: handle bedrock exceptions

### DIFF
--- a/lua/avante/llm.lua
+++ b/lua/avante/llm.lua
@@ -357,7 +357,7 @@ function M._stream(opts)
       end
 
       -- If stream is not enabled, then handle the response here
-      if spec.body.stream == false and result.status == 200 then
+      if (spec.body.stream == nil or spec.body.stream == false) and result.status == 200 then
         vim.schedule(function()
           completed = true
           parse_response_without_stream(result.body)

--- a/lua/avante/providers/bedrock.lua
+++ b/lua/avante/providers/bedrock.lua
@@ -41,6 +41,16 @@ function M.parse_stream_data(ctx, data, opts)
   end
 end
 
+function M.parse_response_without_stream(data, event_state, opts)
+  local bedrock_match = data:gmatch("exception(%b{})")
+  opts.on_chunk("\n**Exception caught**\n\n")
+  for bedrock_data_match in bedrock_match do
+    local jsn = vim.json.decode(bedrock_data_match)
+    opts.on_chunk("- " .. jsn.message .. "\n")
+  end
+  vim.schedule(function() opts.on_stop({ reason = "complete" }) end)
+end
+
 ---@param provider AvanteBedrockProviderFunctor
 ---@param prompt_opts AvantePromptOptions
 ---@return table


### PR DESCRIPTION
This is to handle exceptions from bedrock, one of which happens on command `@codebase`.

<img width="557" alt="image" src="https://github.com/user-attachments/assets/965edeff-230a-4395-8971-9d9803ec0024" />
