### PR TITLE
fix: buffer selection logic to include all listed buffers

### DIFF
--- a/lua/avante/file_selector.lua
+++ b/lua/avante/file_selector.lua
@@ -421,9 +421,11 @@ end
 function FileSelector:add_buffer_files()
   local buffers = vim.api.nvim_list_bufs()
   for _, bufnr in ipairs(buffers) do
-    if vim.api.nvim_buf_is_loaded(bufnr) then
+    -- Skip invalid or unlisted buffers
+    if vim.api.nvim_buf_is_valid(bufnr) and vim.bo[bufnr].buflisted then
       local filepath = vim.api.nvim_buf_get_name(bufnr)
-      if filepath and filepath ~= "" and not has_scheme(filepath) then
+      -- Skip empty paths and special buffers (like terminals)
+      if filepath ~= "" and not has_scheme(filepath) then
         local relative_path = Utils.relative_path(filepath)
         self:add_selected_file(relative_path)
       end


### PR DESCRIPTION
This PR fixes an issue where valid buffers weren't being correctly added to the file selector. 

Previously, we were only checking if buffers were loaded, but this missed buffers that were valid but not visible in a window. The fix changes the condition from `vim.api.nvim_buf_is_loaded()` to a combination of `vim.api.nvim_buf_is_valid()` and `vim.bo[bufnr].buflisted`, ensuring we capture all appropriate buffers regardless of their visibility status.
