### PR TITLE
Dont remove indent in replace_in_file

### DIFF
--- a/lua/avante/llm_tools/replace_in_file.lua
+++ b/lua/avante/llm_tools/replace_in_file.lua
@@ -203,7 +203,7 @@ function M.func(opts, on_log, on_complete, session_ctx)
     for i = 1, #original_lines - #old_lines + 1 do
       local match = true
       for j = 1, #old_lines do
-        if Utils.remove_indentation(original_lines[i + j - 1]) ~= Utils.remove_indentation(old_lines[j]) then
+        if original_lines[i + j - 1] ~= old_lines[j] then
           match = false
           break
         end


### PR DESCRIPTION
In JSON, removing indentation makes its match the `SEARCH` block in the wrong place