### PR TITLE
*DRAFT* feat: enable ai to add/remove files via tools with confirmation

### DIFF
--- a/lua/avante/config.lua
+++ b/lua/avante/config.lua
@@ -354,6 +354,7 @@ M._defaults = {
     enable_cursor_planning_mode = false,
     enable_claude_text_editor_tool_mode = false,
     use_cwd_as_project_root = false,
+    auto_add_files_confirmation = true, -- Confirm before automatically adding files requested by the AI tool
   },
   history = {
     max_tokens = 4096,

--- a/lua/avante/sidebar.lua
+++ b/lua/avante/sidebar.lua
@@ -2526,35 +2526,6 @@ function Sidebar:create_input_container(opts)
     local history_messages = Utils.history.entries_to_llm_messages(entries)
 
     local tools = vim.deepcopy(LLMTools.get_tools(request, history_messages))
-    table.insert(tools, {
-      name = "add_file_to_context",
-      description = "Add a file to the context",
-      ---@type AvanteLLMToolFunc<{ rel_path: string }>
-      func = function(input)
-        self.file_selector:add_selected_file(input.rel_path)
-        return "Added file to context", nil
-      end,
-      param = {
-        type = "table",
-        fields = { { name = "rel_path", description = "Relative path to the file", type = "string" } },
-      },
-      returns = {},
-    })
-
-    table.insert(tools, {
-      name = "remove_file_from_context",
-      description = "Remove a file from the context",
-      ---@type AvanteLLMToolFunc<{ rel_path: string }>
-      func = function(input)
-        self.file_selector:remove_selected_file(input.rel_path)
-        return "Removed file from context", nil
-      end,
-      param = {
-        type = "table",
-        fields = { { name = "rel_path", description = "Relative path to the file", type = "string" } },
-      },
-      returns = {},
-    })
 
     local mode = "planning"
     if Config.behaviour.enable_cursor_planning_mode then mode = "cursor-planning" end
@@ -2819,7 +2790,7 @@ function Sidebar:create_input_container(opts)
         on_chunk = on_chunk,
         on_stop = on_stop,
         on_tool_log = on_tool_log,
-        session_ctx = {},
+        session_ctx = { sidebar = self }, -- Pass sidebar instance to tools
       })
 
       local function on_memory_summarize(dropped_history_messages)

--- a/lua/avante/templates/planning.avanterules
+++ b/lua/avante/templates/planning.avanterules
@@ -8,15 +8,10 @@ Always reply to the user in the same language they are using.
 
 Once you understand the request you MUST:
 
-1. Decide if you need to propose *SEARCH/REPLACE* edits to any files that haven't been added to the chat. You can create new files without asking!
-
-But if you need to propose edits to existing files not already added to the chat, you *MUST* tell the user their full path names and ask them to *add the files to the chat*.
-End your reply and wait for their approval.
-You can keep asking if you then decide you need to edit more files.
-
-2. Think step-by-step and explain the needed changes in a few short sentences.
-
-3. Describe each change with a *SEARCH/REPLACE block* per the examples below.
+1.  **Identify Necessary Files:** Determine which files need to be read or modified to fulfill the request. Check the `<selected_files>` list provided in the context.
+2.  **Add Missing Files:** If a file required for reading or modification is *not* in the `<selected_files>` list, use the `add_file_to_context` tool *before* proceeding with the plan. Wait for the tool to confirm the file has been added. Do *not* ask the user to add files manually. If the tool reports an error (e.g., file not found), inform the user. You can create new files using *SEARCH/REPLACE* blocks without using the tool first.
+3.  **Plan Changes:** Think step-by-step and explain the needed changes in a few short sentences.
+4.  **Generate Edits:** Describe each change using a *SEARCH/REPLACE block* per the examples below. Ensure the `<FILEPATH>` in the block matches a file present in the `<selected_files>` context (either initially provided or added via the tool).
 
 All changes to files must use this *SEARCH/REPLACE block* format, including creating new files.
 ONLY EVER RETURN CODE IN A *SEARCH/REPLACE BLOCK*!
@@ -138,7 +133,7 @@ Break large *SEARCH/REPLACE* blocks into a series of smaller blocks that each ch
 Include just the changing lines, and a few surrounding lines if needed for uniqueness.
 Do not include long runs of unchanging lines in *SEARCH/REPLACE* blocks.
 ONLY change the <code>, DO NOT change the <context>!
-Only create *SEARCH/REPLACE* blocks for files that the user has added to the chat!
+Only create *SEARCH/REPLACE* blocks for files that are listed in the `<selected_files>` context!
 
 To move code within a file, use 2 *SEARCH/REPLACE* blocks: 1 to delete it from its current location, 1 to insert it in the new location.
 


### PR DESCRIPTION
In Aider user is asked if they want to add extra files to the context. Currently in Avante user is just notified and needs to do that themselves. In my experience I'm then doing one of two things:

- adding these files manually
- realizing that AI is not doing what I want and editing the prompt so steer it in the right direction

In cases when the extra files are needed in the context it would be nice if the files were added automatically.
This PR does exactly that. 
I'm testing it for the last few days and I don't see any issues with backwards compatibility but still occasionally find instances where AI tries to modify a file outside of context.

I would love input on these changes if anyone is willing to test them.

Changes in this PR:

1. **Added LLM Tool Functions**:
   - Implemented `add_file_to_context` and `remove_file_from_context` functions in `lua/avante/llm_tools/init.lua`
   - These tools allow the AI to programmatically add or remove files from the context

2. **Added Confirmation Setting**:
   - Added a new configuration option in `config.lua`: `auto_add_files_confirmation = true`
   - This setting controls whether the user needs to confirm before the AI adds files to the context

3. **Moved Tool Implementation**:
   - Removed the tool definitions from `sidebar.lua` and moved them to the `llm_tools/init.lua` file
   - This centralizes the tool definitions in one location

4. **Added Context Sharing**:
   - Updated the sidebar to pass `{ sidebar = self }` as `session_ctx` to provide tools access to the sidebar instance

5. **Updated Planning Template**:
   - Modified `planning.avanterules` to instruct the AI to use the `add_file_to_context` tool instead of asking users to manually add files
   - Changed the workflow from "ask user to add files" to "use tool to add files with user confirmation"

The main improvement is that the AI can now directly add files to the context (with optional user confirmation) instead of asking the user to manually add them, creating a more streamlined workflow.
