### PR TITLE
Fix has_permissions_to_access when file is not ignored but patter is a substring

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -33,6 +33,7 @@ temp/
 
 # Environment variable files (if you use .env file to store API keys)
 .env
+.envrc
 
 # If you use any build tools, you might need to ignore build output directories
 build/

--- a/lua/avante/utils/init.lua
+++ b/lua/avante/utils/init.lua
@@ -728,12 +728,16 @@ function M.parse_gitignore(gitignore_path)
   return ignore_patterns, negate_patterns
 end
 
+-- @param file string
+-- @param ignore_patterns string[]
+-- @param negate_patterns string[]
+-- @return boolean
 function M.is_ignored(file, ignore_patterns, negate_patterns)
   for _, pattern in ipairs(negate_patterns) do
     if file:match(pattern) then return false end
   end
   for _, pattern in ipairs(ignore_patterns) do
-    if file:match(pattern) then return true end
+    if file:match(pattern .. "/") or file:match(pattern .. "$") then return true end
   end
   return false
 end

--- a/tests/llm_tools/helpers_spec.lua
+++ b/tests/llm_tools/helpers_spec.lua
@@ -18,9 +18,7 @@ describe("has_permission_to_access", function()
     stub(Utils, "get_project_root", function() return test_dir end)
   end)
 
-  after_each(function()
-    os.execute("rm -rf " .. test_dir)
-  end)
+  after_each(function() os.execute("rm -rf " .. test_dir) end)
 
   it("Basic ignored and not ignored", function()
     local abs_path

--- a/tests/llm_tools/helpers_spec.lua
+++ b/tests/llm_tools/helpers_spec.lua
@@ -1,0 +1,50 @@
+local LlmToolHelpers = require("avante.llm_tools.helpers")
+local Utils = require("avante.utils")
+local stub = require("luassert.stub")
+
+describe("has_permission_to_access", function()
+  local test_dir = "/tmp/test_llm_tools_helpers"
+
+  before_each(function()
+    os.execute("mkdir -p " .. test_dir)
+    -- create .gitignore file with test.idx file
+    local gitignore_file = io.open(test_dir .. "/.gitignore", "w")
+    if gitignore_file then
+      gitignore_file:write("test.txt\n")
+      gitignore_file:write("data\n")
+      gitignore_file:close()
+    end
+    stub(Utils, "get_project_root", function() return test_dir end)
+  end)
+
+  after_each(function()
+    os.execute("rm -rf " .. test_dir)
+  end)
+
+  it("Basic ignored and not ignored", function()
+    local abs_path
+    abs_path = test_dir .. "/test.txt"
+    assert.is_false(LlmToolHelpers.has_permission_to_access(abs_path))
+
+    abs_path = test_dir .. "/test1.txt"
+    assert.is_true(LlmToolHelpers.has_permission_to_access(abs_path))
+  end)
+
+  it("Ignore files inside directories", function()
+    local abs_path
+    abs_path = test_dir .. "/data/test.txt"
+    assert.is_false(LlmToolHelpers.has_permission_to_access(abs_path))
+
+    abs_path = test_dir .. "/data/test1.txt"
+    assert.is_false(LlmToolHelpers.has_permission_to_access(abs_path))
+  end)
+
+  it("Do not ignore files with just similar paths", function()
+    local abs_path
+    abs_path = test_dir .. "/data_test/test.txt"
+    assert.is_true(LlmToolHelpers.has_permission_to_access(abs_path))
+
+    abs_path = test_dir .. "/data_test/test1.txt"
+    assert.is_true(LlmToolHelpers.has_permission_to_access(abs_path))
+  end)
+end)

--- a/tests/llm_tools/helpers_spec.lua
+++ b/tests/llm_tools/helpers_spec.lua
@@ -8,6 +8,7 @@ describe("has_permission_to_access", function()
   before_each(function()
     os.execute("mkdir -p " .. test_dir)
     -- create .gitignore file with test.idx file
+    os.execute("rm " .. test_dir .. "/.gitignore 2>/dev/null")
     local gitignore_file = io.open(test_dir .. "/.gitignore", "w")
     if gitignore_file then
       gitignore_file:write("test.txt\n")
@@ -42,7 +43,7 @@ describe("has_permission_to_access", function()
   it("Do not ignore files with just similar paths", function()
     local abs_path
     abs_path = test_dir .. "/data_test/test.txt"
-    assert.is_true(LlmToolHelpers.has_permission_to_access(abs_path))
+    assert.is_false(LlmToolHelpers.has_permission_to_access(abs_path))
 
     abs_path = test_dir .. "/data_test/test1.txt"
     assert.is_true(LlmToolHelpers.has_permission_to_access(abs_path))


### PR DESCRIPTION
Perceived issue:
when "data" is included in .gitignore file and the path to evaluate is "data_test/foo.txt", `is_ignored` function returns true when it should returns false.

Updates:
- Added tests for has_permission_to_access function
- Updated the is_ignored function to handle patterns that are substrings of rel_path but are not actually ignored.