### PR TITLE
fix(blink.cmp): crash on run slash commands

### DIFF
--- a/lua/cmp_avante/commands.lua
+++ b/lua/cmp_avante/commands.lua
@@ -51,9 +51,15 @@ function CommandsSource:execute(item, callback)
 
   local sidebar = require("avante").get()
   command.callback(sidebar, nil, function()
-    local content = table.concat(api.nvim_buf_get_lines(sidebar.input_container.bufnr, 0, -1, false), "\n")
-    content = content:gsub(item.label, "")
-    api.nvim_buf_set_lines(sidebar.input_container.bufnr, 0, -1, false, vim.split(content, "\n"))
+    local bufnr = sidebar.input_container.bufnr ---@type integer
+    local content = table.concat(api.nvim_buf_get_lines(bufnr, 0, -1, false), "\n")
+    vim.defer_fn(function()
+      if vim.api.nvim_buf_is_valid(bufnr) then
+        local lines = vim.split(content:gsub(item.label, ""), "\n") ---@type string[]
+        api.nvim_buf_set_lines(bufnr, 0, -1, false, lines)
+      end
+    end, 20)
+
     callback()
   end)
 end

--- a/lua/cmp_avante/commands.lua
+++ b/lua/cmp_avante/commands.lua
@@ -53,13 +53,13 @@ function CommandsSource:execute(item, callback)
   command.callback(sidebar, nil, function()
     local bufnr = sidebar.input_container.bufnr ---@type integer
     local content = table.concat(api.nvim_buf_get_lines(bufnr, 0, -1, false), "\n")
+
     vim.defer_fn(function()
       if vim.api.nvim_buf_is_valid(bufnr) then
         local lines = vim.split(content:gsub(item.label, ""), "\n") ---@type string[]
-        api.nvim_buf_set_lines(bufnr, 0, -1, false, lines)
+        vim.api.nvim_buf_set_lines(bufnr, 0, -1, false, lines)
       end
-    end, 20)
-
+    end, 100)
     callback()
   end)
 end


### PR DESCRIPTION
I'm not sure of the reason, but based on my observations, `nvim-cmp` works well. However, with `blink.cmp`, the completion menu also functions properly, but once I select a command and accept it, Neovim exits immediately. I don't know how to view error messages; if you need them, please let me know.

The crash command caused by the `api.nvim_buf_set_lines(sidebar.input_container.bufnr, 0, -1, false, vim.split(content, "\n"))`