### PR TITLE
fix: prevent extmark line number from being negative in render_state

### DIFF
--- a/lua/avante/sidebar.lua
+++ b/lua/avante/sidebar.lua
@@ -1835,7 +1835,8 @@ function Sidebar:render_state()
     { { string.rep(" ", padding) }, { virt_line, hl } },
   }
 
-  self.state_extmark_id = api.nvim_buf_set_extmark(self.result_container.bufnr, self.state_ns_id, #lines - 2, 0, {
+  local line_num = math.max(0, #lines - 2)
+  self.state_extmark_id = api.nvim_buf_set_extmark(self.result_container.bufnr, self.state_ns_id, line_num, 0, {
     virt_lines = centered_virt_lines,
     hl_eol = true,
     hl_mode = "combine",


### PR DESCRIPTION
- Add boundary check to prevent negative line numbers when using sidebar
- Use math.max to ensure line number is always >= 0
- Fixes 'Invalid line: out of range' error that occurs when sidebar is invoked through advanced shortcuts configuration described in https://github.com/yetone/avante.nvim/wiki/Recipe-and-Tricks#advanced-shortcuts-for-frequently-used-queries-756