### PR TITLE
Add extra headers to providers

### DIFF
--- a/lua/avante/config.lua
+++ b/lua/avante/config.lua
@@ -557,6 +557,7 @@ end
 
 M.BASE_PROVIDER_KEYS = {
   "endpoint",
+  "extra_headers",
   "model",
   "deployment",
   "api_version",

--- a/lua/avante/providers/openai.lua
+++ b/lua/avante/providers/openai.lua
@@ -278,6 +278,12 @@ function M:parse_curl_args(prompt_opts)
     ["Content-Type"] = "application/json",
   }
 
+  if provider_conf.extra_headers then
+    for key, value in pairs(provider_conf.extra_headers) do
+      headers[key] = value
+    end
+  end
+
   if P.env.require_api_key(provider_conf) then
     local api_key = self.parse_api_key()
     if api_key == nil then

--- a/lua/avante/types.lua
+++ b/lua/avante/types.lua
@@ -200,6 +200,7 @@ vim.g.avante_login = vim.g.avante_login
 ---
 ---@class AvanteDefaultBaseProvider: table<string, any>
 ---@field endpoint? string
+---@field extra_headers? table<string, any>
 ---@field model? string
 ---@field local? boolean
 ---@field proxy? string


### PR DESCRIPTION
Hey there 👋 

we are using a proxy for auth which requires some extra headers with API requests, so I setup this PR for OpenAI. As I am using OpenAI can tell you that this works and I can add a `extra_headers` to the config and be fine. IDK if `extra_headers` is okay or if it should just be `headers`. After this is settled, I can also add this feature to the other providers. 
Let me know if you like this!