### PR TITLE
feat: update openai/azure params

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,7 +68,7 @@ For building binary if you wish to build from source, then `cargo` is required. 
       timeout = 30000, -- Timeout in milliseconds, increase this for reasoning models
       temperature = 0,
       max_completion_tokens = 8192, -- Increase this to include reasoning tokens (for reasoning models)
-      --reasoning_effort = 'medium', -- low|medium|high, only used for reasoning models
+      --reasoning_effort = "medium", -- low|medium|high, only used for reasoning models
     },
   },
   -- if you want to build from source then do `make BUILD_FROM_SOURCE=true`

--- a/README.md
+++ b/README.md
@@ -65,10 +65,10 @@ For building binary if you wish to build from source, then `cargo` is required. 
     openai = {
       endpoint = "https://api.openai.com/v1",
       model = "gpt-4o", -- your desired model (or use gpt-4o, etc.)
-      timeout = 30000, -- timeout in milliseconds
-      temperature = 0, -- adjust if needed
-      max_tokens = 4096,
-      -- reasoning_effort = "high" -- only supported for reasoning models (o1, etc.)
+      timeout = 30000, -- Timeout in milliseconds, increase this for reasoning models
+      temperature = 0,
+      max_completion_tokens = 8192, -- Increase this to include reasoning tokens (for reasoning models)
+      --reasoning_effort = 'medium', -- low|medium|high, only used for reasoning models
     },
   },
   -- if you want to build from source then do `make BUILD_FROM_SOURCE=true`

--- a/cursor-planning-mode.md
+++ b/cursor-planning-mode.md
@@ -35,7 +35,7 @@ Then enable it in avante.nvim:
             api_key_name = 'GROQ_API_KEY',
             endpoint = 'https://api.groq.com/openai/v1/',
             model = 'llama-3.3-70b-versatile',
-            max_tokens = 32768, -- remember to increase this value, otherwise it will stop generating halfway
+            max_completion_tokens = 32768, -- remember to increase this value, otherwise it will stop generating halfway
         },
     },
     --- ... existing configurations

