### PR TITLE
feat: support cmd: loading api keys for google search APIs

### DIFF
--- a/lua/avante/llm_tools.lua
+++ b/lua/avante/llm_tools.lua
@@ -298,7 +298,7 @@ function M.web_search(opts, on_log)
   local search_engine = Config.web_search_engine.providers[provider_type]
   if search_engine == nil then return nil, "No search engine found: " .. provider_type end
   if search_engine.api_key_name == "" then return nil, "No API key provided" end
-  local api_key = os.getenv(search_engine.api_key_name)
+  local api_key = Utils.environment.parse(search_engine.api_key_name)
   if api_key == nil or api_key == "" then
     return nil, "Environment variable " .. search_engine.api_key_name .. " is not set"
   end
@@ -350,7 +350,7 @@ function M.web_search(opts, on_log)
     local jsn = vim.json.decode(resp.body)
     return search_engine.format_response_body(jsn)
   elseif provider_type == "google" then
-    local engine_id = os.getenv(search_engine.engine_id_name)
+    local engine_id = Utils.environment.parse(search_engine.engine_id_name)
     if engine_id == nil or engine_id == "" then
       return nil, "Environment variable " .. search_engine.engine_id_name .. " is not set"
     end

--- a/lua/avante/utils/environment.lua
+++ b/lua/avante/utils/environment.lua
@@ -1,0 +1,64 @@
+local Utils = require("avante.utils")
+
+---@class avante.utils.environment
+local M = {}
+
+---@private
+---@type table<string, string>
+M.cache = {}
+
+---Parse environment variable using optional cmd: feature with an override fallback
+---@param key_name string
+---@param override? string
+---@return string | nil
+function M.parse(key_name, override)
+  if key_name == nil then error("Requires key_name") end
+
+  local cache_key = type(key_name) == "table" and table.concat(key_name, "__") or key_name
+
+  if M.cache[cache_key] ~= nil then return M.cache[cache_key] end
+
+  local cmd = type(key_name) == "table" and key_name or key_name:match("^cmd:(.*)")
+
+  local value = nil
+
+  if cmd ~= nil then
+    if override ~= nil and override ~= "" then
+      value = os.getenv(override)
+      if value ~= nil then
+        M.cache[cache_key] = value
+        return value
+      end
+    end
+
+    if type(cmd) == "string" then cmd = vim.split(cmd, " ", { trimempty = true }) end
+
+    Utils.debug("running command:", cmd)
+    local exit_codes = { 0 }
+    local ok, job_or_err = pcall(vim.system, cmd, { text = true }, function(result)
+      Utils.debug("command result:", result)
+      local code = result.code
+      local stderr = result.stderr or ""
+      local stdout = result.stdout and vim.split(result.stdout, "\n") or {}
+      if vim.tbl_contains(exit_codes, code) then
+        value = stdout[1]
+        M.cache[cache_key] = value
+      else
+        Utils.error("failed to get key: (error code" .. code .. ")\n" .. stderr, { once = true, title = "Avante" })
+      end
+    end)
+
+    if not ok then
+      Utils.error("failed to run command: " .. cmd .. "\n" .. job_or_err)
+      return
+    end
+  else
+    value = os.getenv(key_name)
+  end
+
+  if value ~= nil then M.cache[cache_key] = value end
+
+  return value
+end
+
+return M

--- a/lua/avante/utils/init.lua
+++ b/lua/avante/utils/init.lua
@@ -9,6 +9,7 @@ local lsp = vim.lsp
 ---@field root avante.utils.root
 ---@field file avante.utils.file
 ---@field history avante.utils.history
+---@field environment avante.utils.environment
 local M = {}
 
 setmetatable(M, {


### PR DESCRIPTION
Refactor environment loading logic into Utils and use it for existing provider loading, and web search where appropriate.

can be used for moving other api keys to secret loading tools vs. storing them in the config or clunkily trying to load them into the shell's environment.