### PR TITLE
feat: allow overriding img_paste options

### DIFF
--- a/lua/avante/clipboard.lua
+++ b/lua/avante/clipboard.lua
@@ -42,7 +42,7 @@ function M.paste_image(line)
     dir_path = paste_directory:absolute(),
     prompt_for_file_name = false,
     filetypes = {
-      AvanteInput = { url_encode_path = true, template = "\nimage: $FILE_PATH\n" },
+      AvanteInput = Config.img_paste,
     },
   }
 

--- a/lua/avante/config.lua
+++ b/lua/avante/config.lua
@@ -371,6 +371,10 @@ M._defaults = {
       incoming = nil,
     },
   },
+  img_paste = {
+    url_encode_path = true,
+    template = "\nimage: $FILE_PATH\n",
+  },
   mappings = {
     ---@class AvanteConflictMappings
     diff = {


### PR DESCRIPTION
Currently the **img_clip** options are hardcoded. I'd like to add the ability to update the options. Specifically the `url_encode_path` is not working for me, and I'd like to set this to `false` as well as update the `template`.