### PR TITLE
Docs) Add the `AvanteClear` command to the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -612,6 +612,7 @@ The following key bindings are available for use with `avante.nvim`:
 | `:AvanteAsk [question] [position]` | Ask AI about your code. Optional `position` set window position and `ask` enable/disable direct asking mode | `:AvanteAsk position=right Refactor this code here`
 | `:AvanteBuild` | Build dependencies for the project |
 | `:AvanteChat` | Start a chat session with AI about your codebase. Default is `ask`=false |
+| `:AvanteClear` | Clear the chat history |
 | `:AvanteEdit` | Edit the selected code blocks |
 | `:AvanteFocus` | Switch focus to/from the sidebar |
 | `:AvanteRefresh` | Refresh all Avante windows |


### PR DESCRIPTION
The `AvanteClear`  command was not listed in the command section of the README so I added it.