### PR TITLE
Add provider for using Claude through Vertex

### DIFF
--- a/lua/avante/config.lua
+++ b/lua/avante/config.lua
@@ -253,6 +253,14 @@ M._defaults = {
     temperature = 0,
     max_tokens = 4096,
   },
+  ---@type AvanteSupportedProvider
+  vertex_claude = {
+    endpoint = "https://LOCATION-aiplatform.googleapis.com/v1/projects/PROJECT_ID/locations/LOCATION/publishers/anthropic/models",
+    model = "claude-3-5-sonnet-v2@20241022",
+    timeout = 30000, -- Timeout in milliseconds
+    temperature = 0,
+    max_tokens = 4096,
+  },
   ---To add support for custom provider, follow the format below
   ---See https://github.com/yetone/avante.nvim/wiki#custom-providers for more details
   ---@type {[string]: AvanteProvider}

--- a/lua/avante/providers/init.lua
+++ b/lua/avante/providers/init.lua
@@ -18,6 +18,7 @@ local DressingState = { winid = nil, input_winid = nil, input_bufnr = nil }
 ---@field gemini AvanteProviderFunctor
 ---@field cohere AvanteProviderFunctor
 ---@field bedrock AvanteBedrockProviderFunctor
+---@field vertex_claude AvanteProviderFunctor
 local M = {}
 
 ---@class EnvironmentHandler

--- a/lua/avante/providers/vertex_claude.lua
+++ b/lua/avante/providers/vertex_claude.lua
@@ -1,0 +1,62 @@
+local P = require("avante.providers")
+local Utils = require("avante.utils")
+local Claude = require("avante.providers.claude")
+local Vertex = require("avante.providers.vertex")
+---@class AvanteProviderFunctor
+local M = {}
+M.role_map = {
+  user = "user",
+  assistant = "assistant",
+}
+M.use_xml_format = true
+M.is_disable_stream = Claude.is_disable_stream
+M.parse_messages = Claude.parse_messages
+M.parse_response = Claude.parse_response
+M.parse_api_key = Vertex.parse_api_key
+Vertex.api_key_name = "cmd:gcloud auth print-access-token"
+
+---@param provider AvanteProviderFunctor
+---@param prompt_opts AvantePromptOptions
+---@return table
+function M:parse_curl_args(provider, prompt_opts)
+  local provider_conf, request_body = P.parse_config(provider)
+  local messages = self:parse_messages(prompt_opts)
+  request_body = vim.tbl_deep_extend("force", request_body, {
+    anthropic_version = "vertex-2023-10-16",
+    temperature = 0,
+    max_tokens = 4096,
+    stream = true,
+    messages = messages,
+    system = {
+      {
+        type = "text",
+        text = prompt_opts.system_prompt,
+        cache_control = { type = "ephemeral" },
+      },
+    },
+  })
+  return {
+    url = provider_conf.endpoint .. "/" .. provider_conf.model .. ":streamRawPredict",
+    headers = {
+      ["Authorization"] = "Bearer " .. Vertex.parse_api_key(),
+      ["Content-Type"] = "application/json; charset=utf-8",
+    },
+    body = vim.tbl_deep_extend("force", {}, request_body),
+  }
+end
+
+function M.on_error(result)
+  if not result.body then
+    return Utils.error("API request failed with status " .. result.status, { once = true, title = "Avante" })
+  end
+
+  local ok, body = pcall(vim.json.decode, result.body)
+  if not (ok and body and body.error) then
+    return Utils.error("Failed to parse error response", { once = true, title = "Avante" })
+  end
+
+  local error_msg = body.error.message
+
+  Utils.error(error_msg, { once = true, title = "Avante" })
+end
+return M

--- a/lua/avante/providers/vertex_claude.lua
+++ b/lua/avante/providers/vertex_claude.lua
@@ -23,6 +23,15 @@ Vertex.api_key_name = "cmd:gcloud auth print-access-token"
 ---@return table
 function M:parse_curl_args(provider, prompt_opts)
   local provider_conf, request_body = P.parse_config(provider)
