### PR TITLE
fix: remove `sidebar.close_from_input` default keybinding

### DIFF
--- a/README.md
+++ b/README.md
@@ -349,8 +349,14 @@ _See [config.lua#L9](./lua/avante/config.lua) for the full config_
     sidebar = {
       apply_all = "A",
       apply_cursor = "a",
+      retry_user_request = "r",
+      edit_user_request = "e",
       switch_windows = "<Tab>",
       reverse_switch_windows = "<S-Tab>",
+      remove_file = "d",
+      add_file = "@",
+      close = { "<Esc>", "q" },
+      close_from_input = nil, -- e.g., { normal = "<Esc>", insert = "<C-d>" }
     },
   },
   hints = { enabled = true },

--- a/lua/avante/config.lua
+++ b/lua/avante/config.lua
@@ -383,10 +383,7 @@ M._defaults = {
       remove_file = "d",
       add_file = "@",
       close = { "<Esc>", "q" },
-      close_from_input = {
-        normal = "<Esc>",
-        insert = "<C-d>",
-      },
+      close_from_input = { "<Esc>" },
     },
     files = {
       add_current = "<leader>ac", -- Add current buffer to selected files

--- a/lua/avante/config.lua
+++ b/lua/avante/config.lua
@@ -383,7 +383,7 @@ M._defaults = {
       remove_file = "d",
       add_file = "@",
       close = { "<Esc>", "q" },
-      close_from_input = { "<Esc>" },
+      close_from_input = nil, -- e.g., { normal = "<Esc>", insert = "<C-d>" }
     },
     files = {
       add_current = "<leader>ac", -- Add current buffer to selected files

--- a/lua/avante/sidebar.lua
+++ b/lua/avante/sidebar.lua
@@ -2709,8 +2709,10 @@ function Sidebar:create_input_container(opts)
 
   self.input_container:map("n", Config.mappings.submit.normal, on_submit)
   self.input_container:map("i", Config.mappings.submit.insert, on_submit)
-  self.input_container:map("n", Config.mappings.sidebar.close_from_input.normal, function() self:shutdown() end)
-  self.input_container:map("i", Config.mappings.sidebar.close_from_input.insert, function() self:shutdown() end)
+  if Config.mappings.sidebar.close_from_input ~= nil then
+    self.input_container:map("n", Config.mappings.sidebar.close_from_input.normal, function() self:shutdown() end)
+    self.input_container:map("i", Config.mappings.sidebar.close_from_input.insert, function() self:shutdown() end)
+  end
 
   api.nvim_set_option_value("filetype", "AvanteInput", { buf = self.input_container.bufnr })
 

--- a/lua/avante/sidebar.lua
+++ b/lua/avante/sidebar.lua
@@ -2709,9 +2709,11 @@ function Sidebar:create_input_container(opts)
 
   self.input_container:map("n", Config.mappings.submit.normal, on_submit)
   self.input_container:map("i", Config.mappings.submit.insert, on_submit)
-  if Config.mappings.sidebar.close_from_input ~= nil then
-    self.input_container:map("n", Config.mappings.sidebar.close_from_input.normal, function() self:shutdown() end)
-    self.input_container:map("i", Config.mappings.sidebar.close_from_input.insert, function() self:shutdown() end)
+
+  local close_from_input = Config.mappings.sidebar.close_from_input
+  if close_from_input ~= nil then
+    self.input_container:map("n", close_from_input.normal, function() self:shutdown() end)
+    self.input_container:map("i", close_from_input.insert, function() self:shutdown() end)
   end
 
   api.nvim_set_option_value("filetype", "AvanteInput", { buf = self.input_container.bufnr })


### PR DESCRIPTION
`<C-d>` should not be an insert mode default binding.
- `<C-d>` acts as the Delete key (remove a single letter after ther cursor) in shells including Bash and Zsh.
- After all, `<C-d>` (scroll half page) is such a commonly used key combination, and silently binding this key to something else leads to unexpected behavior. For instance, when jumping back and forth between code and Avante, users are prone to press `<C-d>` to scroll either code or the Avante generated response. When the cursor happens to jump to the input text window, `<C-d>` will close Avante and the input text users were currently drafting will be lost.

I've been bit by this like three times today. I think I won't be alone.