### PR TITLE
feature: Allow users to define custom parse_api_key functions.

### DIFF
--- a/lua/avante/providers/init.lua
+++ b/lua/avante/providers/init.lua
@@ -183,16 +183,12 @@ M = setmetatable(M, {
       t[k] = Utils.deep_extend_with_metatable("keep", provider_config, module)
     end
 
-    if t[k].is_env_set == nil then t[k].is_env_set = function() return E.parse_envvar(t[k]) ~= nil end end
-
-    if t[k].parse_api_key == nil then
-      t[k].parse_api_key = function() return E.parse_envvar(t[k]) end
-    else
-      t[k].is_env_set = function() return t[k].parse_api_key() ~= nil end
-    end
+    if t[k].parse_api_key == nil then t[k].parse_api_key = function() return E.parse_envvar(t[k]) end end
 
     -- default to gpt-4o as tokenizer
     if t[k].tokenizer_id == nil then t[k].tokenizer_id = "gpt-4o" end
+
+    if t[k].is_env_set == nil then t[k].is_env_set = function() return t[k].parse_api_key() ~= nil end end
 
     if t[k].setup == nil then
       local provider_conf = M.parse_config(t[k])

--- a/lua/avante/providers/init.lua
+++ b/lua/avante/providers/init.lua
@@ -183,12 +183,16 @@ M = setmetatable(M, {
       t[k] = Utils.deep_extend_with_metatable("keep", provider_config, module)
     end
 
-    t[k].parse_api_key = function() return E.parse_envvar(t[k]) end
+    if t[k].is_env_set == nil then t[k].is_env_set = function() return E.parse_envvar(t[k]) ~= nil end end
+
+    if t[k].parse_api_key == nil then
+      t[k].parse_api_key = function() return E.parse_envvar(t[k]) end
+    else
+      t[k].is_env_set = function() return t[k].parse_api_key() ~= nil end
+    end
 
     -- default to gpt-4o as tokenizer
     if t[k].tokenizer_id == nil then t[k].tokenizer_id = "gpt-4o" end
-
-    if t[k].is_env_set == nil then t[k].is_env_set = function() return E.parse_envvar(t[k]) ~= nil end end
 
     if t[k].setup == nil then
       local provider_conf = M.parse_config(t[k])


### PR DESCRIPTION
Close #1782

Allow users to define custom `parse_api_key` functions.

```
opts = {
  vendors = {
    ["myvendor"] = {
      __inherited_from = "openai",
      endpoint = "https://openai-proxy.com/",
      model = "claude-3.7-sonnet",
      parse_api_key = function()
        return require("env").apikey
      end,
    },                                                                                                                                                                                                                                                                         
  },                                      
}
```

I haven't added additional conditional checks (such as `is_parse_api_key_set()`) for now because I found it involves too many elements. This should be the most minimal modification at present.