### PR TITLE
fix max_tokens for reasoning models

### DIFF
--- a/lua/avante/providers/openai.lua
+++ b/lua/avante/providers/openai.lua
@@ -67,6 +67,13 @@ function M.set_allowed_params(provider_conf, request_body)
   else
     request_body.reasoning_effort = nil
   end
+
+  if M.is_reasoning_model(provider_conf.model) then
+    if request_body.max_tokens then
+      request_body.max_completion_tokens = request_body.max_tokens
+      request_body.max_tokens = nil
+    end
+  end
 end
 
 function M:parse_messages(opts)


### PR DESCRIPTION
Copy `max_tokens` to `max_completion_tokens` for openai reasoning models

Fixes https://github.com/yetone/avante.nvim/issues/1762

Tested against my branch with `o3-mini`