### PR TITLE
fix: bedrock breaks after prompt caching

### DIFF
--- a/lua/avante/providers/bedrock.lua
+++ b/lua/avante/providers/bedrock.lua
@@ -6,6 +6,10 @@ local M = {}
 
 M.api_key_name = "BEDROCK_KEYS"
 M.use_xml_format = true
+M.role_map = {
+  user = "user",
+  assistant = "assistant",
+}
 
 setmetatable(M, {
   __index = function(_, k)
@@ -39,6 +43,8 @@ function M:build_bedrock_payload(prompt_opts, body_opts)
   local model_handler = M.load_model_handler()
   return model_handler.build_bedrock_payload(self, prompt_opts, body_opts)
 end
+
+function M:is_disable_stream() return false end
 
 function M:parse_stream_data(ctx, data, opts)
   -- @NOTE: Decode and process Bedrock response

--- a/lua/avante/providers/bedrock/claude.lua
+++ b/lua/avante/providers/bedrock/claude.lua
@@ -12,12 +12,7 @@ local Claude = require("avante.providers.claude")
 local M = {}
 
 M.support_prompt_caching = false
-M.role_map = {
-  user = "user",
-  assistant = "assistant",
-}
 
-M.is_disable_stream = Claude.is_disable_stream
 M.parse_messages = Claude.parse_messages
 M.parse_response = Claude.parse_response
 


### PR DESCRIPTION
Followup fix of https://github.com/yetone/avante.nvim/issues/1502