### PR TITLE
feat: add config for ollama keep alive

### DIFF
--- a/lua/avante/config.lua
+++ b/lua/avante/config.lua
@@ -288,6 +288,7 @@ M._defaults = {
     options = {
       temperature = 0,
       num_ctx = 20480,
+      keep_alive = "5m",
     },
   },
   ---@type AvanteSupportedProvider

--- a/lua/avante/providers/ollama.lua
+++ b/lua/avante/providers/ollama.lua
@@ -38,6 +38,7 @@ end
 ---@param prompt_opts AvantePromptOptions
 function M:parse_curl_args(prompt_opts)
   local provider_conf, request_body = P.parse_config(self)
+  local keep_alive = provider_conf.keep_alive or "5m"
 
   if not provider_conf.model or provider_conf.model == "" then error("Ollama model must be specified in config") end
   if not provider_conf.endpoint then error("Ollama requires endpoint configuration") end
@@ -53,6 +54,7 @@ function M:parse_curl_args(prompt_opts)
       messages = self:parse_messages(prompt_opts),
       stream = true,
       system = prompt_opts.system_prompt,
+      keep_alive = keep_alive,
     }, request_body),
   }
 end

--- a/lua/avante/types.lua
+++ b/lua/avante/types.lua
@@ -205,6 +205,7 @@ vim.g.avante_login = vim.g.avante_login
 ---@field model? string
 ---@field local? boolean
 ---@field proxy? string
+---@field keep_alive? string
 ---@field timeout? integer
 ---@field allow_insecure? boolean
 ---@field api_key_name? string


### PR DESCRIPTION
the default timeout (5m) isn't large enough for my use case. i would rather prefer to keep the model in memory for longer to avoid the process of reloading it.

this commit introduces the ollama `keep_alive` configuration, the default is set to 5 minutes (that is the default for ollama).