### PR TITLE
feat(ui): add support for multi-line messages in confirm dialog

### DIFF
--- a/lua/avante/ui.lua
+++ b/lua/avante/ui.lua
@@ -42,13 +42,19 @@ function M.confirm(message, callback)
     local yes_style = (focus_index == 1) and BUTTON_FOCUS or BUTTON_NORMAL
     local no_style = (focus_index == 2) and BUTTON_FOCUS or BUTTON_NORMAL
 
-    vim.api.nvim_buf_set_lines(popup.bufnr, 0, -1, false, {
-      "",
-      "  " .. message,
-      "",
-      "                       " .. " Yes       No ",
-      "",
-    })
+    local button_line = string.rep(" ", 23) .. " Yes       No "
+    local replacement = vim
+      .iter({
+        "",
+        vim.tbl_map(function(line) return "  " .. line end, vim.split(message, "\n")),
+        "",
+        button_line,
+        "",
+      })
+      :flatten()
+      :totable()
+
+    vim.api.nvim_buf_set_lines(popup.bufnr, 0, -1, false, replacement)
 
     vim.api.nvim_buf_add_highlight(popup.bufnr, 0, yes_style, 3, yes_button_pos[1], yes_button_pos[2])
     vim.api.nvim_buf_add_highlight(popup.bufnr, 0, no_style, 3, no_button_pos[1], no_button_pos[2])


### PR DESCRIPTION
fix the error:
```
Error executing vim.schedule lua callback: ...nns/.local/share/nvim/lazy/avante.nvim/lua/avante/ui.lua:45: 'replacement string' item contains newlines
stack traceback:
	[C]: in function 'nvim_buf_set_lines'
	...nns/.local/share/nvim/lazy/avante.nvim/lua/avante/ui.lua:45: in function 'render_buttons'
	...nns/.local/share/nvim/lazy/avante.nvim/lua/avante/ui.lua:136: in function 'confirm'
	...cal/share/nvim/lazy/avante.nvim/lua/avante/llm_tools.lua:22: in function 'confirm'
	...cal/share/nvim/lazy/avante.nvim/lua/avante/llm_tools.lua:585: in function 'func'
	...cal/share/nvim/lazy/avante.nvim/lua/avante/llm_tools.lua:1437: in function 'process_tool_use'
	...ns/.local/share/nvim/lazy/avante.nvim/lua/avante/llm.lua:474: in function 'on_stop'
	...re/nvim/lazy/avante.nvim/lua/avante/providers/openai.lua:207: in function 'parse_response'
	...ns/.local/share/nvim/lazy/avante.nvim/lua/avante/llm.lua:263: in function 'parse_stream_data'
	...ns/.local/share/nvim/lazy/avante.nvim/lua/avante/llm.lua:326: in function <...ns/.local/share/nvim/lazy/avante.nvim/lua/avante/llm.lua:313>
```