### PR TITLE
refactor: utilize `Utils.get_hl` to minimize duplicate code

### DIFF
--- a/lua/avante/highlights.lua
+++ b/lua/avante/highlights.lua
@@ -52,10 +52,7 @@ local H = {}
 
 local M = {}
 
-local function has_set_colors(hl_group)
-  local hl = api.nvim_get_hl(0, { name = hl_group, link = false })
-  return next(hl) ~= nil
-end
+local function has_set_colors(hl_group) return next(Utils.get_hl(hl_group)) ~= nil end
 
 local first_setup = true
 local already_set_highlights = {}
@@ -73,10 +70,10 @@ function M.setup()
         if not already_set_highlights[hl.name] then
           local bg = hl.bg
           local fg = hl.fg
-          if hl.bg_link ~= nil then bg = api.nvim_get_hl(0, { name = hl.bg_link, link = false }).bg end
-          if hl.fg_link ~= nil then fg = api.nvim_get_hl(0, { name = hl.fg_link, link = false }).fg end
-          if hl.bg_link_fg ~= nil then bg = api.nvim_get_hl(0, { name = hl.bg_link_fg, link = false }).fg end
-          if hl.fg_link_bg ~= nil then fg = api.nvim_get_hl(0, { name = hl.fg_link_bg, link = false }).bg end
+          if hl.bg_link ~= nil then bg = Utils.get_hl(hl.bg_link).bg end
+          if hl.fg_link ~= nil then fg = Utils.get_hl(hl.fg_link).fg end
+          if hl.bg_link_fg ~= nil then bg = Utils.get_hl(hl.bg_link_fg).fg end
+          if hl.fg_link_bg ~= nil then fg = Utils.get_hl(hl.fg_link_bg).bg end
           api.nvim_set_hl(
             0,
             hl.name,
@@ -100,15 +97,9 @@ function M.setup_conflict_highlights()
   local custom_hls = Config.highlights.diff
 
   ---@return number | nil
-  local function get_bg(hl_name)
-    local hl = api.nvim_get_hl(0, { name = hl_name, link = false })
-    return hl.bg
-  end
+  local function get_bg(hl_name) return Utils.get_hl(hl_name).bg end
 
-  local function get_bold(hl_name)
-    local hl = api.nvim_get_hl(0, { name = hl_name, link = false })
-    return hl.bold
-  end
+  local function get_bold(hl_name) return Utils.get_hl(hl_name).bold end
 
   vim.iter(Highlights.conflict):each(function(key, hl)
     --- set none shade linked highlights first

--- a/lua/avante/utils/init.lua
+++ b/lua/avante/utils/init.lua
@@ -308,7 +308,7 @@ function M.is_valid_buf(bufnr)
 end
 
 ---@param name string?
----@return table<string, string>
+---@return table
 function M.get_hl(name)
   if not name then return {} end
   return api.nvim_get_hl(0, { name = name, link = false })


### PR DESCRIPTION
Follow up to #1682

Rather than duplicating the code for getting highlights without links. We can utilize the `avante.utils` module to simplify the code and improve maintainability.