### PR TITLE
refactor(cmp): Extract get_chat_mentions for third-party cmp source usage

### DIFF
--- a/lua/avante/init.lua
+++ b/lua/avante/init.lua
@@ -494,7 +494,7 @@ function M.setup(opts)
 
     cmp.register_source("avante_mentions", require("cmp_avante.mentions"):new(Utils.get_chat_mentions))
 
-    cmp.register_source("avante_prompt_mentions", require("cmp_avante.mentions"):new(Utils.get_prompt_mentions))
+    cmp.register_source("avante_prompt_mentions", require("cmp_avante.mentions"):new(Utils.get_mentions))
 
     cmp.setup.filetype({ "AvanteInput" }, {
       enabled = true,

--- a/lua/avante/utils/init.lua
+++ b/lua/avante/utils/init.lua
@@ -914,7 +914,7 @@ function M.extract_mentions(content)
 end
 
 ---@return AvanteMention[]
-function M.get_prompt_mentions()
+function M.get_mentions()
   return {
     {
       description = "codebase",
@@ -931,7 +931,7 @@ end
 
 ---@return AvanteMention[]
 function M.get_chat_mentions()
-  local mentions = M.get_prompt_mentions()
+  local mentions = M.get_mentions()
 
   table.insert(mentions, {
     description = "file",

--- a/lua/cmp_avante/mentions.lua
+++ b/lua/cmp_avante/mentions.lua
@@ -1,11 +1,11 @@
 local api = vim.api
 
 ---@class mentions_source : cmp.Source
----@field get_mentions fun(): {description: string, command: AvanteMentions, details: string, shorthelp?: string, callback?: AvanteMentionCallback}[]
+---@field get_mentions fun(): AvanteMention[]
 local MentionsSource = {}
 MentionsSource.__index = MentionsSource
 
----@param get_mentions fun(): {description: string, command: AvanteMentions, details: string, shorthelp?: string, callback?: AvanteMentionCallback}[]
+---@param get_mentions fun(): AvanteMention[]
 function MentionsSource:new(get_mentions)
   local instance = setmetatable({}, MentionsSource)
 

--- a/tests/utils/init_spec.lua
+++ b/tests/utils/init_spec.lua
@@ -115,7 +115,7 @@ describe("Utils", function()
 
   describe("get_mentions", function()
     it("should return valid mentions", function()
-      local mentions = Utils.get_prompt_mentions()
+      local mentions = Utils.get_mentions()
       assert.equals("codebase", mentions[1].command)
       assert.equals("diagnostics", mentions[2].command)
     end)


### PR DESCRIPTION
## Summary

- Extracted the `get_chat_mentions` function to `lua/avante/utils/init.lua`.
- This change allows third-party cmp sources(eg. custom blink.cmp source) to easily access and utilize these mention suggestions.
- Updated relevant type definitions and function calls to accommodate this refactoring.
