### PR TITLE
Add support for searxng

### DIFF
--- a/README.md
+++ b/README.md
@@ -810,12 +810,13 @@ Avante's tools include some web search engines, currently support:
 - Google's [Programmable Search Engine](https://developers.google.com/custom-search/v1/overview)
 - [Kagi](https://help.kagi.com/kagi/api/search.html)
 - [Brave Search](https://api-dashboard.search.brave.com/app/documentation/web-search/get-started)
+- [SearXNG](https://searxng.github.io/searxng/)
 
 The default is Tavily, and can be changed through configuring `Config.web_search_engine.provider`:
 
 ```lua
 web_search_engine = {
-  provider = "tavily", -- tavily, serpapi, searchapi, google or kagi
+  provider = "tavily", -- tavily, serpapi, searchapi, google, kagi, brave, or searxng
   proxy = nil, -- proxy support, e.g., http://127.0.0.1:7890
 }
 ```
@@ -830,6 +831,7 @@ Environment variables required for providers:
   - `GOOGLE_SEARCH_ENGINE_ID` as the [search engine](https://programmablesearchengine.google.com) ID
 - Kagi: `KAGI_API_KEY` as the [API Token](https://kagi.com/settings?p=api)
 - Brave Search: `BRAVE_API_KEY` as the [API key](https://api-dashboard.search.brave.com/app/keys)
+- SearXNG: `SEARXNG_API_URL` as the [API URL](https://docs.searxng.org/dev/search_api.html)
 
 ## Disable Tools
 

--- a/README_zh.md
+++ b/README_zh.md
@@ -807,14 +807,14 @@ Avante 的工具包括一些 Web 搜索引擎，目前支持：
 - Google's [Programmable Search Engine](https://developers.google.com/custom-search/v1/overview)
 - [Kagi](https://help.kagi.com/kagi/api/search.html)
 - [Brave Search](https://api-dashboard.search.brave.com/app/documentation/web-search/get-started)
+- [SearXNG](https://searxng.github.io/searxng/)
 
 默认是 Tavily，可以通过配置 `Config.web_search_engine.provider` 进行更改：
 
 ```lua
 web_search_engine = {
-  provider = "tavily", -- tavily, serpapi, searchapi, google 或 kagi
+  provider = "tavily", -- tavily, serpapi, searchapi, google, kagi, brave 或 searxng
   proxy = nil, -- proxy support, e.g., http://127.0.0.1:7890
-
 }
 ```
 
@@ -828,6 +828,7 @@ web_search_engine = {
   - `GOOGLE_SEARCH_ENGINE_ID` 作为 [搜索引擎](https://programmablesearchengine.google.com) ID
 - Kagi: `KAGI_API_KEY` 作为 [API 令牌](https://kagi.com/settings?p=api)
 - Brave Search: `BRAVE_API_KEY` 作为 [API 密钥](https://api-dashboard.search.brave.com/app/keys)
+- SearXNG: `SEARXNG_API_URL` 作为 [API URL](https://docs.searxng.org/dev/search_api.html)
 
 ## 禁用工具
 

--- a/lua/avante/config.lua
+++ b/lua/avante/config.lua
@@ -194,6 +194,7 @@ M._defaults = {
         extra_request_body = {
           format = "json",
         },
+        ---@type WebSearchEngineProviderResponseBodyFormatter
         format_response_body = function(body)
           if body.results == nil then return "", nil end
 

--- a/lua/avante/config.lua
+++ b/lua/avante/config.lua
@@ -189,6 +189,27 @@ M._defaults = {
           return vim.json.encode(jsn), nil
         end,
       },
+      searxng = {
+        api_url_name = "SEARXNG_API_URL",
+        extra_request_body = {
+          format = "json",
+        },
+        format_response_body = function(body)
+          if body.web == nil then return "", nil end
+
+          local jsn = vim.iter(body.results):map(
+            function(result)
+              return {
+                title = result.title,
+                url = result.url,
+                snippet = result.content,
+              }
+            end
+          )
+
+          return vim.json.encode(jsn), nil
+        end,
+      },
     },
   },
   ---@type AvanteSupportedProvider

--- a/lua/avante/config.lua
+++ b/lua/avante/config.lua
@@ -195,7 +195,7 @@ M._defaults = {
           format = "json",
         },
         format_response_body = function(body)
-          if body.web == nil then return "", nil end
+          if body.results == nil then return "", nil end
 
           local jsn = vim.iter(body.results):map(
             function(result)


### PR DESCRIPTION
Adds support for the [SearXNG search api](https://docs.searxng.org/dev/search_api.html) to web_search tools.

This tool is a bit different from the other ones because it doesn't have an API key, but it does require you to set an api url (since it's usually a self-hosted thing).

- [x] Add SearXNG support to web search
- [x] Implement custom API URL handling and a SEARXNG_API_URL env var
- [x] Make API key optional for SearXNG provider
- [x] Response formatting for search results
- [x] Update docs

Closes #1370 