### PR TITLE
Fix get_opened_buffer_by_filepath comparison

### DIFF
--- a/README.md
+++ b/README.md
@@ -448,60 +448,26 @@ or you can use [Kaiser-Yang/blink-cmp-avante](https://github.com/Kaiser-Yang/bli
   <summary>Lua</summary>
 
 ```lua
-      file_selector = {
-        --- @alias FileSelectorProvider "native" | "fzf" | "mini.pick" | "snacks" | "telescope" | string | fun(params: avante.file_selector.IParams|nil): nil
+      selector = {
+        --- @alias avante.SelectorProvider "native" | "fzf_lua" | "mini_pick" | "snacks" | "telescope" | fun(selector: avante.ui.Selector): nil
         provider = "fzf",
         -- Options override for custom providers
         provider_opts = {},
       }
 ```
 
-To create a customized file_selector, you can specify a customized function to launch a picker to select items and pass the selected items to the `handler` callback.
+To create a customized selector provider, you can specify a customized function to launch a picker to select items and pass the selected items to the `on_select` callback.
 
 ```lua
-      file_selector = {
-        ---@param params avante.file_selector.IParams
-        provider = function(params)
-          local filepaths = params.filepaths ---@type string[]
-          local title = params.title ---@type string
-          local handler = params.handler ---@type fun(selected_filepaths: string[]|nil): nil
+      selector = {
+        ---@param selector avante.ui.Selector
+        provider = function(selector)
+          local items = selector.items ---@type avante.ui.SelectorItem[]
+          local title = selector.title ---@type string
+          local on_select = selector.on_select ---@type fun(selected_item_ids: string[]|nil): nil
 
-          -- Launch your customized picker with the items built from `filepaths`, then in the `on_confirm` callback,
-          -- pass the selected items (convert back to file paths) to the `handler` function.
-
-          local items = __your_items_formatter__(filepaths)
-          __your_picker__({
-            items = items,
-            on_cancel = function()
-              handler(nil)
-            end,
-            on_confirm = function(selected_items)
-              local selected_filepaths = {}
-              for _, item in ipairs(selected_items) do
-                table.insert(selected_filepaths, item.filepath)
-              end
-              handler(selected_filepaths)
-            end
-          })
+          --- your customized picker logic here
         end,
-        ---below is optional
-        provider_opts = {
-          ---@param params avante.file_selector.opts.IGetFilepathsParams
-          get_filepaths = function(params)
-            local cwd = params.cwd ---@type string
-            local selected_filepaths = params.selected_filepaths ---@type string[]
-            local cmd = string.format("fd --base-directory '%s' --hidden", vim.fn.fnameescape(cwd))
-            local output = vim.fn.system(cmd)
-            local filepaths = vim.split(output, "\n", { trimempty = true })
-            return vim
-              .iter(filepaths)
-              :filter(function(filepath)
-                return not vim.tbl_contains(selected_filepaths, filepath)
-              end)
-              :totable()
-          end
-        }
-        end
       }
 ```
 
@@ -708,6 +674,7 @@ return {
 | `:AvanteShowRepoMap`               | Show repo map for project's structure                                                                       |                                                     |
 | `:AvanteToggle`                    | Toggle the Avante sidebar                                                                                   |                                                     |
 | `:AvanteModels`                    | Show model list                                                                                             |                                                     |
+| `:AvanteSwitchSelectorProvider`    | Switch avante selector provider (e.g. native, telescope, fzf_lua, mini_pick, snacks)                        |                                                     |
 
 ## Highlight Groups
 

--- a/README_zh.md
+++ b/README_zh.md
@@ -448,60 +448,26 @@ _请参见 [config.lua#L9](./lua/avante/config.lua) 以获取完整配置_
   <summary>Lua</summary>
 
 ```lua
-      file_selector = {
-        --- @alias FileSelectorProvider "native" | "fzf" | "mini.pick" | "snacks" | "telescope" | string | fun(params: avante.file_selector.IParams|nil): nil
+      selector = {
+        --- @alias avante.SelectorProvider "native" | "fzf_lua" | "mini_pick" | "snacks" | "telescope" | fun(selector: avante.ui.Selector): nil
         provider = "fzf",
         -- 自定义提供者的选项覆盖
         provider_opts = {},
       }
 ```
 
-要创建自定义文件选择器，您可以指定一个自定义函数来启动选择器以选择项目，并将选定的项目传递给 `handler` 回调。
+要创建自定义选择器，您可以指定一个自定义函数来启动选择器以选择项目，并将选定的项目传递给 `on_select` 回调。
 
 ```lua
-      file_selector = {
-        ---@param params avante.file_selector.IParams
-        provider = function(params)
-          local filepaths = params.filepaths ---@type string[]
-          local title = params.title ---@type string
-          local handler = params.handler ---@type fun(selected_filepaths: string[]|nil): nil
+      selector = {
+        ---@param selector avante.ui.Selector
+        provider = function(selector)
+          local items = selector.items ---@type avante.ui.SelectorItem[]
+          local title = selector.title ---@type string
+          local on_select = selector.on_select ---@type fun(selected_item_ids: string[]|nil): nil
 
-          -- 使用从 `filepaths` 构建的项目启动自定义选择器，然后在 `on_confirm` 回调中，
-          -- 将选定的项目（转换回文件路径）传递给 `handler` 函数。
-
-          local items = __your_items_formatter__(filepaths)
-          __your_picker__({
-            items = items,
-            on_cancel = function()
-              handler(nil)
-            end,
-            on_confirm = function(selected_items)
-              local selected_filepaths = {}
-              for _, item in ipairs(selected_items) do
-                table.insert(selected_filepaths, item.filepath)
-              end
-              handler(selected_filepaths)
-            end
-          })
+          --- 在这里添加您的自定义选择器逻辑
         end,
-        ---以下是可选的
-        provider_opts = {
-          ---@param params avante.file_selector.opts.IGetFilepathsParams
-          get_filepaths = function(params)
-            local cwd = params.cwd ---@type string
-            local selected_filepaths = params.selected_filepaths ---@type string[]
-            local cmd = string.format("fd --base-directory '%s' --hidden", vim.fn.fnameescape(cwd))
-            local output = vim.fn.system(cmd)
-            local filepaths = vim.split(output, "\n", { trimempty = true })
-            return vim
-              .iter(filepaths)
-              :filter(function(filepath)
-                return not vim.tbl_contains(selected_filepaths, filepath)
-              end)
-              :totable()
-          end
-        }
-        end
       }
 ```
 

--- a/lua/avante/api.lua
+++ b/lua/avante/api.lua
@@ -11,10 +11,10 @@ local PromptInput = require("avante.ui.prompt_input")
 ---@field toggle avante.ApiToggle
 local M = {}
 
----@param target_provider FileSelectorProvider
-function M.switch_file_selector_provider(target_provider)
+---@param target_provider avante.SelectorProvider
+function M.switch_selector_provider(target_provider)
   require("avante.config").override({
-    file_selector = {
+    selector = {
       provider = target_provider,
     },
   })

--- a/lua/avante/config.lua
+++ b/lua/avante/config.lua
@@ -508,9 +508,13 @@ M._defaults = {
   },
   --- @class AvanteFileSelectorConfig
   file_selector = {
-    --- @alias FileSelectorProvider "native" | "fzf" | "mini.pick" | "snacks" | "telescope" | string | fun(params: avante.file_selector.IParams|nil): nil
-    provider = "native",
+    provider = nil,
     -- Options override for custom providers
+    provider_opts = {},
+  },
+  selector = {
+    ---@alias avante.SelectorProvider "native" | "fzf_lua" | "mini_pick" | "snacks" | "telescope" | fun(selector: avante.ui.Selector): nil
+    provider = "native",
     provider_opts = {},
   },
   suggestion = {

--- a/lua/avante/file_selector.lua
+++ b/lua/avante/file_selector.lua
@@ -2,6 +2,7 @@ local Utils = require("avante.utils")
 local Path = require("plenary.path")
 local scan = require("plenary.scandir")
 local Config = require("avante.config")
+local Selector = require("avante.ui.selector")
 
 local PROMPT_TITLE = "(Avante) Add a file"
 
@@ -168,7 +169,7 @@ function FileSelector:off(event, callback)
   end
 end
 
-function FileSelector:open() self:show_select_ui() end
+function FileSelector:open() self:show_selector_ui() end
 
 function FileSelector:get_filepaths()
   if type(Config.file_selector.provider_opts.get_filepaths) == "function" then
@@ -203,162 +204,56 @@ function FileSelector:get_filepaths()
     :totable()
 end
 
----@type FileSelectorHandler
-function FileSelector:fzf_ui(handler)
-  local success, fzf_lua = pcall(require, "fzf-lua")
-  if not success then
-    Utils.error("fzf-lua is not installed. Please install fzf-lua to use it as a file selector.")
-    return
-  end
-
-  local filepaths = self:get_filepaths()
-
-  local function close_action() handler(nil) end
-  fzf_lua.fzf_exec(
-    filepaths,
-    vim.tbl_deep_extend("force", {
-      prompt = string.format("%s> ", PROMPT_TITLE),
-      fzf_opts = {},
-      git_icons = false,
-      actions = {
-        ["default"] = function(selected)
-          if not selected or #selected == 0 then return close_action() end
-          ---@type string[]
-          local selections = {}
-          for _, entry in ipairs(selected) do
-            local file = fzf_lua.path.entry_to_file(entry)
-            if file and file.path then table.insert(selections, file.path) end
-          end
-
-          handler(selections)
-        end,
-        ["esc"] = close_action,
-        ["ctrl-c"] = close_action,
-      },
-    }, Config.file_selector.provider_opts)
-  )
-end
-
-function FileSelector:mini_pick_ui(handler)
-  -- luacheck: globals MiniPick
-  ---@diagnostic disable-next-line: undefined-field
-  if not _G.MiniPick then
-    Utils.error("mini.pick is not set up. Please install and set up mini.pick to use it as a file selector.")
-    return
-  end
-  local function choose(item) handler(type(item) == "string" and { item } or item) end
-  local function choose_marked(items_marked) handler(items_marked) end
-  local source = { choose = choose, choose_marked = choose_marked }
-  ---@diagnostic disable-next-line: undefined-global
-  local result = MiniPick.builtin.files(nil, { source = source })
-  if result == nil then handler(nil) end
-end
-
-function FileSelector:snacks_picker_ui(handler)
-  ---@diagnostic disable-next-line: undefined-field
-  if not _G.Snacks then
-    Utils.error("Snacks is not set up. Please install and set up Snacks to use it as a file selector.")
-    return
-  end
-  ---@diagnostic disable-next-line: undefined-global
-  Snacks.picker.files({
-    exclude = self.selected_filepaths,
-    confirm = function(picker)
-      picker:close()
-      local items = picker:selected({ fallback = true })
-      local files = vim.tbl_map(function(item) return item.file end, items)
-      handler(files)
-    end,
-  })
-end
-
-function FileSelector:telescope_ui(handler)
-  local success, _ = pcall(require, "telescope")
-  if not success then
-    Utils.error("telescope is not installed. Please install telescope to use it as a file selector.")
-    return
-  end
-
-  local pickers = require("telescope.pickers")
-  local finders = require("telescope.finders")
-  local conf = require("telescope.config").values
-  local actions = require("telescope.actions")
-  local action_state = require("telescope.actions.state")
-  local action_utils = require("telescope.actions.utils")
-
-  local files = self:get_filepaths()
-
-  pickers
-    .new(
-      {},
-      vim.tbl_extend("force", {
-        file_ignore_patterns = self.selected_filepaths,
-        prompt_title = string.format("%s> ", PROMPT_TITLE),
-        finder = finders.new_table(files),
-        sorter = conf.file_sorter(),
-        attach_mappings = function(prompt_bufnr, map)
-          map("i", "<esc>", require("telescope.actions").close)
-          actions.select_default:replace(function()
-            local picker = action_state.get_current_picker(prompt_bufnr)
-
-            if #picker:get_multi_selection() ~= 0 then
-              local selections = {}
-
-              action_utils.map_selections(prompt_bufnr, function(selection) table.insert(selections, selection[1]) end)
-
-              handler(selections)
-            else
-              local selections = action_state.get_selected_entry()
-
-              handler(selections)
-            end
-
-            actions.close(prompt_bufnr)
-          end)
-          return true
-        end,
-      }, Config.file_selector.provider_opts)
-    )
-    :find()
-end
-
-function FileSelector:native_ui(handler)
-  local filepaths = self:get_filepaths()
-
-  vim.ui.select(filepaths, {
-    prompt = string.format("%s:", PROMPT_TITLE),
-    format_item = function(item) return item end,
-  }, function(item)
-    if item then
-      handler({ item })
-    else
-      handler(nil)
-    end
-  end)
-end
-
 ---@return nil
-function FileSelector:show_select_ui()
+function FileSelector:show_selector_ui()
   local function handler(selected_paths) self:handle_path_selection(selected_paths) end
 
   vim.schedule(function()
-    if Config.file_selector.provider == "native" then
-      self:native_ui(handler)
-    elseif Config.file_selector.provider == "fzf" then
-      self:fzf_ui(handler)
-    elseif Config.file_selector.provider == "mini.pick" then
-      self:mini_pick_ui(handler)
-    elseif Config.file_selector.provider == "snacks" then
-      self:snacks_picker_ui(handler)
-    elseif Config.file_selector.provider == "telescope" then
-      self:telescope_ui(handler)
-    elseif type(Config.file_selector.provider) == "function" then
-      local title = string.format("%s:", PROMPT_TITLE) ---@type string
-      local filepaths = self:get_filepaths() ---@type string[]
-      local params = { title = title, filepaths = filepaths, handler = handler } ---@type avante.file_selector.IParams
-      Config.file_selector.provider(params)
+    if Config.file_selector.provider ~= nil then
+      Utils.warn("config.file_selector is deprecated, please use config.selector instead!")
+      if type(Config.file_selector.provider) == "function" then
+        local title = string.format("%s:", PROMPT_TITLE) ---@type string
+        local filepaths = self:get_filepaths() ---@type string[]
+        local params = { title = title, filepaths = filepaths, handler = handler } ---@type avante.file_selector.IParams
+        Config.file_selector.provider(params)
+      else
+        local provider = "native"
+        if Config.file_selector.provider == "native" then
+          provider = "native"
+        elseif Config.file_selector.provider == "fzf" then
+          provider = "fzf_lua"
+        elseif Config.file_selector.provider == "mini.pick" then
+          provider = "mini_pick"
+        elseif Config.file_selector.provider == "snacks" then
+          provider = "snacks"
+        elseif Config.file_selector.provider == "telescope" then
+          provider = "telescope"
+        elseif type(Config.file_selector.provider) == "function" then
+          provider = Config.file_selector.provider
+        end
+        ---@cast provider avante.SelectorProvider
+        local selector = Selector:new({
+          provider = provider,
+          title = PROMPT_TITLE,
+          items = vim.tbl_map(function(filepath) return { id = filepath, title = filepath } end, self:get_filepaths()),
+          default_item_id = self.selected_filepaths[1],
+          selected_item_ids = self.selected_filepaths,
+          provider_opts = Config.file_selector.provider_opts,
+          on_select = function(item_ids) self:handle_path_selection(item_ids) end,
+        })
+        selector:open()
+      end
     else
-      Utils.error("Unknown file selector provider: " .. Config.file_selector.provider)
+      local selector = Selector:new({
+        provider = Config.selector.provider,
+        title = PROMPT_TITLE,
+        items = vim.tbl_map(function(filepath) return { id = filepath, title = filepath } end, self:get_filepaths()),
+        default_item_id = self.selected_filepaths[1],
+        selected_item_ids = self.selected_filepaths,
+        provider_opts = Config.selector.provider_opts,
+        on_select = function(item_ids) self:handle_path_selection(item_ids) end,
+      })
+      selector:open()
     end
   end)
 

--- a/lua/avante/file_selector.lua
+++ b/lua/avante/file_selector.lua
@@ -217,6 +217,7 @@ function FileSelector:show_selector_ui()
         local params = { title = title, filepaths = filepaths, handler = handler } ---@type avante.file_selector.IParams
         Config.file_selector.provider(params)
       else
+        ---@type avante.SelectorProvider
         local provider = "native"
         if Config.file_selector.provider == "native" then
           provider = "native"

--- a/lua/avante/history_selector.lua
+++ b/lua/avante/history_selector.lua
@@ -1,5 +1,7 @@
 local Utils = require("avante.utils")
 local Path = require("avante.path")
+local Config = require("avante.config")
+local Selector = require("avante.ui.selector")
 
 ---@class avante.HistorySelector
 local M = {}
@@ -8,8 +10,10 @@ local M = {}
 ---@return table?
 local function to_selector_item(history)
   local timestamp = #history.entries > 0 and history.entries[#history.entries].timestamp or history.timestamp
+  local name = history.title .. " - " .. timestamp .. " (" .. #history.entries .. ")"
+  name = name:gsub("\n", "\\n")
   return {
-    name = history.title .. " - " .. timestamp .. " (" .. #history.entries .. ")",
+    name = name,
     filename = history.filename,
   }
 end
@@ -30,68 +34,33 @@ function M.open(bufnr, cb)
     return
   end
 
-  local has_telescope, _ = pcall(require, "telescope")
-  if has_telescope then
-    local pickers = require("telescope.pickers")
-    local finders = require("telescope.finders")
-    local previewers = require("telescope.previewers")
-    local actions = require("telescope.actions")
-    local action_state = require("telescope.actions.state")
-    local conf = require("telescope.config").values
-    pickers
-      .new({}, {
-        prompt_title = "Select Avante History",
-        finder = finders.new_table(vim.iter(selector_items):map(function(item) return item.name end):totable()),
-        sorter = conf.generic_sorter({}),
-        previewer = previewers.new_buffer_previewer({
-          title = "Preview",
-          define_preview = function(self, entry)
-            if not entry then return end
-            local item = vim.iter(selector_items):find(function(item) return item.name == entry.value end)
-            if not item then return end
-            local history = Path.history.load(vim.api.nvim_get_current_buf(), item.filename)
-            local Sidebar = require("avante.sidebar")
-            local content = Sidebar.render_history_content(history)
-            local lines = vim.split(content or "", "\n")
-            -- Ensure the buffer exists and is valid before setting lines
-            if vim.api.nvim_buf_is_valid(self.state.bufnr) then
-              vim.api.nvim_buf_set_lines(self.state.bufnr, 0, -1, false, lines)
-              -- Set filetype after content is loaded
-              vim.api.nvim_set_option_value("filetype", "markdown", { buf = self.state.bufnr })
-              -- Ensure cursor is within bounds
-              vim.schedule(function()
-                if vim.api.nvim_buf_is_valid(self.state.bufnr) then
-                  local row = math.min(vim.api.nvim_buf_line_count(self.state.bufnr), 1)
-                  pcall(vim.api.nvim_win_set_cursor, self.state.winnr, { row, 0 })
-                end
-              end)
-            end
-          end,
-        }),
-        attach_mappings = function(prompt_bufnr, map)
-          map("i", "<CR>", function()
-            local selection = action_state.get_selected_entry()
-            if selection then
-              actions.close(prompt_bufnr)
-              local item = vim.iter(selector_items):find(function(item) return item.name == selection.value end)
-              if not item then return end
-              cb(item.filename)
-            end
-          end)
-          return true
-        end,
-      })
-      :find()
-    return
-  end
-
-  vim.ui.select(selector_items, {
-    prompt = "Select Avante History:",
-    format_item = function(item) return item.name:gsub("\n", "\\n") end,
-  }, function(choice)
-    if not choice then return end
-    cb(choice.filename)
-  end)
+  local selector = Selector:new({
+    provider = Config.selector.provider,
+    title = "Select Avante History",
+    items = vim
+      .iter(selector_items)
+      :map(
+        function(item)
+          return {
+            id = item.filename,
+            title = item.name,
+          }
+        end
+      )
+      :totable(),
+    on_select = function(item_ids)
+      if not item_ids then return end
+      if #item_ids == 0 then return end
+      cb(item_ids[1])
+    end,
+    get_preview_content = function(item_id)
+      local history = Path.history.load(vim.api.nvim_get_current_buf(), item_id)
+      local Sidebar = require("avante.sidebar")
+      local content = Sidebar.render_history_content(history)
+      return content, "markdown"
+    end,
+  })
+  selector:open()
 end
 
 return M

--- a/lua/avante/llm.lua
+++ b/lua/avante/llm.lua
@@ -244,7 +244,7 @@ function M.generate_prompts(opts)
     if diagnostics ~= "" then table.insert(messages, { role = "user", content = diagnostics }) end
   end
 
-  if (opts.selected_files and #opts.selected_files > 0 or false) or opts.selected_code ~= nil then
+  if #selected_files > 0 or opts.selected_code ~= nil then
     local code_context = Path.prompts.render_file("_context.avanterules", template_opts)
     if code_context ~= "" then table.insert(messages, { role = "user", content = code_context }) end
   end

--- a/lua/avante/llm.lua
+++ b/lua/avante/llm.lua
@@ -184,10 +184,26 @@ function M.generate_prompts(opts)
 
   local system_info = Utils.get_system_info()
 
+  local selected_files = opts.selected_files or {}
+
+  if opts.selected_filepaths then
+    for _, filepath in ipairs(opts.selected_filepaths) do
+      local lines, error = Utils.read_file_from_buf_or_disk(filepath)
+      lines = lines or {}
+      local filetype = Utils.get_filetype(filepath)
+      if error ~= nil then
+        Utils.error("error reading file: " .. error)
+      else
+        local content = table.concat(lines, "\n")
+        table.insert(selected_files, { path = filepath, content = content, file_type = filetype })
+      end
+    end
+  end
+
   local template_opts = {
     ask = opts.ask, -- TODO: add mode without ask instruction
     code_lang = opts.code_lang,
-    selected_files = opts.selected_files,
+    selected_files = selected_files,
     selected_code = opts.selected_code,
     recently_viewed_files = opts.recently_viewed_files,
     project_context = opts.project_context,

--- a/lua/avante/llm_tools/helpers.lua
+++ b/lua/avante/llm_tools/helpers.lua
@@ -91,6 +91,32 @@ function M.already_in_context(path)
   return false
 end
 
+---@param path string
+---@param session_ctx table
+---@return boolean
+function M.already_viewed(path, session_ctx)
+  local view_history = session_ctx.view_history or {}
+  local uniform_path = Utils.uniform_path(path)
+  if view_history[uniform_path] then return true end
+  return false
+end
+
+---@param path string
+---@param session_ctx table
+function M.mark_as_viewed(path, session_ctx)
+  local view_history = session_ctx.view_history or {}
+  local uniform_path = Utils.uniform_path(path)
+  view_history[uniform_path] = true
+  session_ctx.view_history = view_history
+end
+
+function M.mark_as_not_viewed(path, session_ctx)
+  local view_history = session_ctx.view_history or {}
+  local uniform_path = Utils.uniform_path(path)
+  view_history[uniform_path] = nil
+  session_ctx.view_history = view_history
+end
+
 ---@param abs_path string
 ---@return integer bufnr
 ---@return string | nil error

--- a/lua/avante/llm_tools/init.lua
+++ b/lua/avante/llm_tools/init.lua
@@ -104,14 +104,17 @@ function M.rename_file(opts, on_log, on_complete)
   end
   if Path:new(new_abs_path):exists() then return false, "File already exists: " .. new_abs_path end
   if not on_complete then return false, "on_complete not provided" end
-  Helpers.confirm("Are you sure you want to rename the file: " .. abs_path .. " to: " .. new_abs_path, function(ok)
-    if not ok then
-      on_complete(false, "User canceled")
-      return
+  Helpers.confirm(
+    "Are you sure you want to rename the file: " .. abs_path .. " to: " .. new_abs_path,
+    function(ok, reason)
+      if not ok then
+        on_complete(false, "User declined, reason: " .. (reason or "unknown"))
+        return
+      end
+      os.rename(abs_path, new_abs_path)
+      on_complete(true, nil)
     end
-    os.rename(abs_path, new_abs_path)
-    on_complete(true, nil)
-  end)
+  )
 end
 
 ---@type AvanteLLMToolFunc<{ rel_path: string, new_rel_path: string }>
@@ -137,9 +140,9 @@ function M.delete_file(opts, on_log, on_complete)
   if not Path:new(abs_path):exists() then return false, "File not found: " .. abs_path end
   if not Path:new(abs_path):is_file() then return false, "Path is not a file: " .. abs_path end
   if not on_complete then return false, "on_complete not provided" end
-  Helpers.confirm("Are you sure you want to delete the file: " .. abs_path, function(ok)
+  Helpers.confirm("Are you sure you want to delete the file: " .. abs_path, function(ok, reason)
     if not ok then
-      on_complete(false, "User canceled")
+      on_complete(false, "User declined, reason: " .. (reason or "unknown"))
       return
     end
     if on_log then on_log("Deleting file: " .. abs_path) end
@@ -154,9 +157,9 @@ function M.create_dir(opts, on_log, on_complete)
   if not Helpers.has_permission_to_access(abs_path) then return false, "No permission to access path: " .. abs_path end
   if Path:new(abs_path):exists() then return false, "Directory already exists: " .. abs_path end
   if not on_complete then return false, "on_complete not provided" end
-  Helpers.confirm("Are you sure you want to create the directory: " .. abs_path, function(ok)
+  Helpers.confirm("Are you sure you want to create the directory: " .. abs_path, function(ok, reason)
     if not ok then
-      on_complete(false, "User canceled")
+      on_complete(false, "User declined, reason: " .. (reason or "unknown"))
       return
     end
     if on_log then on_log("Creating directory: " .. abs_path) end
@@ -179,9 +182,9 @@ function M.rename_dir(opts, on_log, on_complete)
   if not on_complete then return false, "on_complete not provided" end
   Helpers.confirm(
     "Are you sure you want to rename directory " .. abs_path .. " to " .. new_abs_path .. "?",
-    function(ok)
+    function(ok, reason)
       if not ok then
-        on_complete(false, "User canceled")
+        on_complete(false, "User declined, reason: " .. (reason or "unknown"))
         return
       end
       if on_log then on_log("Renaming directory: " .. abs_path .. " to " .. new_abs_path) end
@@ -198,9 +201,9 @@ function M.delete_dir(opts, on_log, on_complete)
   if not Path:new(abs_path):exists() then return false, "Directory not found: " .. abs_path end
   if not Path:new(abs_path):is_dir() then return false, "Path is not a directory: " .. abs_path end
   if not on_complete then return false, "on_complete not provided" end
-  Helpers.confirm("Are you sure you want to delete the directory: " .. abs_path, function(ok)
+  Helpers.confirm("Are you sure you want to delete the directory: " .. abs_path, function(ok, reason)
     if not ok then
-      on_complete(false, "User canceled")
+      on_complete(false, "User declined, reason: " .. (reason or "unknown"))
       return
     end
     if on_log then on_log("Deleting directory: " .. abs_path) end
@@ -462,9 +465,9 @@ function M.git_commit(opts, on_log, on_complete)
   if not on_complete then return false, "on_complete not provided" end
 
   -- Confirm with user
-  Helpers.confirm("Are you sure you want to commit with message:\n" .. full_commit_msg, function(ok)
+  Helpers.confirm("Are you sure you want to commit with message:\n" .. full_commit_msg, function(ok, reason)
     if not ok then
-      on_complete(false, "User canceled")
+      on_complete(false, "User declined, reason: " .. (reason or "unknown"))
       return
     end
     -- Stage changes if scope is provided
@@ -530,9 +533,9 @@ function M.python(opts, on_log, on_complete)
       .. abs_path
       .. "`?\n"
       .. opts.code,
-    function(ok)
+    function(ok, reason)
       if not ok then
-        on_complete(nil, "User canceled")
+        on_complete(nil, "User declined, reason: " .. (reason or "unknown"))
         return
       end
       if vim.fn.executable("docker") == 0 then

--- a/lua/avante/llm_tools/insert.lua
+++ b/lua/avante/llm_tools/insert.lua
@@ -84,6 +84,8 @@ function M.func(opts, on_log, on_complete, session_ctx)
       return
     end
     vim.api.nvim_buf_set_lines(bufnr, opts.insert_line, opts.insert_line, false, new_lines)
+    vim.api.nvim_buf_call(bufnr, function() vim.cmd("noautocmd write") end)
+    if session_ctx then Helpers.mark_as_not_viewed(opts.path, session_ctx) end
     on_complete(true, nil)
   end, { focus = true }, session_ctx)
 end

--- a/lua/avante/llm_tools/str_replace.lua
+++ b/lua/avante/llm_tools/str_replace.lua
@@ -148,6 +148,7 @@ function M.func(opts, on_log, on_complete, session_ctx)
         on_complete(false, "User canceled")
         return
       end
+      if session_ctx then Helpers.mark_as_not_viewed(opts.path, session_ctx) end
       on_complete(true, nil)
     end,
   })
@@ -163,6 +164,7 @@ function M.func(opts, on_log, on_complete, session_ctx)
     end
     vim.api.nvim_buf_set_lines(bufnr, start_line - 1, end_line, false, new_lines)
     vim.api.nvim_buf_call(bufnr, function() vim.cmd("noautocmd write") end)
+    if session_ctx then Helpers.mark_as_not_viewed(opts.path, session_ctx) end
     on_complete(true, nil)
   end, { focus = not Config.behaviour.auto_focus_on_diff_view }, session_ctx)
 end

--- a/lua/avante/llm_tools/view.lua
+++ b/lua/avante/llm_tools/view.lua
@@ -81,14 +81,11 @@ function M.func(opts, on_log, on_complete, session_ctx)
     return
   end
   if session_ctx then
-    local view_history = session_ctx.view_history or {}
-    local uniform_path = Utils.uniform_path(opts.path)
-    if view_history[uniform_path] then
+    if Helpers.already_viewed(opts.path, session_ctx) then
       on_complete(nil, "Ooooops! You have already viewed this file! Why you are trying to read it again?")
       return
     end
-    view_history[uniform_path] = true
-    session_ctx.view_history = view_history
+    Helpers.mark_as_viewed(opts.path, session_ctx)
   end
   local abs_path = Helpers.get_abs_path(opts.path)
   if not Helpers.has_permission_to_access(abs_path) then return false, "No permission to access path: " .. abs_path end

--- a/lua/avante/sidebar.lua
+++ b/lua/avante/sidebar.lua
@@ -2472,8 +2472,6 @@ function Sidebar:create_input_container(opts)
 
     local project_context = mentions.enable_project_context and file_ext and RepoMap.get_repo_map(file_ext) or nil
 
-    local selected_files_contents = self.file_selector:get_selected_files_contents() or {}
-
     local diagnostics = nil
     if mentions.enable_diagnostics then
       if self.code ~= nil and self.code.bufnr ~= nil and self.code.selection ~= nil then
@@ -2530,11 +2528,13 @@ function Sidebar:create_input_container(opts)
 
     if Config.behaviour.enable_claude_text_editor_tool_mode then mode = "claude-text-editor-tool" end
 
+    local selected_filepaths = self.file_selector.selected_filepaths or {}
+
     ---@type AvanteGeneratePromptsOptions
     local prompts_opts = {
       ask = opts.ask or true,
       project_context = vim.json.encode(project_context),
-      selected_files = selected_files_contents,
+      selected_filepaths = selected_filepaths,
       recently_viewed_files = Utils.get_recent_filepaths(),
       diagnostics = vim.json.encode(diagnostics),
       history_messages = history_messages,

--- a/lua/avante/types.lua
+++ b/lua/avante/types.lua
@@ -314,6 +314,7 @@ vim.g.avante_login = vim.g.avante_login
 ---@field selected_code AvanteSelectedCode | nil
 ---@field project_context string | nil
 ---@field selected_files AvanteSelectedFile[] | nil
+---@field selected_filepaths string[] | nil
 ---@field diagnostics string | nil
 ---@field history_messages AvanteLLMMessage[] | nil
 ---@field memory string | nil

--- a/lua/avante/ui/confirm.lua
+++ b/lua/avante/ui/confirm.lua
@@ -361,7 +361,6 @@ function M:close()
     self._popup = nil
     return true
   end
-  if self._ns_id then vim.api.nvim_del_namespace(self._ns_id) end
   return false
 end
 

--- a/lua/avante/ui/selector/init.lua
+++ b/lua/avante/ui/selector/init.lua
@@ -1,0 +1,55 @@
+local Utils = require("avante.utils")
+
+---@class avante.ui.SelectorItem
+---@field id string
+---@field title string
+
+---@class avante.ui.SelectorOption
+---@field provider avante.SelectorProvider
+---@field title string
+---@field items avante.ui.SelectorItem[]
+---@field default_item_id string | nil
+---@field selected_item_ids string[] | nil
+---@field provider_opts table | nil
+---@field on_select fun(item_ids: string[] | nil)
+---@field get_preview_content fun(item_id: string): (string, string) | nil
+
+---@class avante.ui.Selector
+---@field provider avante.SelectorProvider
+---@field title string
+---@field items avante.ui.SelectorItem[]
+---@field default_item_id string | nil
+---@field provider_opts table | nil
+---@field on_select fun(item_ids: string[] | nil)
+---@field selected_item_ids string[] | nil
+---@field get_preview_content fun(item_id: string): (string, string) | nil
+local Selector = {}
+Selector.__index = Selector
+
+---@param opts avante.ui.SelectorOption
+function Selector:new(opts)
+  local o = {}
+  setmetatable(o, Selector)
+  o.provider = opts.provider
+  o.title = opts.title
+  o.items = opts.items
+  o.default_item_id = opts.default_item_id
+  o.provider_opts = opts.provider_opts or {}
+  o.on_select = opts.on_select
+  o.selected_item_ids = opts.selected_item_ids or {}
+  o.get_preview_content = opts.get_preview_content
+  return o
+end
+
+function Selector:open()
+  if type(self.provider) == "function" then
+    self.provider(self)
+    return
+  end
+
+  local ok, provider = pcall(require, "avante.ui.selector.providers." .. self.provider)
+  if not ok then Utils.error("Unknown file selector provider: " .. self.provider) end
+  provider.show(self)
+end
+
+return Selector

--- a/lua/avante/ui/selector/providers/fzf_lua.lua
+++ b/lua/avante/ui/selector/providers/fzf_lua.lua
@@ -1,0 +1,49 @@
+local Utils = require("avante.utils")
+local M = {}
+
+---@param selector avante.ui.Selector
+function M.show(selector)
+  local success, fzf_lua = pcall(require, "fzf-lua")
+  if not success then
+    Utils.error("fzf-lua is not installed. Please install fzf-lua to use it as a file selector.")
+    return
+  end
+
+  local formated_items = vim.iter(selector.items):map(function(item) return item.title end):totable()
+  local title_to_id = {}
+  for _, item in ipairs(selector.items) do
+    title_to_id[item.title] = item.id
+  end
+
+  local function close_action() selector.on_select(nil) end
+  fzf_lua.fzf_exec(
+    formated_items,
+    vim.tbl_deep_extend("force", {
+      prompt = selector.title,
+      preview = selector.get_preview_content and function(item)
+        local id = title_to_id[item[1]]
+        local content = selector.get_preview_content(id)
+        return content
+      end or nil,
+      fzf_opts = {},
+      git_icons = false,
+      actions = {
+        ["default"] = function(selected)
+          if not selected or #selected == 0 then return close_action() end
+          ---@type string[]
+          local selections = {}
+          for _, entry in ipairs(selected) do
+            local id = title_to_id[entry]
+            if id then table.insert(selections, id) end
+          end
+
+          selector.on_select(selections)
+        end,
+        ["esc"] = close_action,
+        ["ctrl-c"] = close_action,
+      },
+    }, selector.provider_opts)
+  )
+end
+
+return M

--- a/lua/avante/ui/selector/providers/mini_pick.lua
+++ b/lua/avante/ui/selector/providers/mini_pick.lua
@@ -1,0 +1,37 @@
+local Utils = require("avante.utils")
+local M = {}
+
+---@param selector avante.ui.Selector
+function M.show(selector)
+  -- luacheck: globals MiniPick
+  ---@diagnostic disable-next-line: undefined-field
+  if not _G.MiniPick then
+    Utils.error("mini.pick is not set up. Please install and set up mini.pick to use it as a file selector.")
+    return
+  end
+  local items = {}
+  local title_to_id = {}
+  for _, item in ipairs(selector.items) do
+    title_to_id[item.title] = item.id
+    if not vim.list_contains(selector.selected_item_ids, item.id) then table.insert(items, item) end
+  end
+  local function choose(item)
+    if not item then
+      selector.on_select(nil)
+      return
+    end
+    local item_ids = {}
+    ---item is not a list
+    for _, item_ in pairs(item) do
+      table.insert(item_ids, title_to_id[item_])
+    end
+    selector.on_select(item_ids)
+  end
+  ---@diagnostic disable-next-line: undefined-global
+  MiniPick.ui_select(items, {
+    prompt = selector.title,
+    format_item = function(item) return item.title end,
+  }, choose)
+end
+
+return M

--- a/lua/avante/ui/selector/providers/native.lua
+++ b/lua/avante/ui/selector/providers/native.lua
@@ -1,0 +1,21 @@
+local M = {}
+
+---@param selector avante.ui.Selector
+function M.show(selector)
+  local items = {}
+  for _, item in ipairs(selector.items) do
+    if not vim.list_contains(selector.selected_item_ids, item.id) then table.insert(items, item) end
+  end
+  vim.ui.select(items, {
+    prompt = selector.title,
+    format_item = function(item) return item.title end,
+  }, function(item)
+    if item then
+      selector.on_select({ item.id })
+    else
+      selector.on_select(nil)
+    end
+  end)
+end
+
+return M

--- a/lua/avante/ui/selector/providers/snacks.lua
+++ b/lua/avante/ui/selector/providers/snacks.lua
@@ -1,0 +1,58 @@
+local Utils = require("avante.utils")
+local M = {}
+
+---@param selector avante.ui.Selector
+function M.show(selector)
+  ---@diagnostic disable-next-line: undefined-field
+  if not _G.Snacks then
+    Utils.error("Snacks is not set up. Please install and set up Snacks to use it as a file selector.")
+    return
+  end
+  local finder_items = {}
+  for i, item in ipairs(selector.items) do
+    if not vim.list_contains(selector.selected_item_ids, item.id) then
+      table.insert(finder_items, {
+        formatted = item.title,
+        text = item.title,
+        item = item,
+        idx = i,
+        preview = selector.get_preview_content and (function()
+          local content, filetype = selector.get_preview_content(item.id)
+          return {
+            text = content,
+            ft = filetype,
+          }
+        end)() or nil,
+      })
+    end
+  end
+  local completed = false
+  ---@diagnostic disable-next-line: undefined-global
+  Snacks.picker.pick({
+    source = "select",
+    items = finder_items,
+    ---@diagnostic disable-next-line: undefined-global
+    format = Snacks.picker.format.ui_select(nil, #finder_items),
+    title = selector.title,
+    preview = selector.get_preview_content and "preview" or nil,
+    layout = {
+      preset = "default",
+      preview = selector.get_preview_content ~= nil,
+    },
+    confirm = function(picker)
+      if completed then return end
+      completed = true
+      picker:close()
+      local items = picker:selected({ fallback = true })
+      local selected_item_ids = vim.tbl_map(function(item) return item.item.id end, items)
+      selector.on_select(selected_item_ids)
+    end,
+    on_close = function()
+      if completed then return end
+      completed = true
+      vim.schedule(function() selector.on_select(nil) end)
+    end,
+  })
+end
+
+return M

--- a/lua/avante/ui/selector/providers/telescope.lua
+++ b/lua/avante/ui/selector/providers/telescope.lua
@@ -1,0 +1,92 @@
+local Utils = require("avante.utils")
+
+local M = {}
+
+---@param selector avante.ui.Selector
+function M.show(selector)
+  local success, _ = pcall(require, "telescope")
+  if not success then
+    Utils.error("telescope is not installed. Please install telescope to use it as a file selector.")
+    return
+  end
+
+  local pickers = require("telescope.pickers")
+  local finders = require("telescope.finders")
+  local conf = require("telescope.config").values
+  local actions = require("telescope.actions")
+  local action_state = require("telescope.actions.state")
+  local previewers = require("telescope.previewers")
+
+  local items = {}
+  for _, item in ipairs(selector.items) do
+    if not vim.list_contains(selector.selected_item_ids, item.id) then table.insert(items, item) end
+  end
+
+  pickers
+    .new(
+      {},
+      vim.tbl_extend("force", {
+        prompt_title = selector.title,
+        finder = finders.new_table({
+          results = items,
+          entry_maker = function(entry)
+            return {
+              value = entry.id,
+              display = entry.title,
+              ordinal = entry.title,
+            }
+          end,
+        }),
+        sorter = conf.file_sorter(),
+        previewer = selector.get_preview_content and previewers.new_buffer_previewer({
+          title = "Preview",
+          define_preview = function(self, entry)
+            if not entry then return end
+            local content, filetype = selector.get_preview_content(entry.value)
+            local lines = vim.split(content or "", "\n")
+            -- Ensure the buffer exists and is valid before setting lines
+            if vim.api.nvim_buf_is_valid(self.state.bufnr) then
+              vim.api.nvim_buf_set_lines(self.state.bufnr, 0, -1, false, lines)
+              -- Set filetype after content is loaded
+              vim.api.nvim_set_option_value("filetype", filetype, { buf = self.state.bufnr })
+              -- Ensure cursor is within bounds
+              vim.schedule(function()
+                if vim.api.nvim_buf_is_valid(self.state.bufnr) then
+                  local row = math.min(vim.api.nvim_buf_line_count(self.state.bufnr), 1)
+                  pcall(vim.api.nvim_win_set_cursor, self.state.winnr, { row, 0 })
+                end
+              end)
+            end
+          end,
+        }),
+        attach_mappings = function(prompt_bufnr, map)
+          map("i", "<esc>", require("telescope.actions").close)
+          actions.select_default:replace(function()
+            local picker = action_state.get_current_picker(prompt_bufnr)
+
+            local selections
+            local multi_selection = picker:get_multi_selection()
+            if #multi_selection ~= 0 then
+              selections = multi_selection
+            else
+              selections = action_state.get_selected_entry()
+              selections = vim.islist(selections) and selections or { selections }
+            end
+
+            local selected_item_ids = vim
+              .iter(selections)
+              :map(function(selection) return selection.value end)
+              :totable()
+
+            selector.on_select(selected_item_ids)
+
+            actions.close(prompt_bufnr)
+          end)
+          return true
+        end,
+      }, selector.provider_opts)
+    )
+    :find()
+end
+
+return M

--- a/lua/avante/utils/init.lua
+++ b/lua/avante/utils/init.lua
@@ -630,7 +630,7 @@ function M.winline(winid)
   return line
 end
 
-function M.get_project_root() return M.root.get() end
+function M.get_project_root() return vim.fn.getcwd() end
 
 function M.is_same_file_ext(target_ext, filepath)
   local ext = fn.fnamemodify(filepath, ":e")

--- a/plugin/avante.lua
+++ b/plugin/avante.lua
@@ -122,11 +122,11 @@ cmd("SwitchProvider", function(opts) require("avante.api").switch_provider(vim.t
   end,
 })
 cmd(
-  "SwitchFileSelectorProvider",
-  function(opts) require("avante.api").switch_file_selector_provider(vim.trim(opts.args or "")) end,
+  "SwitchSelectorProvider",
+  function(opts) require("avante.api").switch_selector_provider(vim.trim(opts.args or "")) end,
   {
     nargs = 1,
-    desc = "avante: switch file selector provider",
+    desc = "avante: switch selector provider",
   }
 )
 cmd("Clear", function(opts)


### PR DESCRIPTION
# Pull Request Description
## Summary
This pull request addresses an issue with the buffer path matching logic in the codebase. The previous implementation used the `M.join_paths` function to construct a path by combining the `project_root` and the buffer name (`bufname`). However, this approach did not always produce the correct full path to the buffer. The `absolute_path` variable, on the other hand, contained the correct file path.

## Changes Made
- **Updated Buffer Matching Logic**: 
  - Replaced the exact path match using `M.join_paths` with a more flexible substring search.
  - The new logic checks if the `bufname` is a non-empty string and is included within the `absolute_path`.
  - This change ensures that the buffer is correctly identified by matching the buffer name against the correct file path.
## Code Changes
```lua
for _, buf in ipairs(api.nvim_list_bufs()) do
  - if M.join_paths(project_root, fn.bufname(buf)) == absolute_path then return buf end
  + if fn.bufname(buf) ~= "" and string.find(absolute_path, fn.bufname(buf)) then return buf end
end
```
---