### PR TITLE
refactor: rename is_o_series_model to is_reasoning_model

### DIFF
--- a/lua/avante/providers/copilot.lua
+++ b/lua/avante/providers/copilot.lua
@@ -215,7 +215,7 @@ M.parse_messages = OpenAI.parse_messages
 
 M.parse_response = OpenAI.parse_response
 
-M.is_o_series_model = OpenAI.is_o_series_model
+M.is_reasoning_model = OpenAI.is_reasoning_model
 
 function M:parse_curl_args(prompt_opts)
   -- refresh token synchronously, only if it has expired

--- a/lua/avante/providers/ollama.lua
+++ b/lua/avante/providers/ollama.lua
@@ -12,7 +12,7 @@ M.role_map = {
 }
 
 M.parse_messages = P.openai.parse_messages
-M.is_o_series_model = P.openai.is_o_series_model
+M.is_reasoning_model = P.openai.is_reasoning_model
 
 function M:is_disable_stream() return false end
 


### PR DESCRIPTION
The OpenAI module method was renamed from `is_o_series_model` to `is_reasoning_model` ( [here](https://github.com/yetone/avante.nvim/commit/10ce065d9e78beaf5c8251df91733a72e94b3edc#diff-d719406bc23d21a57dbe39067e94501df3aab00d622f4d78c65d7b1c5a5809b6L70-R71) )but it's usage in copilot and Ollama providers was not updated.