### PR TITLE
fix: enable Claude text editor for claude-3.5 model

### DIFF
--- a/lua/avante/providers/claude.lua
+++ b/lua/avante/providers/claude.lua
@@ -370,9 +370,9 @@ function M:parse_curl_args(prompt_opts)
         type = "text_editor_20250124",
         name = "str_replace_editor",
       })
-    elseif provider_conf.model:match("claude%-3%-5%-instruct") then
+    elseif provider_conf.model:match("claude%-3%-5%-sonnet") then
       table.insert(tools, {
-        type = "text_editor_20241022",
+        type = "text_editor_20250124",
         name = "str_replace_editor",
       })
     end


### PR DESCRIPTION
So, currently Claude 3.7 Sonnet gives alot of rate limit warnings that we hit when using Claude Text Editor mode, which it's kind of sad cause that beats the purpose of the Text Editor mode UI flow in the first place, which it's pretty nice.

So what I have been doing is that I activated the Text editor mode on claude-3.5-sonnet and it's been working very nicely with me, works like a charm with way less rate limit warnings.

Wondering if it would be ok to replace the old claude-3.5-instruct model which I think is no longer available.

Let me know what you think