### PR TITLE
Update displayed response for the first chunk

### DIFF
--- a/lua/avante/sidebar.lua
+++ b/lua/avante/sidebar.lua
@@ -2567,6 +2567,7 @@ function Sidebar:create_input_container(opts)
       if is_first_chunk then
         is_first_chunk = false
         self:update_content(content_prefix .. chunk, { scroll = scroll })
+        displayed_response = cur_displayed_response
         return
       end
       local suffix = get_display_content_suffix(transformed)


### PR DESCRIPTION
If one is using avante.nvim with a non streaming LLM API the API response will only have a single chunk. So that if we don't update the displayed_response in the sidebar component, the output of the LLM will be removed from the sidebar when we complete the interaction with the LLM.

This commit makes sure that the displayed_response is updated for the first chunk as well as subsequent ones.