### PR TITLE
fix: normalize CRLF to LF in read_file_from_buf_or_disk

### DIFF
--- a/lua/avante/utils/init.lua
+++ b/lua/avante/utils/init.lua
@@ -1079,6 +1079,7 @@ function M.read_file_from_buf_or_disk(filepath)
   if file then
     local content = file:read("*all")
     file:close()
+    content = content:gsub("\r\n", "\n")
     return vim.split(content, "\n"), nil
   else
     return {}, open_err


### PR DESCRIPTION
### **What does this PR do?**
This PR fixes incorrect line number detection when modifying CRLF-formatted files in `AvanteSelectedFiles`.  
By normalizing line endings (`\r\n` → `\n`) when reading files from disk, it ensures consistency across different platforms.

### **Issue Reference**
This PR addresses [yetone/avante.nvim#1621](https://github.com/yetone/avante.nvim/issues/1621).

### **Problem**
- When reading files directly from disk, `io.open(filepath, "r")` does **not normalize CRLF (`\r\n`)**.
- However, when files are **opened in a Neovim buffer**, `vim.api.nvim_buf_get_lines()` **automatically normalizes line endings to LF (`\n`)**.
- This inconsistency causes **incorrect line number detection** when modifying files that use Windows-style line endings.

### **Solution**
- Modify `read_file_from_buf_or_disk(filepath)` to **normalize CRLF (`\r\n`) to LF (`\n`)** when reading from disk.
- This ensures **consistent line number calculations**, whether a file is opened in a buffer or read from disk.

### **Impact**
✅ Fixes **incorrect line number detection for Windows/CRLF files**.  
✅ No impact on LF (Unix) formatted files.  
✅ Improves **cross-platform compatibility**.  

---

### **Testing**
1. Open a file with **CRLF (Windows line endings)**.
2. Use `AvanteSelectedFiles` to select and modify the file **without opening it in a buffer**.
3. AI should now correctly detect the modified lines instead of returning `Replace lines: 0-0`.

---

Thanks for your work on Avante.nvim! Let me know if any further improvements are needed.