### PR TITLE
improve: support to customize the keymaps for cancelling the editing

### DIFF
--- a/README.md
+++ b/README.md
@@ -366,6 +366,10 @@ _See [config.lua#L9](./lua/avante/config.lua) for the full config_
       normal = "<CR>",
       insert = "<C-s>",
     },
+    cancel = {
+      normal = { "<C-c>", "<Esc>", "q" },
+      insert = { "<C-c>" },
+    },
     sidebar = {
       apply_all = "A",
       apply_cursor = "a",

--- a/lua/avante/config.lua
+++ b/lua/avante/config.lua
@@ -383,6 +383,10 @@ M._defaults = {
       normal = "<CR>",
       insert = "<C-s>",
     },
+    cancel = {
+      normal = { "<C-c>", "<Esc>", "q" },
+      insert = { "<C-c>" },
+    },
     -- NOTE: The following will be safely set by avante.nvim
     ask = "<leader>aa",
     edit = "<leader>ae",

--- a/lua/avante/ui/prompt_input.lua
+++ b/lua/avante/ui/prompt_input.lua
@@ -268,8 +268,12 @@ function PromptInput:setup_keymaps()
     { buffer = bufnr, noremap = true, silent = true }
   )
 
-  vim.keymap.set("n", "<Esc>", function() self:cancel() end, { buffer = bufnr })
-  vim.keymap.set("n", "q", function() self:cancel() end, { buffer = bufnr })
+  for _, key in ipairs(Config.mappings.cancel.normal) do
+    vim.keymap.set("n", key, function() self:cancel() end, { buffer = bufnr })
+  end
+  for _, key in ipairs(Config.mappings.cancel.insert) do
+    vim.keymap.set("i", key, function() self:cancel() end, { buffer = bufnr })
+  end
 end
 
 function PromptInput:setup_autocmds()


### PR DESCRIPTION
The `<esc>` on normal mode is inconvenient for me since I have a bad habit of pressing the `<esc>` multipe times to ensure back to normal mode. So I want to have a chance to customize the `cancel` keymaps.