### PR TITLE
fix: properly highlight multi filetype code blocks

### DIFF
--- a/lua/avante/utils/init.lua
+++ b/lua/avante/utils/init.lua
@@ -1084,7 +1084,8 @@ function M.get_filetype(filepath)
   local buf = vim.api.nvim_create_buf(false, true)
   local filetype = vim.filetype.match({ filename = filepath, buf = buf }) or ""
   vim.api.nvim_buf_delete(buf, { force = true })
-
+  -- Parse the first filetype from a multifiltype file
+  filetype = filetype:gsub("%..*$", "")
   return filetype
 end
 


### PR DESCRIPTION
Code blocks for files with multiple filetypes are tagged with the entire
multiple filetype combination. For example, yaml.github has a codeblock
with yaml.github tagged in the codeblock, when yaml should be used. This
updates the codeblock to only use the first filetype (and possibly fixes
other usages of `get_filetype` as well).
