### PR TITLE
fix(wsl): wsl should prefer the defined shell instead of powershell.exe

### DIFF
--- a/lua/avante/utils/init.lua
+++ b/lua/avante/utils/init.lua
@@ -96,9 +96,6 @@ local function get_cmd_for_shell(input_cmd, shell_cmd)
   -- powershell then we can just run the cmd
   if shell:match("powershell") or shell:match("pwsh") then
     cmd = input_cmd
-  elseif fn.has("wsl") > 0 then
-    -- wsl: powershell.exe -Command 'command "/path"'
-    cmd = "powershell.exe -NoProfile -Command '" .. input_cmd:gsub("'", '"') .. "'"
   elseif fn.has("win32") > 0 then
     cmd = 'powershell.exe -NoProfile -Command "' .. input_cmd:gsub('"', "'") .. '"'
   else


### PR DESCRIPTION
Resolves #1553

Tested with running `biome` in a React Native config which doesn't just result in Powershell error anymore

Before
![image](https://github.com/user-attachments/assets/9ed3ec0d-ffca-41b4-9b0b-a7b9e37a2b6f)
![image](https://github.com/user-attachments/assets/b37d5250-11b6-43f6-9523-88c6bd5fde0a)

After
![image](https://github.com/user-attachments/assets/b312eff5-3d93-4c8e-955a-18f05bd88fb8)
![image](https://github.com/user-attachments/assets/9b6212cf-6865-4a5f-94b3-2713074315f8)

Typically the workflow for WSL users is everything dev-related within the Linux system itself, powershell is rarely touched. This could be a config option in the user to configure the shell for the tool to use.