### PR TITLE
refactor(sidebar&claude): Simplify Claude provider and unify sidebar UI behavior

### DIFF
--- a/lua/avante/providers/claude.lua
+++ b/lua/avante/providers/claude.lua
@@ -317,19 +317,8 @@ function M:parse_response(ctx, data_stream, event_state, opts)
     if jsn.delta.stop_reason == "end_turn" then
       opts.on_stop({ reason = "complete", usage = jsn.usage })
     elseif jsn.delta.stop_reason == "tool_use" then
-      local tool_use_list = {}
-      for _, content_block in ipairs(ctx.content_blocks) do
-        if content_block.type == "tool_use" then
-          table.insert(tool_use_list, {
-            id = content_block.id,
-            name = content_block.name,
-            input_json = content_block.input_json,
-          })
-        end
-      end
       opts.on_stop({
         reason = "tool_use",
-        -- tool_use_list = tool_use_list,
         usage = jsn.usage,
       })
     end

--- a/lua/avante/sidebar.lua
+++ b/lua/avante/sidebar.lua
@@ -2016,9 +2016,7 @@ function Sidebar:create_selected_code_container()
         winid = self.input_container.winid,
       },
       buf_options = buf_options,
-      win_options = {
-        winhighlight = base_win_options.winhighlight,
-      },
+      win_options = vim.tbl_deep_extend("force", base_win_options, {}),
       size = {
         height = selected_code_size + 3,
       },


### PR DESCRIPTION
**Summary:**

* Refactors `parse_response` in the Claude provider by removing the generation of `tool_use_list`, reducing complexity.  
* Unifies the sidebar's `selected_code_container` window options by using `vim.tbl_deep_extend` with base options for consistent behavior.