### PR TITLE
Fixes to adjusting window sizes

### DIFF
--- a/lua/avante/sidebar.lua
+++ b/lua/avante/sidebar.lua
@@ -130,8 +130,6 @@ function Sidebar:open(opts)
     vim.g.avante_login = true
   end
 
-  vim.cmd("wincmd =")
-
   return self
 end
 
@@ -198,8 +196,6 @@ function Sidebar:close(opts)
   end
 
   self:recover_code_winhl()
-
-  vim.cmd("wincmd =")
 end
 
 function Sidebar:shutdown()

--- a/lua/avante/sidebar.lua
+++ b/lua/avante/sidebar.lua
@@ -3168,10 +3168,8 @@ function Sidebar:get_result_container_width()
 end
 
 function Sidebar:adjust_result_container_layout()
-  local width = self:get_result_container_width()
   local height = self:get_result_container_height()
 
-  api.nvim_win_set_width(self.result_container.winid, width)
   api.nvim_win_set_height(self.result_container.winid, height)
 end
 


### PR DESCRIPTION
Fixes https://github.com/yetone/avante.nvim/issues/1577

First commit drops the `wincmd =` calls and seems straightforward to me, I'm not sure what the reasoning was to add them previously in https://github.com/yetone/avante.nvim/pull/160 and https://github.com/yetone/avante.nvim/pull/198.

Second commit drops the `nvim_win_set_width` call in `adjust_result_container_layout()`, at first I was unsure about this but after testing a bit more and trying different approaches I think it makes sense too: As I understand it the plugin wants to adjust the size of the results container in response to changes to the selected code and files, and this only seems necessary in vertical layout where we want to adjust the height. In horizontal layout the width seems like it should be static so we don't need to mess with it.

See repro steps in https://github.com/yetone/avante.nvim/issues/1577, with these changes the plugin properly respect the `windows.width` setting for me, and the input window width stays at the hard-coded 40%.