--- a/lua/avante/config.lua
+++ b/lua/avante/config.lua
@@ -217,7 +217,7 @@ M._defaults = {
     temperature = 0,
     max_completion_tokens = 8192, -- Increase this to include reasoning tokens (for reasoning models)
     reasoning_effort = "medium", -- low|medium|high, only used for reasoning models
-    max_tokens = 8192,
+    max_completion_tokens = 8192,
   },
   ---@type AvanteSupportedProvider
   claude = {

--- a/lua/avante/config.lua
+++ b/lua/avante/config.lua
@@ -193,9 +193,10 @@ M._defaults = {
   openai = {
     endpoint = "https://api.openai.com/v1",
     model = "gpt-4o",
-    timeout = 30000, -- Timeout in milliseconds
+    timeout = 30000, -- Timeout in milliseconds, increase this for reasoning models
     temperature = 0,
-    max_tokens = 4096,
+    max_completion_tokens = 4096, -- Increase this to include reasoning tokens (for reasoning models)
+    reasoning_effort = 'medium', -- low|medium|high, only used for reasoning models
   },
   ---@type AvanteSupportedProvider
   copilot = {
@@ -211,10 +212,11 @@ M._defaults = {
   azure = {
     endpoint = "", -- example: "https://<your-resource-name>.openai.azure.com"
     deployment = "", -- Azure deployment name (e.g., "gpt-4o", "my-gpt-4o-deployment")
-    api_version = "2024-06-01",
-    timeout = 30000, -- Timeout in milliseconds
+    api_version = "2024-12-01-preview",
+    timeout = 30000, -- Timeout in milliseconds, increase this for reasoning models
     temperature = 0,
-    max_tokens = 4096,
+    max_completion_tokens = 4096, -- Increase this to include reasoning tokens (for reasoning models)
+    reasoning_effort = 'medium', -- low|medium|high, only used for reasoning models
   },
   ---@type AvanteSupportedProvider
   claude = {

--- a/lua/avante/config.lua
+++ b/lua/avante/config.lua
@@ -196,7 +196,7 @@ M._defaults = {
     timeout = 30000, -- Timeout in milliseconds, increase this for reasoning models
     temperature = 0,
     max_completion_tokens = 8192, -- Increase this to include reasoning tokens (for reasoning models)
-    reasoning_effort = 'medium', -- low|medium|high, only used for reasoning models
+    reasoning_effort = "medium", -- low|medium|high, only used for reasoning models
   },
   ---@type AvanteSupportedProvider
   copilot = {
@@ -216,7 +216,7 @@ M._defaults = {
     timeout = 30000, -- Timeout in milliseconds, increase this for reasoning models
     temperature = 0,
     max_completion_tokens = 8192, -- Increase this to include reasoning tokens (for reasoning models)
-    reasoning_effort = 'medium', -- low|medium|high, only used for reasoning models
+    reasoning_effort = "medium", -- low|medium|high, only used for reasoning models
     max_tokens = 8192,
   },
   ---@type AvanteSupportedProvider

--- a/lua/avante/config.lua
+++ b/lua/avante/config.lua
@@ -217,7 +217,6 @@ M._defaults = {
     temperature = 0,
     max_completion_tokens = 8192, -- Increase this to include reasoning tokens (for reasoning models)
     reasoning_effort = "medium", -- low|medium|high, only used for reasoning models
-    max_completion_tokens = 8192,
   },
   ---@type AvanteSupportedProvider
   claude = {

--- a/lua/avante/providers/azure.lua
+++ b/lua/avante/providers/azure.lua
@@ -2,7 +2,8 @@
 ---@field deployment string
 ---@field api_version string
 ---@field temperature number
----@field max_tokens number
+---@field max_completion_tokens number
+---@field reasoning_effort? string
 
 local Utils = require("avante.utils")
 local P = require("avante.providers")

--- a/lua/avante/providers/azure.lua
+++ b/lua/avante/providers/azure.lua
@@ -13,12 +13,7 @@ local M = {}
 
 M.api_key_name = "AZURE_OPENAI_API_KEY"
 
-M.parse_messages = O.parse_messages
-M.parse_response = O.parse_response
-M.parse_response_without_stream = O.parse_response_without_stream
-M.is_disable_stream = O.is_disable_stream
-M.is_o_series_model = O.is_o_series_model
-M.role_map = O.role_map
+setmetatable(M, { __index = O })
 
 function M:parse_curl_args(prompt_opts)
   local provider_conf, request_body = P.parse_config(self)
@@ -35,11 +30,8 @@ function M:parse_curl_args(prompt_opts)
     end
   end
 
-  -- NOTE: When using "o" series set the supported parameters only
-  if O.is_o_series_model(provider_conf.model) then
-    request_body.max_tokens = nil
-    request_body.temperature = 1
-  end
+  -- NOTE: When using reasoning models set supported parameters
+  self.set_reasoning_params(provider_conf, request_body)
 
   return {
     url = Utils.url_join(

--- a/lua/avante/providers/azure.lua
+++ b/lua/avante/providers/azure.lua
@@ -13,6 +13,7 @@ local M = {}
 
 M.api_key_name = "AZURE_OPENAI_API_KEY"
 
+-- Inherit from OpenAI class
 setmetatable(M, { __index = O })
 
 function M:parse_curl_args(prompt_opts)

--- a/lua/avante/providers/openai.lua
+++ b/lua/avante/providers/openai.lua
@@ -83,7 +83,7 @@ function M:parse_messages(opts)
   local provider_conf, _ = P.parse_config(self)
 
   if self.is_reasoning_model(provider_conf.model) then
-    table.insert(messages, { role = "user", content = opts.system_prompt })
+    table.insert(messages, { role = "developer", content = opts.system_prompt })
   else
     table.insert(messages, { role = "system", content = opts.system_prompt })
   end

--- a/lua/avante/types.lua
+++ b/lua/avante/types.lua
@@ -215,6 +215,7 @@ vim.g.avante_login = vim.g.avante_login
 ---@field __inherited_from? string
 ---@field temperature? number
 ---@field max_tokens? number
+---@field max_completion_tokens? number
 ---@field reasoning_effort? string
 ---@field display_name? string
 ---


### PR DESCRIPTION
Realising that a lot of this could be done through user configuration, but I feel it's better for it to be the default.

Update OpenAI and Azure parameters following new docs:

- https://learn.microsoft.com/en-us/azure/ai-services/openai/api-version-deprecation
- https://platform.openai.com/docs/api-reference/chat/create

* Update deprecated `max_tokens` to `max_completion_tokens`
* Add `reasoning_effort` for reasoning models, ignored otherwise
* Use `developer` message instead of `system` for reasoning models
* Detect whether model is reasoning (o-series) and use correct set of parameters
* Reduce duplication between OpenAI and Azure providers
* Tested with both Azure and OpenAI with both reasoning and non-reasoning models