### PR TITLE
feat: allow overriding provider headers

### DIFF
--- a/lua/avante/providers/azure.lua
+++ b/lua/avante/providers/azure.lua
@@ -58,7 +58,7 @@ function M:parse_curl_args(prompt_opts)
     ),
     proxy = provider_conf.proxy,
     insecure = provider_conf.allow_insecure,
-    headers = headers,
+    headers = Utils.tbl_override(headers, self.headers),
     body = vim.tbl_deep_extend("force", {
       messages = self:parse_messages(prompt_opts),
       stream = true,

--- a/lua/avante/providers/bedrock.lua
+++ b/lua/avante/providers/bedrock.lua
@@ -152,7 +152,7 @@ function M:parse_curl_args(prompt_opts)
     url = endpoint,
     proxy = provider_conf.proxy,
     insecure = provider_conf.allow_insecure,
-    headers = headers,
+    headers = Utils.tbl_override(headers, self.headers),
     body = body_payload,
     rawArgs = rawArgs,
   }

--- a/lua/avante/providers/claude.lua
+++ b/lua/avante/providers/claude.lua
@@ -392,7 +392,7 @@ function M:parse_curl_args(prompt_opts)
     url = Utils.url_join(provider_conf.endpoint, "/v1/messages"),
     proxy = provider_conf.proxy,
     insecure = provider_conf.allow_insecure,
-    headers = headers,
+    headers = Utils.tbl_override(headers, self.headers),
     body = vim.tbl_deep_extend("force", {
       model = provider_conf.model,
       system = {

--- a/lua/avante/providers/cohere.lua
+++ b/lua/avante/providers/cohere.lua
@@ -95,7 +95,7 @@ function M:parse_curl_args(prompt_opts)
     url = Utils.url_join(provider_conf.endpoint, "/chat"),
     proxy = provider_conf.proxy,
     insecure = provider_conf.allow_insecure,
-    headers = headers,
+    headers = Utils.tbl_override(headers, self.headers),
     body = vim.tbl_deep_extend("force", {
       model = provider_conf.model,
       stream = true,

--- a/lua/avante/providers/copilot.lua
+++ b/lua/avante/providers/copilot.lua
@@ -222,12 +222,12 @@ function M:models_list()
   H.refresh_token(false, false)
   local provider_conf = Providers.parse_config(self)
   local curl_opts = {
-    headers = {
+    headers = Utils.tbl_override({
       ["Content-Type"] = "application/json",
       ["Authorization"] = "Bearer " .. M.state.github_token.token,
       ["Copilot-Integration-Id"] = "vscode-chat",
       ["Editor-Version"] = ("Neovim/%s.%s.%s"):format(vim.version().major, vim.version().minor, vim.version().patch),
-    },
+    }, self.headers),
     timeout = provider_conf.timeout,
     proxy = provider_conf.proxy,
     insecure = provider_conf.allow_insecure,
@@ -288,12 +288,11 @@ function M:parse_curl_args(prompt_opts)
     timeout = provider_conf.timeout,
     proxy = provider_conf.proxy,
     insecure = provider_conf.allow_insecure,
-    headers = {
-      ["Content-Type"] = "application/json",
+    headers = Utils.tbl_override({
       ["Authorization"] = "Bearer " .. M.state.github_token.token,
       ["Copilot-Integration-Id"] = "vscode-chat",
       ["Editor-Version"] = ("Neovim/%s.%s.%s"):format(vim.version().major, vim.version().minor, vim.version().patch),
-    },
+    }, self.headers),
     body = vim.tbl_deep_extend("force", {
       model = provider_conf.model,
       messages = self:parse_messages(prompt_opts),

--- a/lua/avante/providers/gemini.lua
+++ b/lua/avante/providers/gemini.lua
@@ -309,7 +309,7 @@ function M:parse_curl_args(prompt_opts)
     ),
     proxy = provider_conf.proxy,
     insecure = provider_conf.allow_insecure,
-    headers = { ["Content-Type"] = "application/json" },
+    headers = Utils.tbl_override({ ["Content-Type"] = "application/json" }, self.headers),
     body = M.prepare_request_body(self, prompt_opts, provider_conf, request_body),
   }
 end

--- a/lua/avante/providers/ollama.lua
+++ b/lua/avante/providers/ollama.lua
@@ -213,7 +213,7 @@ function M:parse_curl_args(prompt_opts)
 
   return {
     url = Utils.url_join(provider_conf.endpoint, "/api/chat"),
-    headers = headers,
+    headers = Utils.tbl_override(headers, self.headers),
     body = vim.tbl_deep_extend("force", {
       model = provider_conf.model,
       messages = self:parse_messages(prompt_opts),

--- a/lua/avante/providers/openai.lua
+++ b/lua/avante/providers/openai.lua
@@ -536,7 +536,7 @@ function M:parse_curl_args(prompt_opts)
     url = Utils.url_join(provider_conf.endpoint, "/chat/completions"),
     proxy = provider_conf.proxy,
     insecure = provider_conf.allow_insecure,
-    headers = headers,
+    headers = Utils.tbl_override(headers, self.headers),
     body = vim.tbl_deep_extend("force", {
       model = provider_conf.model,
       messages = self:parse_messages(prompt_opts),

--- a/lua/avante/providers/vertex.lua
+++ b/lua/avante/providers/vertex.lua
@@ -1,4 +1,5 @@
 local P = require("avante.providers")
+local Utils = require("avante.utils")
 local Gemini = require("avante.providers.gemini")
 
 ---@class AvanteProviderFunctor
@@ -50,10 +51,10 @@ function M:parse_curl_args(prompt_opts)
 
   return {
     url = url,
-    headers = {
+    headers = Utils.tbl_override({
       ["Authorization"] = "Bearer " .. bearer_token,
       ["Content-Type"] = "application/json; charset=utf-8",
-    },
+    }, self.headers),
     proxy = provider_conf.proxy,
     insecure = provider_conf.allow_insecure,
     body = Gemini.prepare_request_body(self, prompt_opts, provider_conf, request_body),

--- a/lua/avante/providers/vertex_claude.lua
+++ b/lua/avante/providers/vertex_claude.lua
@@ -1,4 +1,5 @@
 local P = require("avante.providers")
+local Utils = require("avante.utils")
 local Vertex = require("avante.providers.vertex")
 
 ---@class AvanteProviderFunctor
@@ -64,10 +65,10 @@ function M:parse_curl_args(prompt_opts)
 
   return {
     url = url,
-    headers = {
+    headers = Utils.tbl_override({
       ["Authorization"] = "Bearer " .. Vertex.parse_api_key(),
       ["Content-Type"] = "application/json; charset=utf-8",
-    },
+    }, self.headers),
     body = vim.tbl_deep_extend("force", {}, request_body),
   }
 end

--- a/lua/avante/types.lua
+++ b/lua/avante/types.lua
@@ -291,6 +291,7 @@ vim.g.avante_login = vim.g.avante_login
 ---
 ---@class AvanteProviderFunctor
 ---@field _model_list_cache table
+---@field headers function(table) -> table | table | nil
 ---@field support_prompt_caching boolean | nil
 ---@field role_map table<"user" | "assistant", string>
 ---@field parse_messages AvanteMessagesParser

--- a/lua/avante/utils/init.lua
+++ b/lua/avante/utils/init.lua
@@ -1662,4 +1662,10 @@ function M.count_lines(str)
   return count
 end
 
+function M.tbl_override(value, override)
+  override = override or {}
+  if type(override) == "function" then return override(value) or value end
+  return vim.tbl_extend("force", value, override)
+end
+
 return M


### PR DESCRIPTION
Use case:
* Supporting custom authorization while keeping rest of logic same.
* Override `Editor-Version`, `Copilot-Integration-Id` in case neovim isn't supported ( our case. )