### PR TITLE
Fix attempt to call field 'is_o_series_model' in Copilot provider

### DIFF
--- a/lua/avante/providers/copilot.lua
+++ b/lua/avante/providers/copilot.lua
@@ -215,6 +215,8 @@ M.parse_messages = OpenAI.parse_messages
 
 M.parse_response = OpenAI.parse_response
 
+M.is_o_series_model = OpenAI.is_o_series_model
+
 function M:parse_curl_args(prompt_opts)
   -- refresh token synchronously, only if it has expired
   -- (this should rarely happen, as we refresh the token in the background)


### PR DESCRIPTION
Attemted to fix the bug in #1513 according to brunofjesus's solution