### PR TITLE
fix: allow fields like api_key_name to be a table

### DIFF
--- a/lua/avante/providers/init.lua
+++ b/lua/avante/providers/init.lua
@@ -55,7 +55,7 @@ function E.setup(opts)
     return
   end
 
-  if vim.env[var] ~= nil then
+  if type(var) ~= "table" and vim.env[var] ~= nil then
     vim.g.avante_login = true
     return
   end


### PR DESCRIPTION
this is implemented anyways everywhere else I looked anyways

Closes #1891
