### PR TITLE
feat: download only valid artifacts or build them

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -51,36 +51,48 @@ LUA_VERSION="${LUA_VERSION:-luajit}"
 ARTIFACT_NAME_PATTERN="avante_lib-$PLATFORM-$ARCH-$LUA_VERSION"
 
 test_command() {
-    command -v "$1" >/dev/null 2>&1
+  command -v "$1" >/dev/null 2>&1
 }
 
 test_gh_auth() {
-    if gh api user >/dev/null 2>&1; then
-        return 0
-    else
-        return 1
-    fi
+  if gh api user >/dev/null 2>&1; then
+    return 0
+  else
+    return 1
+  fi
 }
 
 if [ ! -d "$TARGET_DIR" ]; then
-    mkdir -p "$TARGET_DIR"
+  mkdir -p "$TARGET_DIR"
 fi
 
-latest_tag_time=$(git tag --sort=-creatordate | xargs git log -1 --format=%at)
-current_build_time=$(stat -c %Y build/avante_html2md* 2>/dev/null || echo "$latest_tag_time")
-if [[ "$latest_tag_time" -ge "$current_build_time" ]]; then
+latest_tag="$(git describe --tags --abbrev=0 || true)" # will be empty in clone repos
+built_tag="$(cat build/.tag 2>/dev/null || true)"
+
+save_tag() {
+  echo "$latest_tag" >build/.tag
+}
+
+if [[ "$latest_tag" = "$built_tag" && -n "$latest_tag" ]]; then
+  echo "Local build is up to date. No download needed."
+elif [[ "$latest_tag" != "$built_tag" && -n "$latest_tag" ]]; then
   if test_command "gh" && test_gh_auth; then
-    gh release download --repo "github.com/$REPO_OWNER/$REPO_NAME" --pattern "*$ARTIFACT_NAME_PATTERN*" --clobber --output - | tar -zxv -C "$TARGET_DIR"
+    gh release download "$latest_tag" --repo "github.com/$REPO_OWNER/$REPO_NAME" --pattern "*$ARTIFACT_NAME_PATTERN*" --clobber --output - | tar -zxv -C "$TARGET_DIR"
+    save_tag
   else
     # Get the artifact download URL
-    ARTIFACT_URL=$(curl -s "https://api.github.com/repos/$REPO_OWNER/$REPO_NAME/releases/latest" | grep "browser_download_url" | cut -d '"' -f 4 | grep $ARTIFACT_NAME_PATTERN)
+    ARTIFACT_URL=$(curl -s "https://api.github.com/repos/$REPO_OWNER/$REPO_NAME/releases/tags/$latest_tag" | grep "browser_download_url" | cut -d '"' -f 4 | grep $ARTIFACT_NAME_PATTERN)
 
     set -x
 
     mkdir -p "$TARGET_DIR"
 
     curl -L "$ARTIFACT_URL" | tar -zxv -C "$TARGET_DIR"
+    save_tag
   fi
 else
-  echo "Local build is up to date. No download needed."
+  cargo build --release --features=$LUA_VERSION
+  for f in target/release/lib*.so; do
+    cp "$f" "build/$(echo $f | sed 's#.*/lib##')"
+  done
 fi


### PR DESCRIPTION
fixes https://github.com/yetone/avante.nvim/issues/2193
fixes https://github.com/yetone/avante.nvim/issues/2142

Fixes an issue where the artifacts/libs were always the latest from GitHub while the source at local could be older.