### PR TITLE
feat: load templates from cache and project directories

### DIFF
--- a/lua/avante/llm.lua
+++ b/lua/avante/llm.lua
@@ -145,7 +145,7 @@ function M.generate_prompts(opts)
   end
 
   local project_root = Utils.root.get()
-  Path.prompts.initialize(Path.prompts.get_templates_dir(project_root))
+  Path.prompts.initialize(Path.prompts.get_templates_dir(project_root), project_root)
 
   local tool_id_to_tool_name = {}
   local tool_id_to_path = {}

--- a/lua/avante/path.lua
+++ b/lua/avante/path.lua
@@ -244,7 +244,9 @@ function Prompt.render_mode(mode, opts)
   return _templates_lib.render(filepath, opts)
 end
 
-function Prompt.initialize(directory) _templates_lib.initialize(directory) end
+function Prompt.initialize(cache_directory, project_directory)
+  _templates_lib.initialize(cache_directory, project_directory)
+end
 
 P.prompts = Prompt
 


### PR DESCRIPTION
This adds a custom loader to the templates where both project cache directories and the project directory are searched.
This allows one to load files from the project directory potentially reusing rules from vscode or cursor.
Example `agentic.avanterules` from one of my projects:
```
{% include './.github/instructions/project.instructions.md' %}
```