### PR TITLE
feat(provider/ollama): allow optional API key without blocking the request

### DIFF
--- a/lua/avante/providers/ollama.lua
+++ b/lua/avante/providers/ollama.lua
@@ -42,13 +42,20 @@ function M:parse_curl_args(prompt_opts)
 
   if not provider_conf.model or provider_conf.model == "" then error("Ollama model must be specified in config") end
   if not provider_conf.endpoint then error("Ollama requires endpoint configuration") end
+  local headers = {
+    ["Content-Type"] = "application/json",
+    ["Accept"] = "application/json",
+  }
+
+  if provider_conf.extra_headers then
+    for key, value in pairs(provider_conf.extra_headers) do
+      headers[key] = value
+    end
+  end
 
   return {
     url = Utils.url_join(provider_conf.endpoint, "/api/chat"),
-    headers = {
-      ["Content-Type"] = "application/json",
-      ["Accept"] = "application/json",
-    },
+    headers = headers,
     body = vim.tbl_deep_extend("force", {
       model = provider_conf.model,
       messages = self:parse_messages(prompt_opts),

--- a/lua/avante/providers/ollama.lua
+++ b/lua/avante/providers/ollama.lua
@@ -47,10 +47,12 @@ function M:parse_curl_args(prompt_opts)
     ["Accept"] = "application/json",
   }
 
-  if provider_conf.extra_headers then
-    for key, value in pairs(provider_conf.extra_headers) do
-      headers[key] = value
+  if Providers.env.require_api_key(provider_conf) then
+    local api_key = self.parse_api_key()
+    if api_key == nil then
+      error(Config.provider .. " API key is not set, please set it in your environment variable or config file")
     end
+    headers["Authorization"] = "Bearer " .. api_key
   end
 
   return {

--- a/lua/avante/providers/ollama.lua
+++ b/lua/avante/providers/ollama.lua
@@ -50,10 +50,11 @@ function M:parse_curl_args(prompt_opts)
 
   if P.env.require_api_key(provider_conf) then
     local api_key = self.parse_api_key()
-    if api_key == nil then
-      error((Config.provider or "Ollama") .. " API key is not set, please set it in your environment variable or config file")
+    if api_key and api_key ~= "" then
+      headers["Authorization"] = "Bearer " .. api_key
+    else
+      Utils.info((Config.provider or "Provider") .. ": API key not set, continuing without authentication")
     end
-    headers["Authorization"] = "Bearer " .. api_key
   end
 
   return {

--- a/lua/avante/providers/ollama.lua
+++ b/lua/avante/providers/ollama.lua
@@ -1,5 +1,6 @@
 local Utils = require("avante.utils")
 local P = require("avante.providers")
+local Config = require("avante.config")
 
 ---@class AvanteProviderFunctor
 local M = {}
@@ -47,10 +48,10 @@ function M:parse_curl_args(prompt_opts)
     ["Accept"] = "application/json",
   }
 
-  if Providers.env.require_api_key(provider_conf) then
+  if P.env.require_api_key(provider_conf) then
     local api_key = self.parse_api_key()
     if api_key == nil then
-      error(Config.provider .. " API key is not set, please set it in your environment variable or config file")
+      error((Config.provider or "Ollama") .. " API key is not set, please set it in your environment variable or config file")
     end
     headers["Authorization"] = "Bearer " .. api_key
   end


### PR DESCRIPTION
### What this does

This update improves the Ollama provider integration by allowing the request to continue **even if no API key is present**, as long as the provider configuration doesn’t require one.

Previously, if `require_api_key()` returned `true` but no API key was set, the code would throw an error and block the request entirely. This new behavior ensures the request proceeds gracefully, and only injects the Authorization header if the key is actually available.

### Why this is needed

This is especially useful when:

- You are running Ollama on a **remote machine** (e.g., LAN or server)
- You have restricted API access **or disabled API key usage** entirely for local development
- You want to use a proxy or custom gateway that does not require authentication

Blocking on a missing key prevents users from leveraging Avante with flexible setups, especially for models hosted outside the local machine (e.g., over SSH tunnels, reverse proxies, or LAN-based model runners).

This change allows:
- Easier development/testing
- Cleaner onboarding experience
- No need to set environment variables just to try things out

### Behavior

- ✅ If API key is required and present → adds the `Authorization` header
- ✅ If API key is required but not present → skips it silently
- ✅ If API key is not required → no header added, no interruption

---

Let me know if you'd like me to revise anything else. Thanks for this great plugin!
