### PR TITLE
Fix - Fix thrown error when trying to use codebase with no buffer opened

### DIFF
--- a/lua/avante/repo_map.lua
+++ b/lua/avante/repo_map.lua
@@ -80,13 +80,9 @@ function RepoMap._get_repo_map(file_ext)
   if not file_ext then
     local current_buf = vim.api.nvim_get_current_buf()
     local buf_name = vim.api.nvim_buf_get_name(current_buf)
-    if buf_name and buf_name ~= "" then
-      file_ext = vim.fn.fnamemodify(buf_name, ":e")
-    end
+    if buf_name and buf_name ~= "" then file_ext = vim.fn.fnamemodify(buf_name, ":e") end
 
-    if not file_ext or file_ext == "" then
-      return {}
-    end
+    if not file_ext or file_ext == "" then return {} end
   end
 
   local project_root = Utils.root.get()

--- a/lua/avante/repo_map.lua
+++ b/lua/avante/repo_map.lua
@@ -62,6 +62,12 @@ end
 local cache = {}
 
 function RepoMap.get_repo_map(file_ext)
+  -- Add safety check for file_ext
+  if not file_ext then
+    Utils.warn("No file extension available - please open a file first")
+    return {}
+  end
+
   local repo_map = RepoMap._get_repo_map(file_ext) or {}
   if not repo_map or next(repo_map) == nil then
     Utils.warn("The repo map is empty. Maybe do not support this language: " .. file_ext)
@@ -70,7 +76,19 @@ function RepoMap.get_repo_map(file_ext)
 end
 
 function RepoMap._get_repo_map(file_ext)
-  file_ext = file_ext or vim.fn.expand("%:e")
+  -- Add safety check at the start of the function
+  if not file_ext then
+    local current_buf = vim.api.nvim_get_current_buf()
+    local buf_name = vim.api.nvim_buf_get_name(current_buf)
+    if buf_name and buf_name ~= "" then
+      file_ext = vim.fn.fnamemodify(buf_name, ":e")
+    end
+
+    if not file_ext or file_ext == "" then
+      return {}
+    end
+  end
+
   local project_root = Utils.root.get()
   local cache_key = project_root .. "." .. file_ext
   local cached = cache[cache_key]

--- a/lua/avante/sidebar.lua
+++ b/lua/avante/sidebar.lua
@@ -2363,6 +2363,13 @@ function Sidebar:create_input_container(opts)
 
     ---@type AvanteSelectedCode | nil
     local selected_code = nil
+    if self.code.selection ~= nil then
+      selected_code = {
+        path = self.code.selection.filepath,
+        file_type = self.code.selection.filetype,
+        content = self.code.selection.content,
+      }
+    end
 
     local mentions = Utils.extract_mentions(request)
     request = mentions.new_content

--- a/lua/avante/sidebar.lua
+++ b/lua/avante/sidebar.lua
@@ -2359,29 +2359,17 @@ function Sidebar:create_input_container(opts)
 
     -- Get file extension safely
     local buf_name = api.nvim_buf_get_name(self.code.bufnr)
-    if buf_name and buf_name ~= "" then
-      file_ext = vim.fn.fnamemodify(buf_name, ":e")
-    end
+    if buf_name and buf_name ~= "" then file_ext = vim.fn.fnamemodify(buf_name, ":e") end
 
     ---@type AvanteSelectedCode | nil
     local selected_code = nil
-    if self.code.selection ~= nil then
-      selected_code = {
-        path = self.code.selection.filepath,
-        file_type = self.code.selection.filetype,
-        content = self.code.selection.content,
-      }
-    end
 
     local mentions = Utils.extract_mentions(request)
     request = mentions.new_content
 
-    local project_context = mentions.enable_project_context
-      and file_ext
-      and RepoMap.get_repo_map(file_ext)
-      or nil
+    local project_context = mentions.enable_project_context and file_ext and RepoMap.get_repo_map(file_ext) or nil
 
-    local selected_files_contents = self.file_selector:get_selected_files_contents()
+    local selected_files_contents = self.file_selector:get_selected_files_contents() or {}
 
     local diagnostics = nil
     if mentions.enable_diagnostics then


### PR DESCRIPTION
The at codebase command was throwing errors when attempting to use it without an active buffer 

This fix adds proper validation and error handling in several key areas:

1.  repo_map.lua: Added safety checks for file extension before attempting to build or access the repo map
2. sidebar.lua: Improved error handling in file scanning operations and added proper validation for buffer operations
3. -Added graceful fallbacks when buffer information is not available