### PR TITLE
fix: support rag search on macos

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -106,5 +106,8 @@ lua-typecheck:
 
 .PHONY: build-image
 build-image:
-	docker build -t $(RAG_SERVICE_IMAGE) -f py/rag-service/Dockerfile py/rag-service
+	docker build --platform=linux/amd64 -t $(RAG_SERVICE_IMAGE) -f py/rag-service/Dockerfile py/rag-service
+
+.PHONY: push-image
+push-image: build-image
 	docker push $(RAG_SERVICE_IMAGE)

--- a/lua/avante/rag_service.lua
+++ b/lua/avante/rag_service.lua
@@ -74,7 +74,9 @@ function M.launch_rag_service(cb)
       M.stop_rag_service()
     end
     local cmd_ = string.format(
-      "docker run --platform=linux/amd64 -d --network=host --name %s -v %s:/data -v %s:/host:ro -e ALLOW_RESET=TRUE -e DATA_DIR=/data -e RAG_PROVIDER=%s -e %s_API_KEY=%s -e %s_API_BASE=%s -e RAG_LLM_MODEL=%s -e RAG_EMBED_MODEL=%s %s %s",
+      "docker run --platform=linux/amd64 -d -p 0.0.0.0:%d:%d --name %s -v %s:/data -v %s:/host:ro -e ALLOW_RESET=TRUE -e DATA_DIR=/data -e RAG_PROVIDER=%s -e %s_API_KEY=%s -e %s_API_BASE=%s -e RAG_LLM_MODEL=%s -e RAG_EMBED_MODEL=%s %s %s",
+      M.get_rag_service_port(),
+      M.get_rag_service_port(),
       container_name,
       data_path,
       Config.rag_service.host_mount,

--- a/py/rag-service/Dockerfile
+++ b/py/rag-service/Dockerfile
@@ -2,7 +2,7 @@ FROM python:3.11-slim-bookworm
 
 WORKDIR /app
 
-RUN apt-get update && apt-get install -y curl \
+RUN apt-get update && apt-get install -y curl git \
     && rm -rf /var/lib/apt/lists/* \
     && curl -LsSf https://astral.sh/uv/install.sh | sh
 


### PR DESCRIPTION
rag_search does not work on macos for the following reasons:
- `--network=host` doesn't work reliably on macos to expose ports
  - I fixed this by specifying the ports to expose in the `docker run` command
- the container somehow does not have `git` installed
  - this might've been because i was building for macos, but the change to install it in the `Dockerfile` didn't work
- the `build-image` step builds for the current platform, even though the `docker run` command runs for linux
  - I added the `--platform linux/amd64` flag to the `docker build` command

