### PR TITLE
feat: add command to include all buffer files in file selector

### DIFF
--- a/lua/avante/api.lua
+++ b/lua/avante/api.lua
@@ -237,6 +237,16 @@ function M.select_history()
   end)
 end
 
+function M.add_buffer_files()
+  local sidebar = require("avante").get()
+  if not sidebar then
+    require("avante.api").ask()
+    sidebar = require("avante").get()
+  end
+  if not sidebar:is_open() then sidebar:open({}) end
+  sidebar.file_selector:add_buffer_files()
+end
+
 function M.stop() require("avante.llm").cancel_inflight_request() end
 
 return setmetatable(M, {

--- a/lua/avante/config.lua
+++ b/lua/avante/config.lua
@@ -416,6 +416,7 @@ M._defaults = {
     },
     files = {
       add_current = "<leader>ac", -- Add current buffer to selected files
+      add_all_buffers = "<leader>aB", -- Add all buffer files to selected files
     },
     select_model = "<leader>a?", -- Select model command
     select_history = "<leader>ah", -- Select history command

--- a/lua/avante/file_selector.lua
+++ b/lua/avante/file_selector.lua
@@ -77,7 +77,7 @@ end
 function FileSelector:new(id)
   return setmetatable({
     id = id,
-    selected_files = {},
+    selected_filepaths = {},
     event_handlers = {},
   }, { __index = self })
 end

--- a/lua/avante/init.lua
+++ b/lua/avante/init.lua
@@ -149,6 +149,13 @@ function H.keymaps()
       function() require("avante.api").select_history() end,
       { desc = "avante: select history" }
     )
+
+    Utils.safe_keymap_set(
+      "n",
+      Config.mappings.files.add_all_buffers,
+      function() require("avante.api").add_buffer_files() end,
+      { desc = "avante: add all open buffers" }
+    )
   end
 
   if Config.behaviour.auto_suggestions then


### PR DESCRIPTION
This PR exposes `FileSelector:add_buffer_files()` to be used in keyboard mapping. 

It introduces a new API function `add_buffer_files()`, a dedicated keycap `<leader>aB`, and fixes an inconsistent property naming issue between `selected_files` and `selected_filepaths`.

The idea is to streamline the workflow where one opens Neovim, loads the session with open buffers and immediately wants to start a conversation with the open files.

I'm not sure if specifying the keymap (`<leader>aB`) in the plugin is the best idea, so I'm open to suggestions to maybe just leave the functionality exposed without the keymap as it's easy to set in the config.
