### PR TITLE
fix: hide gcloud error messages for vertex

### DIFF
--- a/lua/avante/providers/vertex.lua
+++ b/lua/avante/providers/vertex.lua
@@ -17,7 +17,7 @@ M.parse_response = Gemini.parse_response
 M.transform_to_function_declaration = Gemini.transform_to_function_declaration
 
 local function execute_command(command)
-  local handle = io.popen(command)
+  local handle = io.popen(command .. " 2>/dev/null")
   if not handle then error("Failed to execute command: " .. command) end
   local result = handle:read("*a")
   handle:close()


### PR DESCRIPTION
fixes #2154 

occurs when gcloud is not installed on system. 

stderr has no value when being called, was not being handled, and additionally was not relevant to populating the api key; so the fix was just to pipe the error to `/dev/null`

**Before**

![Screenshot 2025-06-06 at 5 04 01 PM](https://github.com/user-attachments/assets/ca810568-160d-4ad2-89dc-9e0ed9f87cd4)

**After**

![Screenshot 2025-06-06 at 5 11 29 PM](https://github.com/user-attachments/assets/ab96029b-6858-44c5-942c-db6c4eed3de9)

