### PR TITLE
fix(sidebar): toggle from empty selected files container

### DIFF
--- a/lua/avante/sidebar.lua
+++ b/lua/avante/sidebar.lua
@@ -2839,10 +2839,10 @@ function Sidebar:create_selected_files_container()
       return
     end
 
-    if not self.selected_files_container or not api.nvim_win_is_valid(self.selected_files_container.winid) then
+    if not Utils.is_valid_container(self.selected_files_container, true) then
       self:create_selected_files_container()
       self:refresh_winids()
-      if not self.selected_files_container or not api.nvim_win_is_valid(self.selected_files_container.winid) then
+      if not Utils.is_valid_container(self.selected_files_container, true) then
         Utils.warn("Failed to create or find selected files container window.")
         return
       end


### PR DESCRIPTION
Was trying to toggle selected file from empty and it errored. turned out to be an easy fix, nui just sets the winid to `nil` on unmount so we should just check for it.
