### PR TITLE
fix(rag_search): ignore global git ignore files

### DIFF
--- a/lua/avante/rag_service.lua
+++ b/lua/avante/rag_service.lua
@@ -74,7 +74,7 @@ function M.launch_rag_service(cb)
       M.stop_rag_service()
     end
     local cmd_ = string.format(
-      "docker run --platform=linux/amd64 -d --network=host --name %s -v %s:/data -v %s:/host:ro -e ALLOW_RESET=TRUE -e DATA_DIR=/data -e RAG_PROVIDER=%s -e %s_API_KEY=%s -e %s_API_BASE=%s -e RAG_LLM_MODEL=%s -e RAG_EMBED_MODEL=%s %s %s",
+      "docker run --platform=linux/amd64 -d --network=host --name %s -v %s:/data -v %s:/host:ro -e ALLOW_RESET=TRUE -e DATA_DIR=/data -e HOST_DIR=/host -e RAG_PROVIDER=%s -e %s_API_KEY=%s -e %s_API_BASE=%s -e RAG_LLM_MODEL=%s -e RAG_EMBED_MODEL=%s %s %s",
       container_name,
       data_path,
       Config.rag_service.host_mount,

--- a/py/rag-service/src/libs/configs.py
+++ b/py/rag-service/src/libs/configs.py
@@ -6,6 +6,7 @@ BASE_DATA_DIR = Path(os.environ.get("DATA_DIR", "data"))
 CHROMA_PERSIST_DIR = BASE_DATA_DIR / "chroma_db"
 LOG_DIR = BASE_DATA_DIR / "logs"
 DB_FILE = BASE_DATA_DIR / "sqlite" / "indexing_history.db"
+HOST_MOUNT = Path(os.environ.get("HOST_DIR", "/host"))
 
 # Configure directories
 BASE_DATA_DIR.mkdir(parents=True, exist_ok=True)


### PR DESCRIPTION
I was getting errors in the rag service about not being able to read files. This was because I had files in the directory that symlinked to files outside of the host directory (specifically python in virtualenv). This was not getting properly ignored by the existing ignore scripts because I had a global ignore for a `venv` path that wasn't getting captured. I thought that in `scan_directory`, I should filter out unreadable paths. This seems like a valid change, but more of a hack than just ignoring the global git ignore file. I can add that change, but adding the global ignore seems to work better for me for now.
