### PR TITLE
opts: allow `false` to be passed as ask flag

### DIFF
--- a/lua/avante/sidebar.lua
+++ b/lua/avante/sidebar.lua
@@ -2172,9 +2172,12 @@ function Sidebar:get_generate_prompts_options(request, cb)
 
   local selected_filepaths = self.file_selector.selected_filepaths or {}
 
+  local ask = self.ask_opts.ask
+  if ask == nil then ask = true end
+
   ---@type AvanteGeneratePromptsOptions
   local prompts_opts = {
-    ask = (self.ask_opts.ask == nil) and true or self.ask_opts.ask and true or false,
+    ask = ask,
     project_context = vim.json.encode(project_context),
     selected_filepaths = selected_filepaths,
     recently_viewed_files = Utils.get_recent_filepaths(),

--- a/lua/avante/sidebar.lua
+++ b/lua/avante/sidebar.lua
@@ -2174,7 +2174,7 @@ function Sidebar:get_generate_prompts_options(request, cb)
 
   ---@type AvanteGeneratePromptsOptions
   local prompts_opts = {
-    ask = self.ask_opts.ask or true,
+    ask = (self.ask_opts.ask == nil) and true or self.ask_opts.ask and true or false,
     project_context = vim.json.encode(project_context),
     selected_filepaths = selected_filepaths,
     recently_viewed_files = Utils.get_recent_filepaths(),


### PR DESCRIPTION
Hello,

I found this issue:
Passing `ask = false` to the `prompt_opts` results in a true. This should only be the case if `ask = null`.

Otherwise, even though `:AvanteChat` sets `ask = false`, the prompt defaults back to true.