### PR TITLE
fix: return statement of the "Utils.has", as "pcall" never returns nil

### DIFF
--- a/lua/avante/utils/init.lua
+++ b/lua/avante/utils/init.lua
@@ -29,7 +29,7 @@ function M.has(plugin)
   if ok then return LazyConfig.plugins[plugin] ~= nil end
 
   local res, _ = pcall(require, plugin)
-  return res ~= nil
+  return res
 end
 
 function M.is_win() return jit.os:find("Windows") ~= nil end


### PR DESCRIPTION
As documented [here](https://www.lua.org/pil/8.4.html) the `pcall` function always returns `true` or `false` as the first value, never `nil`. Comparing it to nil introduces a bug as the `Utils.has` util will always return true.

I encountered it after investigating a bug: the avante setup was throwing an error because it was requiring `img-clip.nvim` even though it wasn't installed.

Using git bisect I was able to track the issue to commit 44e673d13202e211e579b1daaef82ee3d9bde5d9.

Following the error message indication of the exception, I identified this issue. The `Config.support_paste_image` was returning true because the `Utils.has("img-clip.nvim")` was returning true, because of the wrong comparison in the return statement [here](https://github.com/yetone/avante.nvim/blob/44e673d13202e211e579b1daaef82ee3d9bde5d9/lua/avante/utils/init.lua#L32).

Giving that the first value of the `pcall` return is always `true` or `false` it can be used as the return value of the `Utils.has` function and solve the issue.