### PR TITLE
feat: add key mappings to close sidebar in input_container

### DIFF
--- a/lua/avante/config.lua
+++ b/lua/avante/config.lua
@@ -376,6 +376,10 @@ M._defaults = {
       remove_file = "d",
       add_file = "@",
       close = { "<Esc>", "q" },
+      close_from_input = {
+        normal = "<Esc>",
+        insert = "<C-d>",
+      },
     },
     files = {
       add_current = "<leader>ac", -- Add current buffer to selected files


### PR DESCRIPTION
The PR makes below changes

* add key mappings to close sidebar in input_container
* add autocmd to enter normal mode on leaving input_container
* add autocmd to enter insert mode on entering input_container

so that user can close sidebar in input_container directly without switching to result_container.

And the auto commands help to avoid below annoyances in result_container.
<img width="574" alt="image" src="https://github.com/user-attachments/assets/f3a0a68c-f80b-43e3-af3b-39c94a9cba0d" />
