### PR TITLE
feat: Allow Chat Sidebar to Replace the Main Window (No Split)

### DIFF
--- a/lua/avante/api.lua
+++ b/lua/avante/api.lua
@@ -101,6 +101,7 @@ end
 ---@field floating? boolean whether to open a floating input to enter the question
 ---@field new_chat? boolean whether to open a new chat
 ---@field without_selection? boolean whether to open a new chat without selection
+---@field no_split? boolean whether to open a new chat without split side bar
 
 ---@param opts? AskOptions
 function M.ask(opts)

--- a/lua/avante/sidebar.lua
+++ b/lua/avante/sidebar.lua
@@ -140,11 +140,17 @@ end
 function Sidebar:close(opts)
   opts = vim.tbl_extend("force", { goto_code_win = true }, opts or {})
   self:delete_autocmds()
+
+  if opts.goto_code_win and self.code then
+    if self.code.winid and api.nvim_win_is_valid(self.code.winid) then
+      fn.win_gotoid(self.code.winid)
+    else
+      vim.cmd("vert sb" .. self.code.bufnr)
+    end
+  end
+
   for _, comp in pairs(self) do
     if comp and type(comp) == "table" and comp.unmount then comp:unmount() end
-  end
-  if opts.goto_code_win and self.code and self.code.winid and api.nvim_win_is_valid(self.code.winid) then
-    fn.win_gotoid(self.code.winid)
   end
 
   vim.cmd("wincmd =")
@@ -2978,8 +2984,6 @@ function Sidebar:create_input_container(opts)
       if ev.data and ev.data.request then handle_submit(ev.data.request) end
     end,
   })
-
-  self:refresh_winids()
 end
 
 function Sidebar:get_selected_code_size()
@@ -3024,11 +3028,13 @@ function Sidebar:get_result_container_width()
 end
 
 function Sidebar:adjust_result_container_layout()
-  local width = self:get_result_container_width()
-  local height = self:get_result_container_height()
+  if self.code.winid ~= nil and api.nvim_win_is_valid(self.code.winid) then
+    local width = self:get_result_container_width()
+    local height = self:get_result_container_height()
 
-  api.nvim_win_set_width(self.result_container.winid, width)
-  api.nvim_win_set_height(self.result_container.winid, height)
+    api.nvim_win_set_width(self.result_container.winid, width)
+    api.nvim_win_set_height(self.result_container.winid, height)
+  end
 end
 
 ---@param opts AskOptions
@@ -3075,18 +3081,26 @@ function Sidebar:render(opts)
 
   self:update_content_with_history(chat_history)
 
-  -- reset states when buffer is closed
-  api.nvim_buf_attach(self.code.bufnr, false, {
-    on_detach = function(_, _)
-      vim.schedule(function()
-        local bufnr = api.nvim_win_get_buf(self.code.winid)
-        self.code.bufnr = bufnr
-        self:reload_chat_history()
-      end)
-    end,
-  })
+  if opts.no_split == true then
+    vim.cmd(fn.win_getid(self.code.winid) .. "wincmd q")
+    self.code.winid = nil
+    fn.win_gotoid(self.input_container.winid)
+  else
+    -- reset states when buffer is closed
+    api.nvim_buf_attach(self.code.bufnr, false, {
+      on_detach = function(_, _)
+        vim.schedule(function()
+          local bufnr = api.nvim_win_get_buf(self.code.winid)
+          self.code.bufnr = bufnr
+          self:reload_chat_history()
+        end)
+      end,
+    })
+  end
 
   self:create_selected_code_container()
+
+  self:refresh_winids()
 
   self:on_mount(opts)
 


### PR DESCRIPTION
This is to implement #928 -- Allow Chat Sidebar to Replace the Main Window (No Split).

People could use `avante` to ask random questions, and would like to have conversation happen in a large window instead of side bar, as which has a limited width.

To use this feature, add below settings

        keys = {
            {
                "<leader>af",
                function() require("avante.api").ask({no_split = true}) end,
                desc = "avante: ask no split",
                mode = { "n", "v" },
            },
        },
![image](https://github.com/user-attachments/assets/0e1a2a9c-58e7-428c-af2a-d718b98fdff1)
