### PR TITLE
Close avante sidebar before vimexit (fixes sessions)

### DIFF
--- a/lua/avante/init.lua
+++ b/lua/avante/init.lua
@@ -236,9 +236,7 @@ function H.autocmds()
     group = H.augroup,
     callback = function()
       local current_buf = vim.api.nvim_get_current_buf()
-      if Utils.is_sidebar_buffer(current_buf) then
-        return
-      end
+      if Utils.is_sidebar_buffer(current_buf) then return end
 
       local non_sidebar_wins = 0
       local sidebar_wins = {}

--- a/lua/avante/init.lua
+++ b/lua/avante/init.lua
@@ -232,6 +232,36 @@ function H.autocmds()
     end,
   })
 
+  api.nvim_create_autocmd("QuitPre", {
+    group = H.augroup,
+    callback = function()
+      local current_buf = vim.api.nvim_get_current_buf()
+      if Utils.is_sidebar_buffer(current_buf) then
+        return
+      end
+
+      local non_sidebar_wins = 0
+      local sidebar_wins = {}
+      for _, win in ipairs(vim.api.nvim_list_wins()) do
+        if vim.api.nvim_win_is_valid(win) then
+          local win_buf = vim.api.nvim_win_get_buf(win)
+          if Utils.is_sidebar_buffer(win_buf) then
+            table.insert(sidebar_wins, win)
+          else
+            non_sidebar_wins = non_sidebar_wins + 1
+          end
+        end
+      end
+
+      if non_sidebar_wins <= 1 then
+        for _, win in ipairs(sidebar_wins) do
+          pcall(vim.api.nvim_win_close, win, false)
+        end
+      end
+    end,
+    nested = true,
+  })
+
   api.nvim_create_autocmd("TabClosed", {
     group = H.augroup,
     pattern = "*",


### PR DESCRIPTION
Small quality of life improvement, mostly for people who use sessions and/or don't want to have to `:qa` to exit if avante is open (me).

Before, if the Avante sidebar was open and you try to close the last open buffer, it closes the sidebar instead and blocks vim exit with an error. If you force quit `:qa!`, then if you restore the session you get a bunch of dead windows.

Fixed these issues by just adding an autocmd on QuitPre to check if the last non avante sidebar window is being closed, and if so gracefully close the sidebar first.

See vids for more context:

### Before

https://github.com/user-attachments/assets/9255e9e8-e85a-49a7-8179-8ca89bde8100

https://github.com/user-attachments/assets/56ebba5a-d26f-4dcf-bc95-325a56982b8c

### After

https://github.com/user-attachments/assets/96795423-fbe1-4c4c-9d23-7629330e556e


