### PR TITLE
fix: Remove unnecessary CursorMovedI event handler

### DIFF
--- a/lua/avante/selection.lua
+++ b/lua/avante/selection.lua
@@ -311,7 +311,7 @@ function Selection:setup_autocmds()
     end,
   })
 
-  api.nvim_create_autocmd({ "CursorMoved", "CursorMovedI" }, {
+  api.nvim_create_autocmd({ "CursorMoved" }, {
     group = self.augroup,
     callback = function(ev)
       if not Utils.is_sidebar_buffer(ev.buf) then


### PR DESCRIPTION
This PR removes the redundant CursorMovedI event from the autocmd in the Selection:setup_autocmds() function. The event is unnecessary because:

1. Visual mode and Insert mode are mutually exclusive in Vim/Neovim
2. Mode transitions are already handled by the existing ModeChanged autocmd
3. The shortcuts popup is already properly closed when exiting visual mode

This change improves code maintainability without affecting functionality.
