### PR TITLE
feat: more robust sse content regex

### DIFF
--- a/lua/avante/llm.lua
+++ b/lua/avante/llm.lua
@@ -294,12 +294,12 @@ function M.curl(opts)
 
   ---@param line string
   local function parse_stream_data(line)
-    local event = line:match("^event: (.+)$")
+    local event = line:match("^event:%s*(.+)$")
     if event then
       current_event_state = event
       return
     end
-    local data_match = line:match("^data: (.+)$")
+    local data_match = line:match("^data:%s*(.+)$")
     if data_match then provider:parse_response(resp_ctx, data_match, current_event_state, handler_opts) end
   end
 


### PR DESCRIPTION
this pull request makes avante.nvim support the following two kinds of sse format:
```
event: something
event:something
data: something
data:something
```

currently,  avante.nvim only supports sse like following:
```
event: something
data: something
```
some claude provider will remove the space after sse type, which makes  avante.nvim won't be able to render the content.

related issue: https://github.com/yetone/avante.nvim/issues/1403