### PR TITLE
chore: vim.validate deprecation change

### DIFF
--- a/lua/avante/config.lua
+++ b/lua/avante/config.lua
@@ -573,7 +573,11 @@ M._options = {}
 
 ---@param opts? avante.Config
 function M.setup(opts)
-  vim.validate({ opts = { opts, "table", true } })
+  if vim.fn.has("nvim-0.11") == 1 then
+    vim.validate("opts", opts, "table", true)
+  else
+    vim.validate({ opts = { opts, "table", true } })
+  end
 
   opts = opts or {}
 
@@ -719,7 +723,11 @@ function M.setup(opts)
     )
   end
 
-  vim.validate({ provider = { M._options.provider, "string", false } })
+  if vim.fn.has("nvim-0.11") == 1 then
+    vim.validate("provider", M._options.provider, "string", false)
+  else
+    vim.validate({ provider = { M._options.provider, "string", false } })
+  end
 
   for k, v in pairs(M._options.providers) do
     M._options.providers[k] = type(v) == "function" and v() or v
@@ -728,7 +736,11 @@ end
 
 ---@param opts table<string, any>
 function M.override(opts)
-  vim.validate({ opts = { opts, "table", true } })
+  if vim.fn.has("nvim-0.11") == 1 then
+    vim.validate("opts", opts, "table", true)
+  else
+    vim.validate({ opts = { opts, "table", true } })
+  end
 
   M._options = vim.tbl_deep_extend("force", M._options, opts or {})
 

--- a/lua/avante/highlights.lua
+++ b/lua/avante/highlights.lua
@@ -172,7 +172,11 @@ setmetatable(M, {
 ---@param rgb_24bit number 24-bit RGB value
 ---@return {r: integer, g: integer, b: integer} with keys 'r', 'g', 'b' in [0,255]
 function H.decode_24bit_rgb(rgb_24bit)
-  vim.validate({ rgb_24bit = { rgb_24bit, "number", true } })
+  if vim.fn.has("nvim-0.11") == 1 then
+    vim.validate("rgb_24bit", rgb_24bit, "number", true)
+  else
+    vim.validate({ rgb_24bit = { rgb_24bit, "number", true } })
+  end
   local r = band(rshift(rgb_24bit, 16), 255)
   local g = band(rshift(rgb_24bit, 8), 255)
   local b = band(rgb_24bit, 255)


### PR DESCRIPTION
vim.validate spec form deprecated in neovim 0.11 https://github.com/neovim/neovim/pull/30855