### PR TITLE
feat: stop command

### DIFF
--- a/README.md
+++ b/README.md
@@ -611,6 +611,7 @@ The following key bindings are available for use with `avante.nvim`:
 | <kbd>Leader</kbd><kbd>a</kbd><kbd>f</kbd> | switch sidebar focus                         |
 | <kbd>Leader</kbd><kbd>a</kbd><kbd>?</kbd> | select model                                 |
 | <kbd>Leader</kbd><kbd>a</kbd><kbd>e</kbd> | edit selected blocks                         |
+| <kbd>Leader</kbd><kbd>a</kbd><kbd>S</kbd> | stop current AI request                      |
 | <kbd>c</kbd><kbd>o</kbd>                  | choose ours                                  |
 | <kbd>c</kbd><kbd>t</kbd>                  | choose theirs                                |
 | <kbd>c</kbd><kbd>a</kbd>                  | choose all theirs                            |
@@ -687,6 +688,7 @@ return {
 | `:AvanteEdit`                      | Edit the selected code blocks                                                                               | |
 | `:AvanteFocus`                     | Switch focus to/from the sidebar                                                                            | |
 | `:AvanteRefresh`                   | Refresh all Avante windows                                                                                  | |
+| `:AvanteStop`                      | Stop the current AI request                                                                                 | |
 | `:AvanteSwitchProvider`            | Switch AI provider (e.g. openai)                                                                            | |
 | `:AvanteShowRepoMap`               | Show repo map for project's structure                                                                       | |
 | `:AvanteToggle`                    | Toggle the Avante sidebar                                                                                   | |

--- a/lua/avante/api.lua
+++ b/lua/avante/api.lua
@@ -237,6 +237,8 @@ function M.select_history()
   end)
 end
 
+function M.stop() require("avante.llm").cancel_inflight_request() end
+
 return setmetatable(M, {
   __index = function(t, k)
     local module = require("avante")

--- a/lua/avante/config.lua
+++ b/lua/avante/config.lua
@@ -387,6 +387,7 @@ M._defaults = {
     edit = "<leader>ae",
     refresh = "<leader>ar",
     focus = "<leader>af",
+    stop = "<leader>aS",
     toggle = {
       default = "<leader>at",
       debug = "<leader>ad",

--- a/lua/avante/init.lua
+++ b/lua/avante/init.lua
@@ -96,6 +96,12 @@ function H.keymaps()
     )
     Utils.safe_keymap_set(
       "n",
+      Config.mappings.stop,
+      function() require("avante.api").stop() end,
+      { desc = "avante: stop" }
+    )
+    Utils.safe_keymap_set(
+      "n",
       Config.mappings.refresh,
       function() require("avante.api").refresh() end,
       { desc = "avante: refresh" }

--- a/lua/avante/types.lua
+++ b/lua/avante/types.lua
@@ -245,7 +245,7 @@ vim.g.avante_login = vim.g.avante_login
 ---@field usage? AvanteLLMUsage
 ---
 ---@class AvanteLLMStopCallbackOptions
----@field reason "complete" | "tool_use" | "error" | "rate_limit"
+---@field reason "complete" | "tool_use" | "error" | "rate_limit" | "cancelled"
 ---@field error? string | table
 ---@field usage? AvanteLLMUsage
 ---@field tool_use_list? AvanteLLMToolUse[]

--- a/lua/avante/ui/confirm.lua
+++ b/lua/avante/ui/confirm.lua
@@ -253,6 +253,11 @@ end
 
 function M:unbind_window_focus_keymaps() vim.keymap.del({ "n", "i" }, "<C-w>f") end
 
+function M:cancel()
+  self.callback(false)
+  return self:close()
+end
+
 function M:close()
   self:unbind_window_focus_keymaps()
   if self._group then

--- a/plugin/avante.lua
+++ b/plugin/avante.lua
@@ -156,3 +156,4 @@ end, {
 cmd("ShowRepoMap", function() require("avante.repo_map").show() end, { desc = "avante: show repo map" })
 cmd("Models", function() require("avante.model_selector").open() end, { desc = "avante: show models" })
 cmd("History", function() require("avante.api").select_history() end, { desc = "avante: show histories" })
+cmd("Stop", function() require("avante.api").stop() end, { desc = "avante: stop current AI request" })


### PR DESCRIPTION
solves #1531 

Adds a new binding `<leader>aS` and a new cmd `AvanteStop` that cancels any generation/tool use