### PR TITLE
fix: opening when buffer has scheme in path

### DIFF
--- a/lua/avante/file_selector.lua
+++ b/lua/avante/file_selector.lua
@@ -89,7 +89,7 @@ function FileSelector:reset()
 end
 
 function FileSelector:add_selected_file(filepath)
-  if not filepath or filepath == "" then return end
+  if not filepath or filepath == "" or has_scheme(filepath) then return end
 
   local absolute_path = filepath:sub(1, 1) == "/" and filepath or Utils.join_paths(Utils.get_project_root(), filepath)
   local stat = vim.loop.fs_stat(absolute_path)


### PR DESCRIPTION
When opening the sidebar with a new ask from a buffer which is has as scheme for the path such as `term://` the error shown below is thrown. This fix adds a `has_scheme` check to stop adding the path to the selected files

```
error reading file: /path/to/workspace/term:/path/to/workspace/21698:/bin/bash: No such file or directory
```