### PR TITLE
Fix ResourceRequest parameters in remove_resource function

### DIFF
--- a/lua/avante/rag_service.lua
+++ b/lua/avante/rag_service.lua
@@ -270,7 +270,7 @@ function M.add_resource(uri)
   end)
 end
 
-function M.remove_resource(uri)
+function M.remove_resource(uri, name)
   uri = M.to_container_uri(uri)
   local resp = curl.post(M.get_rag_service_url() .. "/api/v1/remove_resource", {
     headers = {
@@ -278,6 +278,7 @@ function M.remove_resource(uri)
     },
     body = vim.json.encode({
       uri = uri,
+      name = name,
     }),
   })
   if resp.status ~= 200 then


### PR DESCRIPTION
## Description
This PR fixes the `remove_resource` function in the RAG service client to properly handle the required parameters for the server API.

## Changes
- Added `name` parameter to the `remove_resource` function to match the server's `ResourceRequest` model


## Problem
The Python server implementation expects both `name` and `uri` fields in the `ResourceRequest` model for the `/api/v1/remove_resource` endpoint, but the Lua client was only sending the `uri` field.