### PR TITLE
feat: Add auto_approve_tool_permissions config allowing the confirm dialogs to be disabled in agentic mode

### DIFF
--- a/README.md
+++ b/README.md
@@ -1089,4 +1089,3 @@ avante.nvim is licensed under the Apache 2.0 License. For more details, please r
     </picture>
   </a>
 </p>
-

--- a/README.md
+++ b/README.md
@@ -357,12 +357,10 @@ _See [config.lua#L9](./lua/avante/config.lua) for the full config_
     support_paste_from_clipboard = false,
     minimize_diff = true, -- Whether to remove unchanged lines when applying a code block
     enable_token_counting = true, -- Whether to enable token counting. Default to true.
-  },
-  tool_permissions = {
-    auto_approve = false, -- Default: show permission prompts for all tools
+    auto_approve_tool_permissions = false, -- Default: show permission prompts for all tools
     -- Examples:
-    -- auto_approve = true,                -- Auto-approve all tools (no prompts)
-    -- auto_approve = {"bash", "replace_in_file"}, -- Auto-approve specific tools only
+    -- auto_approve_tool_permissions = true,                -- Auto-approve all tools (no prompts)
+    -- auto_approve_tool_permissions = {"bash", "replace_in_file"}, -- Auto-approve specific tools only
   },
   mappings = {
     --- @class AvanteConflictMappings
@@ -1091,3 +1089,4 @@ avante.nvim is licensed under the Apache 2.0 License. For more details, please r
     </picture>
   </a>
 </p>
+

--- a/README.md
+++ b/README.md
@@ -358,6 +358,12 @@ _See [config.lua#L9](./lua/avante/config.lua) for the full config_
     minimize_diff = true, -- Whether to remove unchanged lines when applying a code block
     enable_token_counting = true, -- Whether to enable token counting. Default to true.
   },
+  tool_permissions = {
+    auto_approve = false, -- Default: show permission prompts for all tools
+    -- Examples:
+    -- auto_approve = true,                -- Auto-approve all tools (no prompts)
+    -- auto_approve = {"bash", "replace_in_file"}, -- Auto-approve specific tools only
+  },
   mappings = {
     --- @class AvanteConflictMappings
     diff = {

--- a/lua/avante/config.lua
+++ b/lua/avante/config.lua
@@ -534,6 +534,11 @@ M._defaults = {
   disabled_tools = {}, ---@type string[]
   ---@type AvanteLLMToolPublic[] | fun(): AvanteLLMToolPublic[]
   custom_tools = {},
+  ---@class AvanteToolPermissions
+  ---@field public auto_approve boolean | string[] -- true: auto-approve all tools, false: normal prompts, string[]: auto-approve specific tools by name
+  tool_permissions = {
+    auto_approve = false, -- Default: show permission prompts for all tools
+  },
   ---@type AvanteSlashCommand[]
   slash_commands = {},
 }

--- a/lua/avante/config.lua
+++ b/lua/avante/config.lua
@@ -536,7 +536,6 @@ M._defaults = {
   disabled_tools = {}, ---@type string[]
   ---@type AvanteLLMToolPublic[] | fun(): AvanteLLMToolPublic[]
   custom_tools = {},
-
   ---@type AvanteSlashCommand[]
   slash_commands = {},
 }

--- a/lua/avante/config.lua
+++ b/lua/avante/config.lua
@@ -386,6 +386,8 @@ M._defaults = {
     enable_token_counting = true,
     use_cwd_as_project_root = false,
     auto_focus_on_diff_view = false,
+    ---@type boolean | string[] -- true: auto-approve all tools, false: normal prompts, string[]: auto-approve specific tools by name
+    auto_approve_tool_permissions = false, -- Default: show permission prompts for all tools
   },
   history = {
     max_tokens = 4096,
@@ -534,11 +536,7 @@ M._defaults = {
   disabled_tools = {}, ---@type string[]
   ---@type AvanteLLMToolPublic[] | fun(): AvanteLLMToolPublic[]
   custom_tools = {},
-  ---@class AvanteToolPermissions
-  ---@field public auto_approve boolean | string[] -- true: auto-approve all tools, false: normal prompts, string[]: auto-approve specific tools by name
-  tool_permissions = {
-    auto_approve = false, -- Default: show permission prompts for all tools
-  },
+
   ---@type AvanteSlashCommand[]
   slash_commands = {},
 }

--- a/lua/avante/llm_tools/bash.lua
+++ b/lua/avante/llm_tools/bash.lua
@@ -246,7 +246,8 @@ function M.func(opts, on_log, on_complete, session_ctx)
       end, abs_path)
     end,
     { focus = true },
-    session_ctx
+    session_ctx,
+    M.name -- Pass the tool name for permission checking
   )
 end
 

--- a/lua/avante/llm_tools/create.lua
+++ b/lua/avante/llm_tools/create.lua
@@ -75,7 +75,7 @@ function M.func(opts, on_log, on_complete, session_ctx)
     vim.cmd("noautocmd write")
     vim.api.nvim_set_current_win(current_winid)
     on_complete(true, nil)
-  end, { focus = true }, session_ctx)
+  end, { focus = true }, session_ctx, M.name)
 end
 
 return M

