### PR TITLE
chore: disambiguate lua syntax

### DIFF
--- a/stylua.toml
+++ b/stylua.toml
@@ -1,3 +1,4 @@
+syntax = "Lua52"
 indent_type = "Spaces"
 indent_width = 2
 column_width = 119


### PR DESCRIPTION
Since there are `goto` statements with labels in the repo, we need lua52
syntax, so it would be best to enforce this syntax. Additionally, this
helps disambiguate from the `luau` syntax which has a different meaning
for label syntax (`::`)
