### PR TITLE
feat: add Bedrock Claude 3.7 Sonnet model configuration

### DIFF
--- a/lua/avante/config.lua
+++ b/lua/avante/config.lua
@@ -334,6 +334,11 @@ M._defaults = {
       model = "claude-3-7-sonnet-20250219",
       api_key_name = "AIHUBMIX_API_KEY",
     },
+    ["bedrock-claude-3.7-sonnet"] = {
+      __inherited_from = "bedrock",
+      model = "us.anthropic.claude-3-7-sonnet-20250219-v1:0",
+      max_tokens = 4096,
+    },
   },
   ---Specify the special dual_boost mode
   ---1. enabled: Whether to enable dual_boost mode. Default to false.


### PR DESCRIPTION
### Description
Bedrock Claude 3.7 use the same anthropic version. The tricky part is model id should use `us.anthropic.claude-3-7-sonnet-20250219-v1:0` in order for it to work. Hopefully this will solve the pain for bedrock users

```
{
  "modelId": "anthropic.claude-3-7-sonnet-20250219-v1:0",
  "contentType": "application/json",
  "accept": "application/json",
  "body": {
    "anthropic_version": "bedrock-2023-05-31",
    "max_tokens": 200,
    "top_k": 250,
    "stop_sequences": [],
    "temperature": 1,
    "top_p": 0.999,
    "messages": [
      {
        "role": "user",
        "content": [
          {
            "type": "text",
            "text": "hello world"
          }
        ]
      }
    ]
  }
}
```

### Test
- `<leader>a?` should be able to select the model
- be able to use the model in configuration too
```
opts = {
    -- add any opts here
    -- for example
    provider = "bedrock",
    bedrock = {
      model = "us.anthropic.claude-3-7-sonnet-20250219-v1:0"
    }
  }
```

