### PR TITLE
feat: support multiple models in one provider

### DIFF
--- a/lua/avante/types.lua
+++ b/lua/avante/types.lua
@@ -289,6 +289,7 @@ vim.g.avante_login = vim.g.avante_login
 ---@field parse_api_key? fun(): string | nil
 ---
 ---@class AvanteProviderFunctor
+---@field _model_list_cache table
 ---@field support_prompt_caching boolean | nil
 ---@field role_map table<"user" | "assistant", string>
 ---@field parse_messages AvanteMessagesParser


### PR DESCRIPTION
Multiple changes:
1. Support endpoint redirection for copilot, which is used by enterprise users.
2. Support having multiple models in one provider.
   Note: You will see more models in avante than in vscode or CopilotChat.nvim because they filter out models having multiple versions. In this implementation, I am showing all the versions.

![image](https://github.com/user-attachments/assets/5b35f7db-7290-4898-81f9-c1a999ae655a)