+  local location = vim.fn.getenv("LOCATION")
+  local project_id = vim.fn.getenv("PROJECT_ID")
+  local model_id = provider_conf.model or "default-model-id"
+  if location == nil or location == vim.NIL then location = "default-location" end
+  if project_id == nil or project_id == vim.NIL then project_id = "default-project-id" end
+  local url = provider_conf.endpoint:gsub("LOCATION", location):gsub("PROJECT_ID", project_id)
+
+  url = string.format("%s/%s:streamRawPredict", url, model_id)
+
   local system_prompt = prompt_opts.system_prompt or ""
   local messages = self:parse_messages(prompt_opts)
   request_body = vim.tbl_deep_extend("force", request_body, {
@@ -40,7 +49,7 @@ function M:parse_curl_args(provider, prompt_opts)
     },
   })
   return {
-    url = provider_conf.endpoint .. "/" .. provider_conf.model .. ":streamRawPredict",
+    url = url,
     headers = {
       ["Authorization"] = "Bearer " .. Vertex.parse_api_key(),
       ["Content-Type"] = "application/json; charset=utf-8",

--- a/lua/avante/providers/vertex_claude.lua
+++ b/lua/avante/providers/vertex_claude.lua
@@ -1,18 +1,21 @@
 local P = require("avante.providers")
-local Utils = require("avante.utils")
 local Claude = require("avante.providers.claude")
 local Vertex = require("avante.providers.vertex")
+
 ---@class AvanteProviderFunctor
 local M = {}
 M.role_map = {
   user = "user",
   assistant = "assistant",
 }
+
 M.use_xml_format = true
 M.is_disable_stream = Claude.is_disable_stream
 M.parse_messages = Claude.parse_messages
 M.parse_response = Claude.parse_response
 M.parse_api_key = Vertex.parse_api_key
+M.on_error = Vertex.on_error
+
 Vertex.api_key_name = "cmd:gcloud auth print-access-token"
 
 ---@param provider AvanteProviderFunctor
@@ -20,6 +23,7 @@ Vertex.api_key_name = "cmd:gcloud auth print-access-token"
 ---@return table
 function M:parse_curl_args(provider, prompt_opts)
   local provider_conf, request_body = P.parse_config(provider)
+  local system_prompt = prompt_opts.system_prompt or ""
   local messages = self:parse_messages(prompt_opts)
   request_body = vim.tbl_deep_extend("force", request_body, {
     anthropic_version = "vertex-2023-10-16",
@@ -30,7 +34,7 @@ function M:parse_curl_args(provider, prompt_opts)
     system = {
       {
         type = "text",
-        text = prompt_opts.system_prompt,
+        text = system_prompt,
         cache_control = { type = "ephemeral" },
       },
     },
@@ -45,18 +49,4 @@ function M:parse_curl_args(provider, prompt_opts)
   }
 end
 
-function M.on_error(result)
-  if not result.body then
-    return Utils.error("API request failed with status " .. result.status, { once = true, title = "Avante" })
-  end
-
-  local ok, body = pcall(vim.json.decode, result.body)
-  if not (ok and body and body.error) then
-    return Utils.error("Failed to parse error response", { once = true, title = "Avante" })
-  end
-
-  local error_msg = body.error.message
-
-  Utils.error(error_msg, { once = true, title = "Avante" })
-end
 return M

--- a/lua/avante/providers/vertex_claude.lua
+++ b/lua/avante/providers/vertex_claude.lua
@@ -18,9 +18,6 @@ M.on_error = Vertex.on_error
 
 Vertex.api_key_name = "cmd:gcloud auth print-access-token"
 
----@param provider AvanteProviderFunctor
----@param prompt_opts AvantePromptOptions
----@return table
 function M:parse_curl_args(provider, prompt_opts)
   local provider_conf, request_body = P.parse_config(provider)
   local location = vim.fn.getenv("LOCATION")


### PR DESCRIPTION

This pull request introduces a dedicated vertex_claude provider to enable seamless integration and utilization of the Claude model through Google Cloud's Vertex AI platform. The custom provider configuration  I posted in #764 stopped working for me so I decided to create this provider.

### Key Changes:

Added: 

- `lua/avante/provider/vertex_claude.lua` - Implements the vertex_claude provider logic.

Modified: 

- lua/avante/config.lua - Registers the new vertex_claude provider in the configuration system.
- lua/avante/providers.lua - Adds the vertex_claude provider to the provider list.

Purpose:

I posted configuration for a custom provider using Claude through Vertex in #764. This configuration stopped working for me, so I created a new provider vertex_claude  

