### PR TITLE
Fix find next on diff view

### DIFF
--- a/lua/avante/diff.lua
+++ b/lua/avante/diff.lua
@@ -494,7 +494,7 @@ end
 function M.find_next(side)
   local pos = find_position(
     0,
-    function(line, position) return position.current.range_start >= line and position.incoming.range_end >= line end
+    function(line, position) return position.current.range_start > line and position.incoming.range_end > line end
   )
   set_cursor(pos, side)
 end


### PR DESCRIPTION
SO!

Basically I noticed that when I got SEARCH/REPLACE suggestions and I wanted to go next to the next occurrence "]x"
the plugin did not actually sent me to the next ocurrence, it stayed in the current position of the file.

<img width="1061" alt="image" src="https://github.com/user-attachments/assets/bf4db8e9-6f28-4bf7-a457-7f3f9aecae05" />

I implemented a small change to fix the "find_next" Lua function of the plugin.

With this change, the find_next shortcut works as expected