### PR TITLE
feat: Add ability to expire cached credentials

### DIFF
--- a/README.md
+++ b/README.md
@@ -582,6 +582,17 @@ Given its early stage, `avante.nvim` currently supports the following basic func
 > ```
 >
 > Note: The aws_session_token is optional and only needed when using temporary AWS credentials
+>
+> If you use temporary credentials which you refresh using a credentials_process in your AWS profile, you can
+> configure your api key to reference a shell command as follows:
+> ```lua
+>    bedrock = {
+>      -- ...
+>      api_key_name = { "sh", "-c", "REGION=$(aws configure get region --profile bedrock) && aws configure export-credentials --profile bedrock | jq -r --arg region \"$REGION\" '[.AccessKeyId, .SecretAccessKey, $region, .SessionToken] | join(\",\")'"},
+>      reevaluate_api_key_after = 3500, -- reevaluate the API key once per hour to get fresh credentials
+>    }
+> ```
+
 
 1. Open a code file in Neovim.
 2. Use the `:AvanteAsk` command to query the AI about the code.

--- a/lua/avante/config.lua
+++ b/lua/avante/config.lua
@@ -640,6 +640,7 @@ M.BASE_PROVIDER_KEYS = {
   "proxy",
   "allow_insecure",
   "api_key_name",
+  "reevaluate_api_key_after", -- Time in seconds after which to re-evaluate the api_key_name command
   "timeout",
   "display_name",
   -- internal

--- a/lua/avante/providers/init.lua
+++ b/lua/avante/providers/init.lua
@@ -37,9 +37,7 @@ E.cache = {}
 ---@param entry CacheEntry
 ---@return boolean
 function E.is_expired(entry)
-  if not entry.expires_at then
-    return false
-  end
+  if not entry.expires_at then return false end
   return os.time() >= entry.expires_at
 end
 
@@ -49,9 +47,7 @@ function E.parse_envvar(Opts)
   local key = Opts.api_key_name
 
   -- Check cache first
-  if E.cache[key] and not E.is_expired(E.cache[key]) then
-    return E.cache[key].value
-  end
+  if E.cache[key] and not E.is_expired(E.cache[key]) then return E.cache[key].value end
 
   -- Force cache invalidation when re-evaluating expired keys
   local force_invalidate = E.cache[key] and E.is_expired(E.cache[key])
@@ -61,14 +57,12 @@ function E.parse_envvar(Opts)
 
     -- Calculate expiry if reevaluate_api_key_after is set
     local expires_at = nil
-    if Opts.reevaluate_api_key_after then
-      expires_at = os.time() + Opts.reevaluate_api_key_after
-    end
+    if Opts.reevaluate_api_key_after then expires_at = os.time() + Opts.reevaluate_api_key_after end
 
     -- Cache the value with expiry
     E.cache[key] = {
       value = value,
-      expires_at = expires_at
+      expires_at = expires_at,
     }
 
     return value

--- a/lua/avante/types.lua
+++ b/lua/avante/types.lua
@@ -227,6 +227,7 @@ vim.g.avante_login = vim.g.avante_login
 ---@field timeout? integer
 ---@field allow_insecure? boolean
 ---@field api_key_name? string
+---@field reevaluate_api_key_after? number
 ---@field _shellenv? string
 ---@field disable_tools? boolean
 ---@field entra? boolean

--- a/lua/avante/utils/environment.lua
+++ b/lua/avante/utils/environment.lua
@@ -10,13 +10,14 @@ M.cache = {}
 ---Parse environment variable using optional cmd: feature with an override fallback
 ---@param key_name string
 ---@param override? string
+---@param force_cache_invalidate? boolean
 ---@return string | nil
-function M.parse(key_name, override)
+function M.parse(key_name, override, force_cache_invalidate)
   if key_name == nil then error("Requires key_name") end
 
   local cache_key = type(key_name) == "table" and table.concat(key_name, "__") or key_name
 
-  if M.cache[cache_key] ~= nil then return M.cache[cache_key] end
+  if not force_cache_invalidate and M.cache[cache_key] ~= nil then return M.cache[cache_key] end
 
   local cmd = type(key_name) == "table" and key_name or key_name:match("^cmd:(.*)")
 
@@ -35,21 +36,32 @@ function M.parse(key_name, override)
 
     Utils.debug("running command:", cmd)
     local exit_codes = { 0 }
-    local ok, job_or_err = pcall(vim.system, cmd, { text = true }, function(result)
-      local code = result.code
+
+    ---@param result {code: number, stderr: string, stdout: string} | nil
+    local function handle_command_result(result)
+      local code = result.code or -1
       local stderr = result.stderr or ""
       local stdout = result.stdout and vim.split(result.stdout, "\n") or {}
-      if vim.tbl_contains(exit_codes, code) then
+
+      if vim.tbl_contains(exit_codes, code) and stdout[1] then
         value = stdout[1]
         M.cache[cache_key] = value
       else
-        Utils.error("failed to get key: (error code" .. code .. ")\n" .. stderr, { once = true, title = "Avante" })
+        local error_msg = "failed to get key: (error code " .. code .. ")"
+        if stderr ~= "" then
+          error_msg = error_msg .. "\n" .. stderr
+        end
+        Utils.error(error_msg, { once = true, title = "Avante" })
       end
-    end)
+    end
 
-    if not ok then
-      Utils.error("failed to run command: " .. cmd .. "\n" .. job_or_err)
-      return
+    -- Create the system job
+    local job = vim.system(cmd, { text = true }, handle_command_result)
+
+    if force_cache_invalidate then
+      -- Run synchronously when force invalidating cache because the credentials are likely already expired
+      -- and trying to use the old ones will result in failure
+      job:wait()
     end
   else
     value = os.getenv(key_name)

--- a/lua/avante/utils/environment.lua
+++ b/lua/avante/utils/environment.lua
@@ -48,9 +48,7 @@ function M.parse(key_name, override, force_cache_invalidate)
         M.cache[cache_key] = value
       else
         local error_msg = "failed to get key: (error code " .. code .. ")"
-        if stderr ~= "" then
-          error_msg = error_msg .. "\n" .. stderr
-        end
+        if stderr ~= "" then error_msg = error_msg .. "\n" .. stderr end
         Utils.error(error_msg, { once = true, title = "Avante" })
       end
     end

--- a/tests/providers_spec.lua
+++ b/tests/providers_spec.lua
@@ -1,0 +1,99 @@
+local mock = require("luassert.mock")
+local stub = require("luassert.stub")
+
+describe("Providers", function()
+  local Providers
+  local Config_mock
+  local Utils_mock
+  local Environment
+
+  before_each(function()
+    Providers = require("avante.providers")
+    Environment = require("avante.utils.environment")
+
+    Config_mock = mock(require("avante.config"), true)
+    Utils_mock = mock(require("avante.utils"), true)
+
+    Environment.cache = {}
+  end)
+
+  after_each(function()
+    package.loaded["avante.providers"] = nil
+    package.loaded["avante.utils.environment"] = nil
+    mock.revert(Config_mock)
+    mock.revert(Utils_mock)
+  end)
+
+  describe("API key caching and expiry", function()
+    it("should cache API key values", function()
+      local provider = {
+        api_key_name = "TEST_API_KEY",
+        reevaluate_api_key_after = nil -- No expiry
+      }
+
+      stub(Utils_mock.environment, "parse", function(key)
+        if key == "TEST_API_KEY" then
+          return "test-api-key-value"
+        end
+      end)
+
+      -- First call should get from environment
+      local value1 = Providers.env.parse_envvar(provider)
+      assert.equals("test-api-key-value", value1)
+      assert.spy(Utils_mock.environment.parse).was_called(1)
+
+      -- Second call should get from cache
+      local value2 = Providers.env.parse_envvar(provider)
+      assert.equals("test-api-key-value", value2)
+      assert.spy(Utils_mock.environment.parse).was_called(1) -- Should not call parse again
+
+      Utils_mock.environment.parse:revert()
+    end)
+
+    it("should handle API key caching and expiry lifecycle", function()
+      local provider = {
+        api_key_name = "TEST_API_KEY",
+        reevaluate_api_key_after = 1 -- 1 second expiry
+      }
+
+      local current_time = 1000
+      stub(os, "time", function() return current_time end)
+
+      stub(Utils_mock.environment, "parse", function(key)
+        if key == "TEST_API_KEY" then
+          return "test-api-key-value"
+        end
+      end)
+
+      -- Initial fetch should get from environment and cache
+      local value1 = Providers.env.parse_envvar(provider)
+      assert.equals("test-api-key-value", value1)
+      assert.spy(Utils_mock.environment.parse).was_called(1)
+
+      -- Verify initial cache state
+      assert.equals("test-api-key-value", Providers.env.cache["TEST_API_KEY"].value)
+      assert.equals(current_time + 1, Providers.env.cache["TEST_API_KEY"].expires_at)
+
+      -- Immediate second call should use cache
+      local value2 = Providers.env.parse_envvar(provider)
+      assert.equals("test-api-key-value", value2)
+      assert.spy(Utils_mock.environment.parse).was_called(1) -- No new environment check
+
+      -- Simulate time passing beyond expiry
+      current_time = current_time + 2 -- 2 seconds later
+
+      -- Call after expiry should force new environment check
+      local value3 = Providers.env.parse_envvar(provider)
+      assert.equals("test-api-key-value", value3)
+      assert.spy(Utils_mock.environment.parse).was_called(2) -- New environment check
+
+      -- Verify cache was updated with new expiry time
+      assert.equals("test-api-key-value", Providers.env.cache["TEST_API_KEY"].value)
+      assert.equals(current_time + 1, Providers.env.cache["TEST_API_KEY"].expires_at)
+
+      Utils_mock.environment.parse:revert()
+      os.time:revert()
+    end)
+  end)
+end)
+

--- a/tests/providers_spec.lua
+++ b/tests/providers_spec.lua
@@ -28,13 +28,11 @@ describe("Providers", function()
     it("should cache API key values", function()
       local provider = {
         api_key_name = "TEST_API_KEY",
-        reevaluate_api_key_after = nil -- No expiry
+        reevaluate_api_key_after = nil, -- No expiry
       }
 
       stub(Utils_mock.environment, "parse", function(key)
-        if key == "TEST_API_KEY" then
-          return "test-api-key-value"
-        end
+        if key == "TEST_API_KEY" then return "test-api-key-value" end
       end)
 
       -- First call should get from environment
@@ -53,16 +51,14 @@ describe("Providers", function()
     it("should handle API key caching and expiry lifecycle", function()
       local provider = {
         api_key_name = "TEST_API_KEY",
-        reevaluate_api_key_after = 1 -- 1 second expiry
+        reevaluate_api_key_after = 1, -- 1 second expiry
       }
 
       local current_time = 1000
       stub(os, "time", function() return current_time end)
 
       stub(Utils_mock.environment, "parse", function(key)
-        if key == "TEST_API_KEY" then
-          return "test-api-key-value"
-        end
+        if key == "TEST_API_KEY" then return "test-api-key-value" end
       end)
 
       -- Initial fetch should get from environment and cache
@@ -96,4 +92,3 @@ describe("Providers", function()
     end)
   end)
 end)
-

--- a/tests/utils/environment_spec.lua
+++ b/tests/utils/environment_spec.lua
@@ -100,10 +100,7 @@ describe("environment", function()
     end)
 
     it("should handle nil input", function()
-      assert.has_error(function()
-        environment.parse(nil)
-      end, "Requires key_name")
+      assert.has_error(function() environment.parse(nil) end, "Requires key_name")
     end)
   end)
 end)
-

--- a/tests/utils/environment_spec.lua
+++ b/tests/utils/environment_spec.lua
@@ -1,0 +1,109 @@
+local environment = require("avante.utils.environment")
+
+describe("environment", function()
+  local original_system
+
+  before_each(function()
+    -- Clear the cache before each test
+    environment.cache = {}
+    -- Store original vim.system
+    original_system = vim.system
+  end)
+
+  after_each(function()
+    -- Restore original vim.system
+    vim.system = original_system
+  end)
+
+  describe("parse", function()
+    it("should read environment variables directly", function()
+      vim.env.TEST_VAR = "test_value"
+      assert.equals("test_value", environment.parse("TEST_VAR"))
+      -- Should use cache on second call
+      vim.env.TEST_VAR = "changed_value"
+      assert.equals("test_value", environment.parse("TEST_VAR"))
+    end)
+
+    it("should execute commands and cache results", function()
+      vim.system = function(cmd, opts, callback)
+        assert.same(vim.split("echo hello", " "), cmd)
+        callback({ code = 0, stdout = "hello\n", stderr = "" })
+        return { wait = function() end }
+      end
+
+      local result = environment.parse("cmd:echo hello")
+      assert.equals("hello", result)
+      assert.equals("hello", environment.cache["cmd:echo hello"])
+      -- Should use cache on second call
+      assert.equals("hello", environment.parse("cmd:echo hello"))
+    end)
+
+    it("should handle command arrays", function()
+      vim.system = function(cmd, opts, callback)
+        assert.same({ "echo", "world" }, cmd)
+        callback({ code = 0, stdout = "world\n", stderr = "" })
+        return { wait = function() end }
+      end
+
+      local result = environment.parse({ "echo", "world" })
+      assert.equals("world", result)
+      assert.equals("world", environment.cache["echo__world"])
+      -- Should use cache on second call using the concatenated key
+      assert.equals("world", environment.parse({ "echo", "world" }))
+    end)
+
+    it("should force cache invalidation when requested", function()
+      local call_count = 0
+      vim.system = function(cmd, opts, callback)
+        call_count = call_count + 1
+        callback({ code = 0, stdout = "hello\n", stderr = "" })
+        return { wait = function() end }
+      end
+
+      -- First call caches the value
+      local result = environment.parse("cmd:echo hello")
+      assert.equals("hello", result)
+      assert.equals(1, call_count)
+
+      -- Second call with force_cache_invalidate should run command again
+      result = environment.parse("cmd:echo hello", nil, true)
+      assert.equals("hello", result)
+      assert.equals(2, call_count)
+
+      -- Third call should use cache
+      result = environment.parse("cmd:echo hello")
+      assert.equals("hello", result)
+      assert.equals(2, call_count)
+    end)
+
+    it("should use override when provided", function()
+      vim.env.OVERRIDE_VAR = "override_value"
+      -- The command should never be called when override is used
+      vim.system = function(cmd, opts, callback)
+        assert.fail("Command should not be called when override is used")
+        return { wait = function() end }
+      end
+
+      local result = environment.parse("cmd:echo should_not_see_this", "OVERRIDE_VAR")
+      assert.equals("override_value", result)
+    end)
+
+    it("should handle command failures gracefully", function()
+      vim.system = function(cmd, opts, callback)
+        callback({ code = 1, stdout = "", stderr = "command not found" })
+        return { wait = function() end }
+      end
+
+      local result = environment.parse("cmd:nonexistent_command")
+      assert.is_nil(result)
+      assert.is_nil(environment.cache["cmd:nonexistent_command"])
+    end)
+
+    it("should handle nil input", function()
+      assert.has_error(function()
+        environment.parse(nil)
+      end, "Requires key_name")
+    end)
+  end)
+end)
+


### PR DESCRIPTION
I tried using avante with the Bedrock provider and I found it quite nice to obtain the credenitals using the command as `api_key_name` convention: It allows a config such as the following to get the credentials string from an AWS profile:

```lua
  opts = {
    provider = "bedrock",
    -- I'm not sure if auto suggestions are even active but if I do not set this to bedrock, I will still be prompted
    -- for a anthropic key for no reason
    auto_suggestions_provider = "bedrock",
    bedrock = {
      model = "anthropic.claude-3-5-sonnet-20241022-v2:0",
      api_key_name = { "sh", "-c", "REGION=$(aws configure get region --profile bedrock) && aws configure export-credentials --profile bedrock | jq -r --arg region \"$REGION\" '[.AccessKeyId, .SecretAccessKey, $region, .SessionToken] | join(\",\")'"},
    },
  },
```

The `bedrock` aws profile gives me short-lived credentials which are refreshed using the `credentials_process` using SSO. (https://docs.aws.amazon.com/cli/v1/userguide/cli-configure-sourcing-external.html).

The only problem with this setup is that Avante caches these credentials and I have to restart nvim once they expire.

My proposal in this PR is to add an optional parameter `reevaluate_api_key_after` which invalidates the credenitals cache after a set number of seconds.

Note that there are two different caches that need to be invalidated, one in `providers/init.lua` and one in `environment.lua`. My idea was to add the expiry to one of them and a force invalidation flag to the other.
Note furthermore, that the command execution in `environment.lua` is async which is fine for startup where we do not want to block on this evaluation - however when we invalidate the credentials, we actually want to wait for the credentials to be available because the old credentials are likely no longer available.
 