### PR TITLE
fix: apply re-uses the correct buffer when using non-cwd project root

### DIFF
--- a/lua/avante/utils/init.lua
+++ b/lua/avante/utils/init.lua
@@ -933,7 +933,7 @@ end
 ---@param filepath string
 ---@return integer|nil bufnr
 local function get_opened_buffer_by_filepath(filepath)
-  local project_root = M.get_project_root()
+  local project_root = vim.fn.getcwd()
   local absolute_path = M.join_paths(project_root, filepath)
   for _, buf in ipairs(api.nvim_list_bufs()) do
     if M.join_paths(project_root, fn.bufname(buf)) == absolute_path then return buf end


### PR DESCRIPTION
The buffer name is the relative path to vim.fn.getcwd() which is not
necessarily the same as the project root. However, we were using this to
prepend the filepath to the buffer name and match up the filepath being
applied to the relevant buffer. This resulted in a bug where apply
opened an unnamed buffer in the background instead of the relevant
buffer. Thus we use vim.fn.getcwd() to prepend the buffer name which
makes the buffer for the filepath properly being re-used.
