### PR TITLE
fix(sidebar): Reset old_result_lines in Sidebar:close to prevent content loss on resize

### DIFF
--- a/lua/avante/sidebar.lua
+++ b/lua/avante/sidebar.lua
@@ -221,6 +221,7 @@ function Sidebar:close(opts)
   for _, comp in pairs(self) do
     if comp and type(comp) == "table" and comp.unmount then comp:unmount() end
   end
+  self.old_result_lines = {}
   if opts.goto_code_win and self.code and self.code.winid and api.nvim_win_is_valid(self.code.winid) then
     fn.win_gotoid(self.code.winid)
   end


### PR DESCRIPTION
## Problem

When the Avante sidebar is open and the **cursor is in the code window**, triggering a `VimResize` event (e.g., by resizing the terminal or Neovim GUI window) can cause the sidebar content to disappear.

## Cause

The `VimResize` event triggers the `AvanteRefresh` command, which involves closing and then re-rendering the sidebar. The `old_result_lines` variable, which is crucial for diffing and updating the sidebar's content buffer, was not being reset when the `Sidebar:close` method was called.

As a result, when the sidebar was re-rendered after the `close` operation, the `update_content` function would compare the new content against a stale `old_result_lines` (from the previous, now closed, window instance). This often led to an incorrect diff calculation, resulting in an empty diff and thus no content being rendered in the newly created sidebar window.

## Solution

This commit addresses the issue by adding `self.old_result_lines = {}` at the beginning of the `Sidebar:close` method, right after its components are unmounted. This ensures that the cached state of the result lines is cleared whenever the sidebar is closed.

## Impact

With this change, when a `VimResize` event occurs and `AvanteRefresh` is executed:
1. The sidebar closes, and `old_result_lines` is correctly reset to an empty table.
2. The sidebar re-renders, and `update_content` now compares the history lines against a fresh (empty) `old_result_lines`, ensuring all content is correctly displayed in the new sidebar buffer.

This resolves the bug where sidebar content would vanish after a resize.

## Steps to Reproduce / Video Demonstration

https://github.com/user-attachments/assets/c76e7a65-7410-48d4-9333-3005f30fb4b8