--- a/lua/avante/llm_tools/helpers.lua
+++ b/lua/avante/llm_tools/helpers.lua
@@ -23,11 +23,30 @@ end
 ---@param callback fun(yes: boolean, reason?: string)
 ---@param confirm_opts? { focus?: boolean }
 ---@param session_ctx? table
+---@param tool_name? string -- Optional tool name to check against tool_permissions config
 ---@return avante.ui.Confirm | nil
-function M.confirm(message, callback, confirm_opts, session_ctx)
+function M.confirm(message, callback, confirm_opts, session_ctx, tool_name)
   if session_ctx and session_ctx.always_yes then
     callback(true)
     return
+  end
+  
+  -- Check tool_permissions config for auto-approval
+  if tool_name then
+    local Config = require("avante.config")
+    local auto_approve = Config.tool_permissions.auto_approve
+    
+    -- If auto_approve is true, auto-approve all tools
+    if auto_approve == true then
+      callback(true)
+      return
+    end
+    
+    -- If auto_approve is a table (array of tool names), check if this tool is in the list
+    if type(auto_approve) == "table" and vim.tbl_contains(auto_approve, tool_name) then
+      callback(true)
+      return
+    end
   end
   local Confirm = require("avante.ui.confirm")
   local sidebar = require("avante").get()

--- a/lua/avante/llm_tools/helpers.lua
+++ b/lua/avante/llm_tools/helpers.lua
@@ -31,10 +31,10 @@ function M.confirm(message, callback, confirm_opts, session_ctx, tool_name)
     return
   end
 
-  -- Check tool_permissions config for auto-approval
+  -- Check behaviour.auto_approve_tool_permissions config for auto-approval
   if tool_name then
     local Config = require("avante.config")
-    local auto_approve = Config.tool_permissions.auto_approve
+    local auto_approve = Config.behaviour.auto_approve_tool_permissions
 
     -- If auto_approve is true, auto-approve all tools
     if auto_approve == true then

--- a/lua/avante/llm_tools/helpers.lua
+++ b/lua/avante/llm_tools/helpers.lua
@@ -30,18 +30,18 @@ function M.confirm(message, callback, confirm_opts, session_ctx, tool_name)
     callback(true)
     return
   end
-  
+
   -- Check tool_permissions config for auto-approval
   if tool_name then
     local Config = require("avante.config")
     local auto_approve = Config.tool_permissions.auto_approve
-    
+
     -- If auto_approve is true, auto-approve all tools
     if auto_approve == true then
       callback(true)
       return
     end
-    
+
     -- If auto_approve is a table (array of tool names), check if this tool is in the list
     if type(auto_approve) == "table" and vim.tbl_contains(auto_approve, tool_name) then
       callback(true)

--- a/lua/avante/llm_tools/helpers.lua
+++ b/lua/avante/llm_tools/helpers.lua
@@ -32,21 +32,19 @@ function M.confirm(message, callback, confirm_opts, session_ctx, tool_name)
   end
 
   -- Check behaviour.auto_approve_tool_permissions config for auto-approval
