### PR TITLE
fix(azure): attempt to call is_o_series_model

### DIFF
--- a/lua/avante/providers/azure.lua
+++ b/lua/avante/providers/azure.lua
@@ -18,6 +18,7 @@ M.parse_response = O.parse_response
 M.parse_response_without_stream = O.parse_response_without_stream
 M.is_disable_stream = O.is_disable_stream
 M.is_o_series_model = O.is_o_series_model
+M.role_map = O.role_map
 
 function M:parse_curl_args(prompt_opts)
   local provider_conf, request_body = P.parse_config(self)

--- a/lua/avante/providers/azure.lua
+++ b/lua/avante/providers/azure.lua
@@ -17,6 +17,7 @@ M.parse_messages = O.parse_messages
 M.parse_response = O.parse_response
 M.parse_response_without_stream = O.parse_response_without_stream
 M.is_disable_stream = O.is_disable_stream
+M.is_o_series_model = O.is_o_series_model
 
 function M:parse_curl_args(prompt_opts)
   local provider_conf, request_body = P.parse_config(self)


### PR DESCRIPTION
Fixes issue #1522 but for azure models.

Similarly defines `role_map` table in azure file to fix issue like #1518.

I think we should consider making the `azure` file inherit from `openai` so any new fields don't have to be copied over too e.g.:

```lua
-- Inherit from openai provider
setmetatable(M, { __index = O })
```