### PR TITLE
fix: update gemini max_tokens and use gemini-2.0-flash model

### DIFF
--- a/lua/avante/config.lua
+++ b/lua/avante/config.lua
@@ -237,10 +237,10 @@ M._defaults = {
   ---@type AvanteSupportedProvider
   gemini = {
     endpoint = "https://generativelanguage.googleapis.com/v1beta/models",
-    model = "gemini-1.5-flash-latest",
+    model = "gemini-2.0-flash",
     timeout = 30000, -- Timeout in milliseconds
     temperature = 0,
-    max_tokens = 20480,
+    max_tokens = 8192,
   },
   ---@type AvanteSupportedProvider
   vertex = {


### PR DESCRIPTION
docs ref for max output tokens:
https://ai.google.dev/gemini-api/docs/models#gemini-2.0-flash

Token limits[*]

Input token limit
1,048,576

Output token limit
8,192