### PR TITLE
fix: contradictory lazy.nvim installation spec

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,7 +57,6 @@ For building binary if you wish to build from source, then `cargo` is required. 
 {
   "yetone/avante.nvim",
   event = "VeryLazy",
-  lazy = false,
   version = false, -- Set this to "*" to always pull the latest release version, or set it to false to update to the latest code changes.
   opts = {
     -- add any opts here


### PR DESCRIPTION
I think the lazy.nvim installation spec in the readme is contradicting itself 🤔 

Setting `lazy=false` means eagerly loading the plugin while `event = "VeryLazy"` suggests the plugin should be lazy loaded.

https://lazy.folke.io/spec/lazy_loading

> Plugins will be lazy-loaded when one of the following is true:
>
> * The plugin only exists as a dependency in your spec
> * It has an event, cmd, ft or keys key
> * config.defaults.lazy == true

see example

https://github.com/folke/lazy.nvim/blob/6c3bda4aca61a13a9c63f1c1d1b16b9d3be90d7a/lua/lazy/example.lua#L58-L60

I noticed this due to slow startup times.