### PR TITLE
feat(windows): add fillchars option for the windows

### DIFF
--- a/lua/avante/config.lua
+++ b/lua/avante/config.lua
@@ -463,6 +463,7 @@ M._defaults = {
   windows = {
     ---@alias AvantePosition "right" | "left" | "top" | "bottom" | "smart"
     position = "right",
+    fillchars = "eob: ",
     wrap = true, -- similar to vim.o.wrap
     width = 30, -- default % based on available width in vertical layout
     height = 30, -- default % based on available height in horizontal layout

--- a/lua/avante/sidebar.lua
+++ b/lua/avante/sidebar.lua
@@ -3231,6 +3231,7 @@ function Sidebar:create_selected_files_container()
     }),
     win_options = vim.tbl_deep_extend("force", base_win_options, {
       wrap = Config.windows.wrap,
+      fillchars = Config.windows.fillchars,
     }),
     position = "top",
     size = {

--- a/lua/avante/sidebar.lua
+++ b/lua/avante/sidebar.lua
@@ -3147,6 +3147,7 @@ function Sidebar:render(opts)
     }),
     win_options = vim.tbl_deep_extend("force", base_win_options, {
       wrap = Config.windows.wrap,
+      fillchars = Config.windows.fillchars,
     }),
     size = {
       width = self:get_result_container_width(),


### PR DESCRIPTION
the new config looks like following:

```
{
  windows = {
    fillchars = "eob: ",
  },
}
```