### PR TITLE
fix(sidebar): correct syntax highlighting for selected code

### DIFF
--- a/lua/avante/sidebar.lua
+++ b/lua/avante/sidebar.lua
@@ -2126,7 +2126,7 @@ local function render_chat_record_prefix(timestamp, provider, model, request, se
       .. "\n\n- Selected code: "
       .. "\n\n```"
       .. (selected_code.file_type or "")
-      .. (selected_code.path and ":" .. selected_code.path or "")
+      .. (selected_code.path and " " .. selected_code.path or "")
       .. "\n"
       .. selected_code.content
       .. "\n```"


### PR DESCRIPTION
The selected code is not highlighted correctly in the sidebar chat history view because there is not space between the filetype and the filepath. This adds that to make the syntax highlighting work again.
