### PR TITLE
Feat - prevent file scanning hang on large codebases & fix Repo map is empty

### DIFF
--- a/lua/avante/llm_tools.lua
+++ b/lua/avante/llm_tools.lua
@@ -52,18 +52,36 @@ end
 function M.list_files(opts, on_log)
   local abs_path = get_abs_path(opts.rel_path)
   if not has_permission_to_access(abs_path) then return "", "No permission to access path: " .. abs_path end
-  if on_log then on_log("path: " .. abs_path) end
-  if on_log then on_log("max depth: " .. tostring(opts.max_depth)) end
+
+  -- Set a reasonable default max_depth if not specified
+  local max_depth = opts.max_depth or 100
+
   local files = Utils.scan_directory({
     directory = abs_path,
     add_dirs = true,
-    max_depth = opts.max_depth,
+    max_depth = max_depth,
   })
+
+  if on_log then on_log("Scanning directory: " .. abs_path) end
+  if on_log then on_log("path: " .. abs_path) end
+  if on_log then on_log("max depth: " .. tostring(opts.max_depth)) end
+
+  if not files or #files == 0 then
+    return "", "No files found in directory: " .. abs_path
+  end
+
   local filepaths = {}
   for _, file in ipairs(files) do
     local uniform_path = Utils.uniform_path(file)
     table.insert(filepaths, uniform_path)
   end
+
+  if on_log then
+    on_log(string.format("Found %d filepaths (max_depth: %s)", #files, tostring(max_depth)))
+  end
+
+
+
   return vim.json.encode(filepaths), nil
 end
 

--- a/lua/avante/llm_tools.lua
+++ b/lua/avante/llm_tools.lua
@@ -66,9 +66,7 @@ function M.list_files(opts, on_log)
   if on_log then on_log("path: " .. abs_path) end
   if on_log then on_log("max depth: " .. tostring(opts.max_depth)) end
 
-  if not files or #files == 0 then
-    return "", "No files found in directory: " .. abs_path
-  end
+  if not files or #files == 0 then return "", "No files found in directory: " .. abs_path end
 
   local filepaths = {}
   for _, file in ipairs(files) do
@@ -76,11 +74,7 @@ function M.list_files(opts, on_log)
     table.insert(filepaths, uniform_path)
   end
 
-  if on_log then
-    on_log(string.format("Found %d filepaths (max_depth: %s)", #files, tostring(max_depth)))
-  end
-
-
+  if on_log then on_log(string.format("Found %d filepaths (max_depth: %s)", #files, tostring(max_depth))) end
 
   return vim.json.encode(filepaths), nil
 end

--- a/lua/avante/utils/init.lua
+++ b/lua/avante/utils/init.lua
@@ -731,9 +731,7 @@ function M.scan_directory(options)
       if type == "file" then
         table.insert(files, path)
       elseif type == "directory" and name ~= ".git" and name ~= "node_modules" then
-        if options.add_dirs then
-          table.insert(files, path)
-        end
+        if options.add_dirs then table.insert(files, path) end
         if not depth or depth > 1 then
           local subfiles = scan_directory_lua(path, depth and depth - 1)
           vim.list_extend(files, subfiles)
@@ -748,15 +746,11 @@ function M.scan_directory(options)
     local cmd
     if vim.fn.executable("rg") == 1 then
       cmd = { "rg", "--files", "--color", "never", "--no-require-git" }
-      if options.max_depth then
-        vim.list_extend(cmd, { "--max-depth", tostring(options.max_depth) })
-      end
+      if options.max_depth then vim.list_extend(cmd, { "--max-depth", tostring(options.max_depth) }) end
       table.insert(cmd, options.directory)
     elseif vim.fn.executable("fd") == 1 then
       cmd = { "fd", "--type", "f", "--color", "never", "--no-require-git" }
-      if options.max_depth then
-        vim.list_extend(cmd, { "--max-depth", tostring(options.max_depth) })
-      end
+      if options.max_depth then vim.list_extend(cmd, { "--max-depth", tostring(options.max_depth) }) end
       vim.list_extend(cmd, { "--base-directory", options.directory })
     end
 
@@ -778,14 +772,14 @@ function M.scan_directory(options)
     if job <= 0 then return nil end
 
     -- Wait for job with timeout
-    local timeout = 5000  -- 5 seconds timeout
+    local timeout = 5000 -- 5 seconds timeout
     local start_time = vim.loop.now()
-    while vim.fn.jobwait({job}, 0)[1] == -1 do
+    while vim.fn.jobwait({ job }, 0)[1] == -1 do
       if (vim.loop.now() - start_time) > timeout then
         vim.fn.jobstop(job)
         return nil
       end
-      vim.cmd("sleep 1m")  -- Small sleep to prevent CPU hogging and NVIM crashes on large files / codebases
+      vim.cmd("sleep 1m") -- Small sleep to prevent CPU hogging and NVIM crashes on large files / codebases
     end
 
     if error_output ~= "" then return nil end
@@ -794,9 +788,7 @@ function M.scan_directory(options)
 
   -- Try external commands first, fall back to Lua implementation
   local files = try_external_commands()
-  if not files then
-    files = scan_directory_lua(options.directory, options.max_depth)
-  end
+  if not files then files = scan_directory_lua(options.directory, options.max_depth) end
 
   -- Filter and normalize paths
   local result = {}


### PR DESCRIPTION
This commit was able to fix the pesky Repo map is empty once and for all. it was also tested on multiple prod codeabses in different languages, and it was able to explain the codebase for me fine

In this commit, the following was done : 

- Add max_depth limit (100) to prevent deep directory recursion
- Use fast external tools (rg/fd) for file scanning with Lua fallback (way faster than Lua and proved better in large code files that are in the thousands)
- Add timeout protection for external commands
- Improve directory scanning to handle large projects efficiently

Previously, scanning large codebases would hang when trying to access all files recursively. Now, the system efficiently scans directories using ripgrep/fd with depth limits, making it work reliably even on large projects with deep directory structures.