### PR TITLE
feat: add caller information to debug logs

### DIFF
--- a/lua/avante/utils/init.lua
+++ b/lua/avante/utils/init.lua
@@ -383,8 +383,17 @@ function M.debug(...)
 
   local args = { ... }
   if #args == 0 then return end
+
+  -- Get caller information
+  local info = debug.getinfo(2, "Sl")
+  local caller_source = info.source:match("@(.+)$") or "unknown"
+  local caller_module = caller_source:gsub("^.*/lua/", ""):gsub("%.lua$", ""):gsub("/", ".")
+
   local timestamp = os.date("%Y-%m-%d %H:%M:%S")
-  local formated_args = { "[" .. timestamp .. "] [AVANTE] [DEBUG]" }
+  local formated_args = {
+    "[" .. timestamp .. "] [AVANTE] [DEBUG] [" .. caller_module .. ":" .. info.currentline .. "]",
+  }
+
   for _, arg in ipairs(args) do
     if type(arg) == "string" then
       table.insert(formated_args, arg)


### PR DESCRIPTION
to help identify log sources when debugging issues.

example debug output:
```
[2025-03-09 02:37:54] [AVANTE] [DEBUG] [avante.init:31] LazyConfig loaded
[2025-03-09 02:37:54] [AVANTE] [DEBUG] [avante.utils.environment:36] running command: { "secret-tool", "lookup", "service", "***", "type", "***" }
[2025-03-09 02:37:54] [AVANTE] [DEBUG] [avante.utils.environment:39] command result: {
  code = 0,
  signal = 0,
  stderr = "",
  stdout = "****"
}
````