### PR TITLE
feat(hints): add config to toggle submit hint popup

### DIFF
--- a/lua/avante/config.lua
+++ b/lua/avante/config.lua
@@ -504,8 +504,11 @@ M._defaults = {
     override_timeoutlen = 500,
   },
   --- @class AvanteHintsConfig
+  --- @field enabled boolean Whether to enable hints (default true).
+  --- @field submit_hint boolean Whether to show submit hint popup in prompt input (default true).
   hints = {
     enabled = true,
+    submit_hint = true,
   },
   --- @class AvanteRepoMapConfig
   repo_map = {

--- a/lua/avante/sidebar.lua
+++ b/lua/avante/sidebar.lua
@@ -2430,6 +2430,9 @@ function Sidebar:create_input_container(opts)
   -- Create a floating window as a hint
   local function show_hint()
     close_hint() -- Close the existing hint window
+    if not Config.hints.submit_hint then
+      return
+    end
 
     local hint_text = (fn.mode() ~= "i" and Config.mappings.submit.normal or Config.mappings.submit.insert)
       .. ": submit"

--- a/lua/avante/ui/prompt_input.lua
+++ b/lua/avante/ui/prompt_input.lua
@@ -170,6 +170,9 @@ function PromptInput:submit(input)
 end
 
 function PromptInput:show_shortcuts_hints()
+  if not Config.hints.submit_hint then
+    return
+  end
   self:close_shortcuts_hints()
 
   if not self.winid or not api.nvim_win_is_valid(self.winid) then return end


### PR DESCRIPTION
Addresses #1872

Introduce a new `submit_hint` option in the hints config to allow enabling or disabling the submit hint popup in prompt input. Updated sidebar and prompt input logic to respect this setting, preventing the hint from showing when disabled. This provides users with more control over UI hints.