### PR TITLE
fix(read-file-or-buf): report error when path is a directory

### DIFF
--- a/lua/avante/utils/init.lua
+++ b/lua/avante/utils/init.lua
@@ -1103,6 +1103,9 @@ function M.read_file_from_buf_or_disk(filepath)
     return lines, nil
   end
 
+  local stat = vim.uv.fs_stat(abs_path)
+  if stat and stat.type == "directory" then return {}, "Cannot read a directory as file" .. filepath end
+
   -- Fallback: read file from disk
   local file, open_err = io.open(abs_path, "r")
   if file then


### PR DESCRIPTION
If the llm executes write_to_file using a directory path, `io.open` will still open it however reading the content results in a runtime error and no feedback is provided to indicate a failure.

```lua
  -- Fallback: read file from disk
  local file, open_err = io.open(abs_path, "r")
  if file then
    local content = file:read("*all")
    file:close()
    content = content:gsub("\r\n", "\n") -- error here: content is nil.
    return vim.split(content, "\n"), nil
  else
    return {}, open_err
  end
```