### PR TITLE
feat(sidebar): Add option and keymap to start a new chat directly

### DIFF
--- a/lua/avante/api.lua
+++ b/lua/avante/api.lua
@@ -111,8 +111,9 @@ function M.ask(opts)
   end
 
   local has_question = opts.question ~= nil and opts.question ~= ""
+  local new_chat = opts.new_chat == true
 
-  if Utils.is_sidebar_buffer(0) and not has_question then
+  if Utils.is_sidebar_buffer(0) and not has_question and not new_chat then
     require("avante").close_sidebar()
     return false
   end
@@ -127,7 +128,7 @@ function M.ask(opts)
       sidebar:close({ goto_code_win = false })
     end
     require("avante").open_sidebar(opts)
-    if opts.new_chat then sidebar:new_chat() end
+    if new_chat then sidebar:new_chat() end
     if opts.without_selection then
       sidebar.code.selection = nil
       sidebar.file_selector:reset()

--- a/lua/avante/config.lua
+++ b/lua/avante/config.lua
@@ -435,6 +435,7 @@ M._defaults = {
     },
     -- NOTE: The following will be safely set by avante.nvim
     ask = "<leader>aa",
+    new_ask = "<leader>an",
     edit = "<leader>ae",
     refresh = "<leader>ar",
     focus = "<leader>af",

--- a/lua/avante/init.lua
+++ b/lua/avante/init.lua
@@ -59,6 +59,12 @@ function H.keymaps()
   vim.keymap.set({ "n", "v" }, "<Plug>(AvanteAsk)", function() require("avante.api").ask() end, { noremap = true })
   vim.keymap.set(
     { "n", "v" },
+    "<Plug>(AvanteAskNew)",
+    function() require("avante.api").ask({ new_chat = true }) end,
+    { noremap = true }
+  )
+  vim.keymap.set(
+    { "n", "v" },
     "<Plug>(AvanteChat)",
     function() require("avante.api").ask({ ask = false }) end,
     { noremap = true }
@@ -87,6 +93,12 @@ function H.keymaps()
       Config.mappings.ask,
       function() require("avante.api").ask() end,
       { desc = "avante: ask" }
+    )
+    Utils.safe_keymap_set(
+      { "n", "v" },
+      Config.mappings.new_ask,
+      function() require("avante.api").ask({ new_chat = true }) end,
+      { desc = "avante: create new ask" }
     )
     Utils.safe_keymap_set(
       "v",


### PR DESCRIPTION
## Summary

This PR introduces a new feature that allows users to directly start a new Avante chat session via a new API option and a dedicated keymap, even when currently in the sidebar buffer.

## Key Changes

*   **`lua/avante/api.lua`**:
    *   Adjusted the behavior of the `M.ask` function: When `opts.new_chat` is `true`, the sidebar will not be closed even if in the sidebar buffer and no question is immediately provided; instead, a new chat will be initiated.
*   **`lua/avante/config.lua`**:
    *   Added a new keymap configuration `new_ask` (defaults to `<leader>an`) in the default settings to trigger a new chat session.
*   **`lua/avante/init.lua`**:
    *   Added the `<Plug>(AvanteAskNew)` mapping, which calls `require("avante.api").ask({ new_chat = true })`.
    *   Set up a keymap for `Config.mappings.new_ask` for user convenience.

## Motivation

Previously, the `ask` command might close the sidebar if the user was in the sidebar and didn't immediately type a question. This change improves the user experience by introducing more explicit handling of the `new_chat` option and a dedicated shortcut for "starting a new chat," giving users more control over their chat sessions.
