### PR TITLE
fix: Always handle the extra response outside of stream, such as the exceptions from bedrock

### DIFF
--- a/lua/avante/llm.lua
+++ b/lua/avante/llm.lua
@@ -246,7 +246,9 @@ function M.curl(opts)
   end
 
   local function parse_response_without_stream(data)
-    provider:parse_response_without_stream(data, current_event_state, handler_opts)
+    if provider.parse_response_without_stream then
+      provider:parse_response_without_stream(data, current_event_state, handler_opts)
+    end
   end
 
   local completed = false
@@ -354,8 +356,8 @@ function M.curl(opts)
         end)
       end
 
-      -- If stream is not enabled, then handle the response here
-      if provider:is_disable_stream() and result.status == 200 then
+      -- Always handle the extra response outside of stream, such as the exceptions from bedrock
+      if result.status == 200 then
         vim.schedule(function()
           completed = true
           parse_response_without_stream(result.body)

--- a/lua/avante/providers/azure.lua
+++ b/lua/avante/providers/azure.lua
@@ -16,7 +16,6 @@ M.api_key_name = "AZURE_OPENAI_API_KEY"
 M.parse_messages = O.parse_messages
 M.parse_response = O.parse_response
 M.parse_response_without_stream = O.parse_response_without_stream
-M.is_disable_stream = O.is_disable_stream
 M.is_o_series_model = O.is_o_series_model
 M.role_map = O.role_map
 

--- a/lua/avante/providers/bedrock/claude.lua
+++ b/lua/avante/providers/bedrock/claude.lua
@@ -17,7 +17,6 @@ M.role_map = {
   assistant = "assistant",
 }
 
-M.is_disable_stream = Claude.is_disable_stream
 M.parse_messages = Claude.parse_messages
 M.parse_response = Claude.parse_response
 

--- a/lua/avante/providers/claude.lua
+++ b/lua/avante/providers/claude.lua
@@ -36,8 +36,6 @@ M.role_map = {
   assistant = "assistant",
 }
 
-function M:is_disable_stream() return false end
-
 function M:parse_messages(opts)
   ---@type AvanteClaudeMessage[]
   local messages = {}

--- a/lua/avante/providers/cohere.lua
+++ b/lua/avante/providers/cohere.lua
@@ -47,8 +47,6 @@ M.role_map = {
   assistant = "assistant",
 }
 
-function M:is_disable_stream() return false end
-
 function M:parse_messages(opts)
   local messages = {
     { role = "system", content = opts.system_prompt },

--- a/lua/avante/providers/copilot.lua
+++ b/lua/avante/providers/copilot.lua
@@ -209,8 +209,6 @@ M.role_map = {
   assistant = "assistant",
 }
 
-function M:is_disable_stream() return false end
-
 M.parse_messages = OpenAI.parse_messages
 
 M.parse_response = OpenAI.parse_response

--- a/lua/avante/providers/gemini.lua
+++ b/lua/avante/providers/gemini.lua
@@ -12,8 +12,6 @@ M.role_map = {
 }
 -- M.tokenizer_id = "google/gemma-2b"
 
-function M:is_disable_stream() return false end
-
 function M:parse_messages(opts)
   local contents = {}
   local prev_role = nil

--- a/lua/avante/providers/ollama.lua
+++ b/lua/avante/providers/ollama.lua
@@ -14,8 +14,6 @@ M.role_map = {
 M.parse_messages = P.openai.parse_messages
 M.is_o_series_model = P.openai.is_o_series_model
 
-function M:is_disable_stream() return false end
-
 function M:parse_stream_data(ctx, data, handler_opts)
   local ok, json_data = pcall(vim.json.decode, data)
   if not ok or not json_data then

--- a/lua/avante/providers/openai.lua
+++ b/lua/avante/providers/openai.lua
@@ -13,8 +13,6 @@ M.role_map = {
   assistant = "assistant",
 }
 
-function M:is_disable_stream() return false end
-
 ---@param tool AvanteLLMTool
 ---@return AvanteOpenAITool
 function M.transform_tool(tool)

--- a/lua/avante/providers/vertex.lua
+++ b/lua/avante/providers/vertex.lua
@@ -11,7 +11,6 @@ M.role_map = {
   assistant = "model",
 }
 
-M.is_disable_stream = Gemini.is_disable_stream
 M.parse_messages = Gemini.parse_messages
 M.parse_response = Gemini.parse_response
 

--- a/lua/avante/providers/vertex_claude.lua
+++ b/lua/avante/providers/vertex_claude.lua
@@ -9,7 +9,6 @@ M.role_map = {
   assistant = "assistant",
 }
 
-M.is_disable_stream = P.claude.is_disable_stream
 M.parse_messages = P.claude.parse_messages
 M.parse_response = P.claude.parse_response
 M.parse_api_key = Vertex.parse_api_key

--- a/lua/avante/types.lua
+++ b/lua/avante/types.lua
@@ -261,7 +261,6 @@ vim.g.avante_login = vim.g.avante_login
 ---@field parse_messages AvanteMessagesParser
 ---@field parse_response AvanteResponseParser
 ---@field parse_curl_args AvanteCurlArgsParser
----@field is_disable_stream fun(self: AvanteProviderFunctor): boolean
 ---@field setup fun(): nil
 ---@field is_env_set fun(): boolean
 ---@field api_key_name string


### PR DESCRIPTION
Just found bedrock exception handling is broken, we need to check stream flag from server response(`spec.body.stream`) also, rather than just depend on the provider config.