### PR TITLE
fix: correct max_tokens for Claude 3.5 Haiku

### DIFF
--- a/lua/avante/config.lua
+++ b/lua/avante/config.lua
@@ -285,7 +285,7 @@ M._defaults = {
       model = "claude-3-5-haiku-20241022",
       timeout = 30000, -- Timeout in milliseconds
       temperature = 0,
-      max_tokens = 20480,
+      max_tokens = 8192,
     },
     ---@type AvanteSupportedProvider
     ["claude-opus"] = {


### PR DESCRIPTION
The maximum token output for Haiku is 8192 tokens, see [here](https://docs.anthropic.com/en/docs/about-claude/models/all-models). Currently, if you attempt to use this provider, you get an error response from the API call.