-  if tool_name then
-    local Config = require("avante.config")
-    local auto_approve = Config.behaviour.auto_approve_tool_permissions
+  local Config = require("avante.config")
+  local auto_approve = Config.behaviour.auto_approve_tool_permissions
 
-    -- If auto_approve is true, auto-approve all tools
-    if auto_approve == true then
-      callback(true)
-      return
-    end
+  -- If auto_approve is true, auto-approve all tools
+  if auto_approve == true then
+    callback(true)
+    return
+  end
 
-    -- If auto_approve is a table (array of tool names), check if this tool is in the list
-    if type(auto_approve) == "table" and vim.tbl_contains(auto_approve, tool_name) then
-      callback(true)
-      return
-    end
+  -- If auto_approve is a table (array of tool names), check if this tool is in the list
+  if type(auto_approve) == "table" and vim.tbl_contains(auto_approve, tool_name) then
+    callback(true)
+    return
   end
   local Confirm = require("avante.ui.confirm")
   local sidebar = require("avante").get()

--- a/lua/avante/llm_tools/insert.lua
+++ b/lua/avante/llm_tools/insert.lua
@@ -92,7 +92,7 @@ function M.func(opts, on_log, on_complete, session_ctx)
     vim.api.nvim_buf_call(bufnr, function() vim.cmd("noautocmd write") end)
     if session_ctx then Helpers.mark_as_not_viewed(opts.path, session_ctx) end
     on_complete(true, nil)
-  end, { focus = true }, session_ctx)
+  end, { focus = true }, session_ctx, M.name)
 end
 
 return M

--- a/lua/avante/llm_tools/replace_in_file.lua
+++ b/lua/avante/llm_tools/replace_in_file.lua
@@ -541,7 +541,7 @@ function M.func(opts, on_log, on_complete, session_ctx)
     vim.api.nvim_buf_call(bufnr, function() vim.cmd("noautocmd write") end)
     if session_ctx then Helpers.mark_as_not_viewed(opts.path, session_ctx) end
     on_complete(true, nil)
-  end, { focus = not Config.behaviour.auto_focus_on_diff_view }, session_ctx)
+  end, { focus = not Config.behaviour.auto_focus_on_diff_view }, session_ctx, M.name)
 end
 
 return M

--- a/lua/avante/llm_tools/undo_edit.lua
+++ b/lua/avante/llm_tools/undo_edit.lua
@@ -61,7 +61,7 @@ function M.func(opts, on_log, on_complete, session_ctx)
     vim.api.nvim_buf_call(bufnr, function() vim.cmd("noautocmd write") end)
     if session_ctx then Helpers.mark_as_not_viewed(opts.path, session_ctx) end
     on_complete(true, nil)
-  end, { focus = true }, session_ctx)
+  end, { focus = true }, session_ctx, M.name)
 end
 
 return M


### PR DESCRIPTION
### Summary
- Adds a new `behaviour.auto_approve_tool_permissions` configuration option to control when users are prompted before tool execution
- Provides flexible control over tool execution permissions with three modes: prompt for all (default), auto-approve all, or auto-approve specific tools only

### Changes Made
- **Config**: Added `auto_approve_tool_permissions` field to the `behaviour` configuration table supporting boolean or string table values
- **Helpers**: Enhanced `confirm()` function to check tool permissions before showing prompts, with automatic approval based on configuration
- **Tools**: Updated all LLM tools (`bash`, `create`, `insert`, `replace_in_file`, `undo_edit`) to pass tool names for permission checking
- **Documentation**: Added configuration examples in README showing all three usage patterns

### Configuration Options
```lua
behaviour = {
  auto_approve_tool_permissions = false,                    -- Default: show prompts for all tools
  -- auto_approve_tool_permissions = true,                  -- Auto-approve all tools (no prompts)
  -- auto_approve_tool_permissions = {"bash", "replace_in_file"}, -- Auto-approve specific tools only
}
```
