### PR TITLE
Remove advertising from commit messages

### DIFF
--- a/lua/avante/llm_tools/bash.lua
+++ b/lua/avante/llm_tools/bash.lua
@@ -33,7 +33,8 @@ local banned_commands = {
 M.get_description = function()
   local provider = Providers[Config.provider]
   if Config.provider:match("copilot") and provider.model and provider.model:match("gpt") then
-    return [[Executes a given bash command in a persistent shell session with optional timeout, ensuring proper handling and security measures. Do not use bash command to read or modify files, or you will be fired!]]
+    return
+    [[Executes a given bash command in a persistent shell session with optional timeout, ensuring proper handling and security measures. Do not use bash command to read or modify files, or you will be fired!]]
   end
 
   local res = ([[Executes a given bash command in a persistent shell session with optional timeout, ensuring proper handling and security measures.
@@ -103,17 +104,10 @@ When the user asks you to create a new git commit, follow these steps carefully:
 - Review the draft message to ensure it accurately reflects the changes and their purpose
 </commit_analysis>
 
-4. Create the commit with a message ending with:
-🤖 Generated with [avante.nvim](https://github.com/yetone/avante.nvim)
-Co-Authored-By: avante.nvim <noreply-avante@yetone.ai>
-
 - In order to ensure good formatting, ALWAYS pass the commit message via a HEREDOC, a la this example:
 <example>
 git commit -m "$(cat <<'EOF'
    Commit message here.
-
-   🤖 Generated with [avante.nvim](https://github.com/yetone/avante.nvim)
-   Co-Authored-By: avante.nvim <noreply-avante@yetone.ai>
    EOF
    )"
 </example>
@@ -175,7 +169,6 @@ gh pr create --title "the pr title" --body "$(cat <<'EOF'
 ## Test plan
 [Checklist of TODOs for testing the pull request...]
 
-🤖 Generated with [avante.nvim](https://github.com/yetone/avante.nvim)
 EOF
 )"
 </example>

--- a/lua/avante/llm_tools/bash.lua
+++ b/lua/avante/llm_tools/bash.lua
@@ -33,8 +33,7 @@ local banned_commands = {
 M.get_description = function()
   local provider = Providers[Config.provider]
   if Config.provider:match("copilot") and provider.model and provider.model:match("gpt") then
-    return
-    [[Executes a given bash command in a persistent shell session with optional timeout, ensuring proper handling and security measures. Do not use bash command to read or modify files, or you will be fired!]]
+    return [[Executes a given bash command in a persistent shell session with optional timeout, ensuring proper handling and security measures. Do not use bash command to read or modify files, or you will be fired!]]
   end
 
   local res = ([[Executes a given bash command in a persistent shell session with optional timeout, ensuring proper handling and security measures.

--- a/lua/avante/llm_tools/init.lua
+++ b/lua/avante/llm_tools/init.lua
@@ -525,11 +525,11 @@ function M.python(opts, on_log, on_complete)
   if not on_complete then return nil, "on_complete not provided" end
   Helpers.confirm(
     "Are you sure you want to run the following python code in the `"
-    .. container_image
-    .. "` container, in the directory: `"
-    .. abs_path
-    .. "`?\n"
-    .. opts.code,
+      .. container_image
+      .. "` container, in the directory: `"
+      .. abs_path
+      .. "`?\n"
+      .. opts.code,
     function(ok, reason)
       if not ok then
         on_complete(nil, "User declined, reason: " .. (reason or "unknown"))
@@ -583,17 +583,17 @@ function M.get_tools(user_input, history_messages)
   ---@type AvanteLLMTool[]
   local unfiltered_tools = vim.list_extend(vim.list_extend({}, M._tools), custom_tools)
   return vim
-      .iter(unfiltered_tools)
-      :filter(function(tool) ---@param tool AvanteLLMTool
-        -- Always disable tools that are explicitly disabled
-        if vim.tbl_contains(Config.disabled_tools, tool.name) then return false end
-        if tool.enabled == nil then
-          return true
-        else
-          return tool.enabled({ user_input = user_input, history_messages = history_messages })
-        end
-      end)
-      :totable()
+    .iter(unfiltered_tools)
+    :filter(function(tool) ---@param tool AvanteLLMTool
+      -- Always disable tools that are explicitly disabled
+      if vim.tbl_contains(Config.disabled_tools, tool.name) then return false end
+      if tool.enabled == nil then
+        return true
+      else
+        return tool.enabled({ user_input = user_input, history_messages = history_messages })
+      end
+    end)
+    :totable()
 end
 
 ---@type AvanteLLMTool[]
@@ -603,8 +603,7 @@ M._tools = {
   {
     name = "rag_search",
     enabled = function() return Config.rag_service.enabled and RagService.is_ready() end,
-    description =
-    "Use Retrieval-Augmented Generation (RAG) to search for relevant information from an external knowledge base or documents. This tool retrieves relevant context from a large dataset and integrates it into the response generation process, improving accuracy and relevance. Use it when answering questions that require factual knowledge beyond what the model has been trained on.",
+    description = "Use Retrieval-Augmented Generation (RAG) to search for relevant information from an external knowledge base or documents. This tool retrieves relevant context from a large dataset and integrates it into the response generation process, improving accuracy and relevance. Use it when answering questions that require factual knowledge beyond what the model has been trained on.",
     param = {
       type = "table",
       fields = {
@@ -757,8 +756,7 @@ M._tools = {
   require("avante.llm_tools.undo_edit"),
   {
     name = "read_global_file",
-    description =
-    "Read the contents of a file in the global scope. If the file content is already in the context, do not use this tool.",
+    description = "Read the contents of a file in the global scope. If the file content is already in the context, do not use this tool.",
     enabled = function(opts)
       if opts.user_input:match("@read_global_file") then return true end
       for _, message in ipairs(opts.history_messages) do
@@ -1047,8 +1045,7 @@ M._tools = {
   },
   {
     name = "read_definitions",
-    description =
-    "Retrieves the complete source code definitions of any symbol (function, type, constant, etc.) from your codebase.",
+    description = "Retrieves the complete source code definitions of any symbol (function, type, constant, etc.) from your codebase.",
     param = {
       type = "table",
       fields = {

--- a/lua/avante/llm_tools/init.lua
+++ b/lua/avante/llm_tools/init.lua
@@ -451,7 +451,7 @@ function M.git_commit(opts, on_log, on_complete)
   for line in opts.message:gmatch("[^\r\n]+") do
     commit_msg_lines[#commit_msg_lines + 1] = line:gsub('"', '\\"')
   end
-
+  commit_msg_lines[#commit_msg_lines + 1] = ""
   if git_user ~= "" and git_email ~= "" then
     commit_msg_lines[#commit_msg_lines + 1] = string.format("Signed-off-by: %s <%s>", git_user, git_email)
   end

--- a/lua/avante/llm_tools/init.lua
+++ b/lua/avante/llm_tools/init.lua
@@ -452,9 +452,6 @@ function M.git_commit(opts, on_log, on_complete)
     commit_msg_lines[#commit_msg_lines + 1] = line:gsub('"', '\\"')
   end
 
-  commit_msg_lines[#commit_msg_lines + 1] = ""
-  commit_msg_lines[#commit_msg_lines + 1] = "🤖 Generated with [avante.nvim](https://github.com/yetone/avante.nvim)"
-  commit_msg_lines[#commit_msg_lines + 1] = "Co-Authored-By: avante.nvim <noreply-avante@yetone.ai>"
   if git_user ~= "" and git_email ~= "" then
     commit_msg_lines[#commit_msg_lines + 1] = string.format("Signed-off-by: %s <%s>", git_user, git_email)
   end
@@ -528,11 +525,11 @@ function M.python(opts, on_log, on_complete)
   if not on_complete then return nil, "on_complete not provided" end
   Helpers.confirm(
     "Are you sure you want to run the following python code in the `"
-      .. container_image
-      .. "` container, in the directory: `"
-      .. abs_path
-      .. "`?\n"
-      .. opts.code,
+    .. container_image
+    .. "` container, in the directory: `"
+    .. abs_path
+    .. "`?\n"
+    .. opts.code,
     function(ok, reason)
       if not ok then
         on_complete(nil, "User declined, reason: " .. (reason or "unknown"))
@@ -586,17 +583,17 @@ function M.get_tools(user_input, history_messages)
   ---@type AvanteLLMTool[]
   local unfiltered_tools = vim.list_extend(vim.list_extend({}, M._tools), custom_tools)
   return vim
-    .iter(unfiltered_tools)
-    :filter(function(tool) ---@param tool AvanteLLMTool
-      -- Always disable tools that are explicitly disabled
-      if vim.tbl_contains(Config.disabled_tools, tool.name) then return false end
-      if tool.enabled == nil then
-        return true
-      else
-        return tool.enabled({ user_input = user_input, history_messages = history_messages })
-      end
-    end)
-    :totable()
+      .iter(unfiltered_tools)
+      :filter(function(tool) ---@param tool AvanteLLMTool
+        -- Always disable tools that are explicitly disabled
+        if vim.tbl_contains(Config.disabled_tools, tool.name) then return false end
+        if tool.enabled == nil then
+          return true
+        else
+          return tool.enabled({ user_input = user_input, history_messages = history_messages })
+        end
+      end)
+      :totable()
 end
 
 ---@type AvanteLLMTool[]
@@ -606,7 +603,8 @@ M._tools = {
   {
     name = "rag_search",
     enabled = function() return Config.rag_service.enabled and RagService.is_ready() end,
-    description = "Use Retrieval-Augmented Generation (RAG) to search for relevant information from an external knowledge base or documents. This tool retrieves relevant context from a large dataset and integrates it into the response generation process, improving accuracy and relevance. Use it when answering questions that require factual knowledge beyond what the model has been trained on.",
+    description =
+    "Use Retrieval-Augmented Generation (RAG) to search for relevant information from an external knowledge base or documents. This tool retrieves relevant context from a large dataset and integrates it into the response generation process, improving accuracy and relevance. Use it when answering questions that require factual knowledge beyond what the model has been trained on.",
     param = {
       type = "table",
       fields = {
@@ -759,7 +757,8 @@ M._tools = {
   require("avante.llm_tools.undo_edit"),
   {
     name = "read_global_file",
-    description = "Read the contents of a file in the global scope. If the file content is already in the context, do not use this tool.",
+    description =
+    "Read the contents of a file in the global scope. If the file content is already in the context, do not use this tool.",
     enabled = function(opts)
       if opts.user_input:match("@read_global_file") then return true end
       for _, message in ipairs(opts.history_messages) do
@@ -1048,7 +1047,8 @@ M._tools = {
   },
   {
     name = "read_definitions",
-    description = "Retrieves the complete source code definitions of any symbol (function, type, constant, etc.) from your codebase.",
+    description =
+    "Retrieves the complete source code definitions of any symbol (function, type, constant, etc.) from your codebase.",
     param = {
       type = "table",
       fields = {


### PR DESCRIPTION
## Summary
- Remove advertising links and co-author tag from commit messages

As it is mentioned in #1831 most people don't see the value in advertising avante in git commits and having to manually edit each commit after the tool is wasting time. 

Plus It could cause trouble for people working in production environments 

Edit: From this pr I also realized that generated with avante.nvim message sticks in PRs as well which could cause a bigger issue since the edits are public

## Test plan
- [x] Create a commit using avante.nvim
- [x] Verify commit message does not contain advertising/co-author lines

🤖 Generated with [avante.nvim](https://github.com/yetone/avante.nvim)