### PR TITLE
Fix tool name conflict with o‑series models by renaming python to run_python (closes #1890)

### DIFF
--- a/lua/avante/llm_tools/init.lua
+++ b/lua/avante/llm_tools/init.lua
@@ -629,7 +629,7 @@ M._tools = {
     },
   },
   {
-    name = "python",
+    name = "run_python",
     description = "Run python code in current project scope. Can't use it to read files or modify files.",
     param = {
       type = "table",
@@ -1095,6 +1095,9 @@ M._tools = {
     end,
   },
 }
+
+--- compatibility alias for old calls & tests
+M.run_python = M.python
 
 ---@param tools AvanteLLMTool[]
 ---@param tool_use AvanteLLMToolUse


### PR DESCRIPTION
When you call an o‑series model such as o4‑mini, the name python is already taken by the model’s built‑in code interpreter. Because Avante also registers a tool called python, the API returns a 400 error: “The function name 'python' is reserved for use by this model.” Issue #1890 tracks this problem.

This patch changes the tool metadata in lua/avante/llm_tools/init.lua:
- name = "python" -> name = "run_python"

To keep existing configs and scripts working, the code now adds a one‑line alias right after the original function:
```
M.run_python = M.python
```
