### PR TITLE
fix(Sidebar): fix: Hide default statusline when laststatus=0

### DIFF
--- a/lua/avante/sidebar.lua
+++ b/lua/avante/sidebar.lua
@@ -977,7 +977,7 @@ local base_win_options = {
     .. ",Normal:"
     .. Highlights.AVANTE_SIDEBAR_NORMAL,
   winbar = "",
-  statusline = "",
+  statusline = " ",
 }
 
 function Sidebar:render_header(winid, bufnr, header_text, hl, reverse_hl)


### PR DESCRIPTION
## Summary

This PR improves the visual experience when using sidebar windows in Neovim with `vim.opt.laststatus = 0`. Specifically, it hides the default status line content in sidebar windows by setting their local `statusline` option to a single space character.

This change ensures a cleaner and more minimal UI, especially in setups where the global status line is disabled.

### Before & After Comparison

Below are screenshots demonstrating the effect of this change when `vim.opt.laststatus = 0`:

**Before:**
<!-- Insert before screenshot here -->
![an1](https://github.com/user-attachments/assets/9643cc99-e2c2-4db8-82a7-7938f69d995b)


**After:**
<!-- Insert after screenshot here -->
![an2](https://github.com/user-attachments/assets/6bea7d1a-e91c-4339-80fd-911e9ec6a94d)


