### PR TITLE
fix: make sure to get the final highlight values rather than link names

### DIFF
--- a/lua/avante/highlights.lua
+++ b/lua/avante/highlights.lua
@@ -90,12 +90,12 @@ function M.setup_conflict_highlights()
 
   ---@return number | nil
   local function get_bg(hl_name)
-    local hl = api.nvim_get_hl(0, { name = hl_name })
+    local hl = api.nvim_get_hl(0, { name = hl_name, link = false })
     return hl.bg
   end
 
   local function get_bold(hl_name)
-    local hl = api.nvim_get_hl(0, { name = hl_name })
+    local hl = api.nvim_get_hl(0, { name = hl_name, link = false })
     return hl.bold
   end
 

--- a/lua/avante/highlights.lua
+++ b/lua/avante/highlights.lua
@@ -53,7 +53,7 @@ local H = {}
 local M = {}
 
 local function has_set_colors(hl_group)
-  local hl = api.nvim_get_hl(0, { name = hl_group })
+  local hl = api.nvim_get_hl(0, { name = hl_group, link = false })
   return next(hl) ~= nil
 end
 

--- a/lua/avante/highlights.lua
+++ b/lua/avante/highlights.lua
@@ -69,10 +69,10 @@ function M.setup()
         if not has_set_colors(hl.name) then
           local bg = hl.bg
           local fg = hl.fg
-          if hl.bg_link ~= nil then bg = api.nvim_get_hl(0, { name = hl.bg_link }).bg end
-          if hl.fg_link ~= nil then fg = api.nvim_get_hl(0, { name = hl.fg_link }).fg end
-          if hl.bg_link_fg ~= nil then bg = api.nvim_get_hl(0, { name = hl.bg_link_fg }).fg end
-          if hl.fg_link_bg ~= nil then fg = api.nvim_get_hl(0, { name = hl.fg_link_bg }).bg end
+          if hl.bg_link ~= nil then bg = api.nvim_get_hl(0, { name = hl.bg_link, link = false }).bg end
+          if hl.fg_link ~= nil then fg = api.nvim_get_hl(0, { name = hl.fg_link, link = false }).fg end
+          if hl.bg_link_fg ~= nil then bg = api.nvim_get_hl(0, { name = hl.bg_link_fg, link = false }).fg end
+          if hl.fg_link_bg ~= nil then fg = api.nvim_get_hl(0, { name = hl.fg_link_bg, link = false }).bg end
           api.nvim_set_hl(
             0,
             hl.name,

--- a/lua/avante/utils/init.lua
+++ b/lua/avante/utils/init.lua
@@ -311,7 +311,7 @@ end
 ---@return table<string, string>
 function M.get_hl(name)
   if not name then return {} end
-  return api.nvim_get_hl(0, { name = name })
+  return api.nvim_get_hl(0, { name = name, link = false })
 end
 
 --- vendor from lazy.nvim for early access and override


### PR DESCRIPTION
If any of the avante highlight groups are configured as links to different highlight groups, then the internals of retrieving highlights and detecting background fallback stuff breaks. This makes sure to get the final highlight values of `fg/bg` rather than just `link = "x"`