### PR TITLE
fix(sidebar): do not wrap lines in selected files container

### DIFF
--- a/lua/avante/sidebar.lua
+++ b/lua/avante/sidebar.lua
@@ -2816,7 +2816,6 @@ function Sidebar:create_selected_files_container()
       filetype = "AvanteSelectedFiles",
     }),
     win_options = vim.tbl_deep_extend("force", base_win_options, {
-      wrap = Config.windows.wrap,
       fillchars = Config.windows.fillchars,
     }),
     position = "top",


### PR DESCRIPTION
We resize the window of the selected files window based on the number of files, and allowing it to wrap doesn't really make since in that case. Can be convinced to actually support wrapped in this case tho.

