### PR TITLE
feat: add ollama as supported provider

### DIFF
--- a/README.md
+++ b/README.md
@@ -683,6 +683,17 @@ return {
 
 See [highlights.lua](./lua/avante/highlights.lua) for more information
 
+## Ollama
+
+ollama is a first-class provider for avante.nvim. You can use it by setting `provider = "ollama"` in the configuration, and set the `model` field in `ollama` to the model you want to use. For example:
+
+```lua
+provider = "ollama",
+ollama = {
+  model = "qwq:32b",
+}
+```
+
 ## Custom providers
 
 Avante provides a set of default providers, but users can also create their own providers.

--- a/lua/avante/config.lua
+++ b/lua/avante/config.lua
@@ -20,7 +20,7 @@ local M = {}
 ---@field custom_tools AvanteLLMToolPublic[]
 M._defaults = {
   debug = false,
-  ---@alias ProviderName "claude" | "openai" | "azure" | "gemini" | "vertex" | "cohere" | "copilot" | "bedrock" | string
+  ---@alias ProviderName "claude" | "openai" | "azure" | "gemini" | "vertex" | "cohere" | "copilot" | "bedrock" | "ollama" | string
   provider = "claude",
   -- WARNING: Since auto-suggestions are a high-frequency operation and therefore expensive,
   -- currently designating it as `copilot` provider is dangerous because: https://github.com/yetone/avante.nvim/issues/1048
@@ -254,6 +254,15 @@ M._defaults = {
     timeout = 30000, -- Timeout in milliseconds
     temperature = 0,
     max_tokens = 4096,
+  },
+  ---@type AvanteSupportedProvider
+  ollama = {
+    endpoint = "https://127.0.0.1:11434",
+    timeout = 30000, -- Timeout in milliseconds
+    options = {
+      temperature = 0,
+      num_ctx = 4096,
+    },
   },
   ---To add support for custom provider, follow the format below
   ---See https://github.com/yetone/avante.nvim/wiki#custom-providers for more details

--- a/lua/avante/config.lua
+++ b/lua/avante/config.lua
@@ -257,7 +257,7 @@ M._defaults = {
   },
   ---@type AvanteSupportedProvider
   ollama = {
-    endpoint = "https://127.0.0.1:11434",
+    endpoint = "http://127.0.0.1:11434",
     timeout = 30000, -- Timeout in milliseconds
     options = {
       temperature = 0,

--- a/lua/avante/providers/init.lua
+++ b/lua/avante/providers/init.lua
@@ -153,8 +153,13 @@ M = setmetatable(M, {
   __index = function(t, k)
     local provider_config = M.get_config(k)
 
+    if Config.vendors[k] ~= nil and k == "ollama" then
+      Utils.warn(
+        "ollama is now a first-class provider in avante.nvim, please stop using vendors to define ollama, for migration guide please refer to: https://github.com/yetone/avante.nvim/wiki/Custom-providers#ollama"
+      )
+    end
     ---@diagnostic disable: undefined-field,no-unknown,inject-field
-    if Config.vendors[k] ~= nil then
+    if Config.vendors[k] ~= nil and k ~= "ollama" then
       if provider_config.parse_response_data ~= nil then
         Utils.error("parse_response_data is not supported for avante.nvim vendors")
       end

--- a/lua/avante/providers/init.lua
+++ b/lua/avante/providers/init.lua
@@ -18,6 +18,7 @@ local DressingState = { winid = nil, input_winid = nil, input_bufnr = nil }
 ---@field gemini AvanteProviderFunctor
 ---@field cohere AvanteProviderFunctor
 ---@field bedrock AvanteBedrockProviderFunctor
+---@field ollama AvanteProviderFunctor
 local M = {}
 
 ---@class EnvironmentHandler

--- a/lua/avante/providers/ollama.lua
+++ b/lua/avante/providers/ollama.lua
@@ -1,0 +1,106 @@
+local Utils = require("avante.utils")
+local Config = require("avante.config")
+local Clipboard = require("avante.clipboard")
+local P = require("avante.providers")
+
+---@class AvanteProviderFunctor
+local M = {}
+
+M.api_key_name = "" -- Ollama typically doesn't require API keys for local use
+
+---@param opts AvantePromptOptions
+M.parse_messages = function(opts)
+  local messages = {}
+  local has_images = Config.behaviour.support_paste_from_clipboard and opts.image_paths and #opts.image_paths > 0
+
+  -- Convert avante messages to ollama format
+  for _, msg in ipairs(opts.messages) do
+    local role = msg.role == "user" and "user" or "assistant"
+    local content = msg.content
+
+    -- Handle multimodal content if images are present
+    if has_images and role == "user" then
+      local message_content = {
+        role = role,
+        content = content,
+        images = {},
+      }
+
+      for _, image_path in ipairs(opts.image_paths) do
+        table.insert(message_content.images, "data:image/png;base64," .. Clipboard.get_base64_content(image_path))
+      end
+
+      table.insert(messages, message_content)
+    else
+      table.insert(messages, {
+        role = role,
+        content = content,
+      })
+    end
+  end
+
+  return messages
+end
+
+---@param data string
+---@param handler_opts AvanteHandlerOptions
+M.parse_stream_data = function(data, handler_opts)
+  local ok, json_data = pcall(vim.json.decode, data)
+  if not ok or not json_data then
+    -- Add debug logging
+    Utils.debug("Failed to parse JSON: " .. data)
+    return
+  end
+
+  -- Add debug logging
+  Utils.debug("Received data: " .. vim.inspect(json_data))
+
+  if json_data.message and json_data.message.content then
+    local content = json_data.message.content
+    if content and content ~= "" then
+      Utils.debug("Sending chunk: " .. content)
+      handler_opts.on_chunk(content)
+    end
+  end
+
+  if json_data.done then
+    Utils.debug("Stream complete")
+    handler_opts.on_complete(nil)
+    return
+  end
+end
+
+---@param provider AvanteProvider
+---@param prompt_opts AvantePromptOptions
+M.parse_curl_args = function(provider, prompt_opts)
+  local base, body_opts = P.parse_config(provider)
+
+  if not base.model or base.model == "" then error("Ollama model must be specified in config") end
+  if not base.endpoint then error("Ollama requires endpoint configuration") end
+
+  return {
+    url = Utils.url_join(base.endpoint, "/api/chat"),
+    headers = {
+      ["Content-Type"] = "application/json",
+      ["Accept"] = "application/json",
+    },
+    body = vim.tbl_deep_extend("force", {
+      model = base.model,
+      messages = M.parse_messages(prompt_opts),
+      stream = true,
+      system = prompt_opts.system_prompt,
+    }, body_opts),
+  }
+end
+
+---@param result table
+M.on_error = function(result)
+  local error_msg = "Ollama API error"
+  if result.body then
+    local ok, body = pcall(vim.json.decode, result.body)
+    if ok and body.error then error_msg = body.error end
+  end
+  Utils.error(error_msg, { title = "Ollama" })
+end
+
+return M

--- a/lua/avante/providers/openai.lua
+++ b/lua/avante/providers/openai.lua
@@ -67,12 +67,11 @@ function M.is_o_series_model(model) return model and string.match(model, "^o%d+"
 
 function M:parse_messages(opts)
   local messages = {}
-  local provider = P[Config.provider]
-  local base, _ = P.parse_config(provider)
+  local provider_conf, _ = P.parse_config(self)
 
   -- NOTE: Handle the case where the selected model is the `o1` model
   -- "o1" models are "smart" enough to understand user prompt as a system prompt in this context
-  if self.is_o_series_model(base.model) then
+  if self.is_o_series_model(provider_conf.model) then
     table.insert(messages, { role = "user", content = opts.system_prompt })
   else
     table.insert(messages, { role = "system", content = opts.system_prompt })


### PR DESCRIPTION
Because the original PR cannot be reopened, I can only fork from this PR: https://github.com/yetone/avante.nvim/pull/1150

Thanks and sorry for @jtabke 

*This implementation is only working with `stream = true`*
- Uses the actual ollama api and allows for passing additional options
- Properly passes the system prompt to api

Use ollama as provider in opts like this:
```lua
opts = {
        debug = true,
        provider = "ollama",
        ollama = {
                api_key_name = "",
                endpoint = "http://127.0.0.1:11434",
                model = "qwen2.5-coder:latest",
                options = {
                        num_ctx = 32768,
                        temperature = 0,
                },
                stream = true,
        },
}
```