### PR TITLE
fix(sidebar): make tab work when toggling selected files container

### DIFF
--- a/lua/avante/sidebar.lua
+++ b/lua/avante/sidebar.lua
@@ -2834,12 +2834,14 @@ function Sidebar:create_selected_files_container()
     if #selected_filepaths_ == 0 then
       if self.selected_files_container and api.nvim_win_is_valid(self.selected_files_container.winid) then
         self.selected_files_container:unmount()
+        self:refresh_winids()
       end
       return
     end
 
     if not self.selected_files_container or not api.nvim_win_is_valid(self.selected_files_container.winid) then
       self:create_selected_files_container()
+      self:refresh_winids()
       if not self.selected_files_container or not api.nvim_win_is_valid(self.selected_files_container.winid) then
         Utils.warn("Failed to create or find selected files container window.")
         return


### PR DESCRIPTION
Noticed tab didn't work when the selected files container was toggled, so added the winids to be refreshed whenever it was toggled
