### PR TITLE
fix(utils): when locking a buffer, only stopinsert if buffer is current

### DIFF
--- a/lua/avante/utils/init.lua
+++ b/lua/avante/utils/init.lua
@@ -473,9 +473,7 @@ function M.unlock_buf(bufnr)
 end
 
 function M.lock_buf(bufnr)
-  if bufnr == api.nvim_get_current_buf() then
-    vim.cmd("noautocmd stopinsert")
-  end
+  if bufnr == api.nvim_get_current_buf() then vim.cmd("noautocmd stopinsert") end
   vim.bo[bufnr].readonly = true
   vim.bo[bufnr].modified = false
   vim.bo[bufnr].modifiable = false

--- a/lua/avante/utils/init.lua
+++ b/lua/avante/utils/init.lua
@@ -473,7 +473,9 @@ function M.unlock_buf(bufnr)
 end
 
 function M.lock_buf(bufnr)
-  vim.cmd("noautocmd stopinsert")
+  if bufnr == api.nvim_get_current_buf() then
+    vim.cmd("noautocmd stopinsert")
+  end
   vim.bo[bufnr].readonly = true
   vim.bo[bufnr].modified = false
   vim.bo[bufnr].modifiable = false


### PR DESCRIPTION
This change fixes avante's sidebar starting out in normal mode when being freshly opened (as opposed to re-focused), despite `start_insert = true`.
