### PR TITLE
Skip audio and video files during directory scan in RAG Service.

### DIFF
--- a/py/rag-service/src/main.py
+++ b/py/rag-service/src/main.py
@@ -660,14 +660,33 @@ def scan_directory(directory: Path) -> list[str]:
     """Scan directory and return a list of matched files."""
     spec = get_pathspec(directory)
 
+    audio_video_exts = [
+        ".mp3",
+        ".wav",
+        ".ogg",
+        ".flac",
+        ".aac",
+        ".m4a",
+        ".wma",
+        ".mp4",
+        ".avi",
+        ".mov",
+        ".wmv",
+        ".flv",
+        ".mkv",
+        ".webm",
+    ]
+
     matched_files = []
 
     for root, _, files in os.walk(directory):
         file_paths = [str(Path(root) / file) for file in files]
-        if not spec:
-            matched_files.extend(file_paths)
-            continue
         for file in file_paths:
+            file_ext = Path(file).suffix.lower()
+            if file_ext in audio_video_exts:
+                logger.info("Skipping audio/video file: %s", file)
+                continue
+
             if spec and spec.match_file(os.path.relpath(file, directory)):
                 logger.info("Ignoring file: %s", file)
             else:


### PR DESCRIPTION
# Skip audio and video files during directory scan in RAG Service

## Description
This PR adds functionality to skip audio and video files during the directory scanning process in the RAG service. Previously, these file types were being included in the indexing process, which could lead to unnecessary resource consumption and potential errors when attempting to process binary files.

## Changes
- Added a list of common audio and video file extensions to filter during directory scans
- Modified the `scan_directory` function to check file extensions and skip audio/video files
- Added logging to indicate when files are being skipped due to their file type
- Simplified the file path handling logic for better readability and maintainability

## Why
Audio and video files:
1. Are binary in nature and not suitable for text-based indexing
2. Can be large, leading to increased memory usage and processing time
3. Were causing errors in the downstream processing pipeline