### PR TITLE
Resolve AWS credentials using default credentials provider chain for Bedrock

### DIFF
--- a/README.md
+++ b/README.md
@@ -561,12 +561,16 @@ Given its early stage, `avante.nvim` currently supports the following basic func
 >
 > For Amazon Bedrock:
 >
-> ```sh
-> export BEDROCK_KEYS=aws_access_key_id,aws_secret_access_key,aws_region[,aws_session_token]
+> Bedrock tries to resolve AWS credentials using the [Default Credentials Provider Chain](https://docs.aws.amazon.com/cli/v1/userguide/cli-chap-authentication.html).
+> This means you can have credentials e.g. configured via the AWS CLI, stored in your ~/.aws/profile, use AWS SSO etc.
+> Of course you can also set the regular [AWS environement variables](https://docs.aws.amazon.com/cli/v1/userguide/cli-configure-envvars.html) if preferred:
 >
+> ```sh
+> export AWS_ACCESS_KEY_ID=<access-key-id>
+> export AWS_SECRET_ACCESS_KEY=<secret-access-key>
 > ```
 >
-> Note: The aws_session_token is optional and only needed when using temporary AWS credentials
+> Note: Bedrock requires the [AWS CLI](https://aws.amazon.com/cli/) to be installed on your system.
 
 1. Open a code file in Neovim.
 2. Use the `:AvanteAsk` command to query the AI about the code.

--- a/README.md
+++ b/README.md
@@ -561,13 +561,24 @@ Given its early stage, `avante.nvim` currently supports the following basic func
 >
 > For Amazon Bedrock:
 >
-> Bedrock tries to resolve AWS credentials using the [Default Credentials Provider Chain](https://docs.aws.amazon.com/cli/v1/userguide/cli-chap-authentication.html).
-> This means you can have credentials e.g. configured via the AWS CLI, stored in your ~/.aws/profile, use AWS SSO etc.
-> Of course you can also set the regular [AWS environement variables](https://docs.aws.amazon.com/cli/v1/userguide/cli-configure-envvars.html) if preferred:
+> You can specify the `BEDROCK_KEYS` environment variable to set credentials. When this variable is not specified, bedrock will use the default AWS credentials chain (see below).
 >
 > ```sh
-> export AWS_ACCESS_KEY_ID=<access-key-id>
-> export AWS_SECRET_ACCESS_KEY=<secret-access-key>
+> export BEDROCK_KEYS=aws_access_key_id,aws_secret_access_key,aws_region[,aws_session_token]
+> ```
+>
+> Note: The aws_session_token is optional and only needed when using temporary AWS credentials
+>
+> Alternatively Bedrock tries to resolve AWS credentials using the [Default Credentials Provider Chain](https://docs.aws.amazon.com/cli/v1/userguide/cli-chap-authentication.html).
+> This means you can have credentials e.g. configured via the AWS CLI, stored in your ~/.aws/profile, use AWS SSO etc.
+> In this case `aws_region` and optionally `aws_profile` should be specified via the bedrock config, e.g.:
+>
+> ```lua
+> bedrock = {
+>   model = "us.anthropic.claude-3-5-sonnet-20241022-v2:0",
+>   aws_profile = "bedrock",
+>   aws_region = "us-east-1",
+>},
 > ```
 >
 > Note: Bedrock requires the [AWS CLI](https://aws.amazon.com/cli/) to be installed on your system.

--- a/lua/avante/config.lua
+++ b/lua/avante/config.lua
@@ -256,6 +256,8 @@ M._defaults = {
     timeout = 30000, -- Timeout in milliseconds
     temperature = 0,
     max_tokens = 20480,
+    aws_region = "", -- AWS region to use for authentication and bedrock API
+    aws_profile = "", -- AWS profile to use for authentication, if unspecified uses default credentials chain
   },
   ---@type AvanteSupportedProvider
   gemini = {
@@ -625,6 +627,8 @@ M.BASE_PROVIDER_KEYS = {
   "api_key_name",
   "timeout",
   "display_name",
+  "aws_region",
+  "aws_profile",
   -- internal
   "local",
   "_shellenv",

--- a/tests/providers/bedrock_spec.lua
+++ b/tests/providers/bedrock_spec.lua
@@ -1,0 +1,43 @@
+local bedrock_provider = require("avante.providers.bedrock")
+
+describe("bedrock_provider", function()
+  describe("check_curl_version_supports_aws_sig", function()
+    it(
+      "should return true for curl version 8.10.0",
+      function()
+        assert.is_true(
+          bedrock_provider.check_curl_version_supports_aws_sig(
+            "curl 8.10.0 (x86_64-pc-linux-gnu) libcurl/7.68.0 OpenSSL/1.1.1f zlib/1.2.11 brotli/1.0.7 libidn2/2.2.0 libpsl/0.21.0 (+libidn2/2.2.0) libssh2/1.8.0 nghttp2/1.40.0 librtmp/2.3"
+          )
+        )
+      end
+    )
+
+    it(
+      "should return true for curl version higher than 8.10.0",
+      function()
+        assert.is_true(
+          bedrock_provider.check_curl_version_supports_aws_sig(
+            "curl 8.11.0 (aarch64-apple-darwin23.6.0) libcurl/8.11.0 OpenSSL/3.4.0 (SecureTransport) zlib/1.2.12 brotli/1.1.0 zstd/1.5.6 AppleIDN libssh2/1.11.1 nghttp2/1.64.0 librtmp/2.3"
+          )
+        )
+      end
+    )
+
+    it(
+      "should return false for curl version lower than 8.10.0",
+      function()
+        assert.is_false(
+          bedrock_provider.check_curl_version_supports_aws_sig(
+            "curl 7.68.0 (x86_64-pc-linux-gnu) libcurl/7.68.0 OpenSSL/1.1.1f zlib/1.2.11 brotli/1.0.7 libidn2/2.2.0 libpsl/0.21.0 (+libidn2/2.2.0) libssh2/1.8.0 nghttp2/1.40.0 librtmp/2.3"
+          )
+        )
+      end
+    )
+
+    it(
+      "should return false for invalid version string",
+      function() assert.is_false(bedrock_provider.check_curl_version_supports_aws_sig("Invalid version string")) end
+    )
+  end)
+end)


### PR DESCRIPTION
This switches to resolving AWS credentials using the default AWS
credentials provider chain.

This has the advantage that AWS credentials are resolved in the same way
as other AWS tools do. It also supports more mechanisms now like AWS
profiles, AWS authentication via single-sign on and more.

It is a breaking change for bedrock users, as the old `BEDROCK_KEYS` env
var will no longer work, however it gives much more flexibility in terms
of authentication.

I have used this in my custom provider for quite some time successfully: https://gitlab.com/msvechla/avante-provider-bedrock.nvim

Let me know if you have some thoughts on this or other improvements ideas.

Thanks a lot!