### PR TITLE
fix: error when adding files where root != cwd

### DIFF
--- a/lua/avante/sidebar.lua
+++ b/lua/avante/sidebar.lua
@@ -3088,9 +3088,11 @@ function Sidebar:create_selected_files_container()
     local lines_to_set = {}
     local highlights_to_apply = {}
 
+    local project_path = Utils.root.get()
     for i, filepath in ipairs(selected_filepaths_) do
       local icon, hl = Utils.file.get_file_icon(filepath)
-      local formatted_line = string.format("%s %s", icon, filepath)
+      local renderpath = PPath:new(filepath):normalize(project_path)
+      local formatted_line = string.format("%s %s", icon, renderpath)
       table.insert(lines_to_set, formatted_line)
       if hl and hl ~= "" then table.insert(highlights_to_apply, { line_nr = i, icon = icon, hl = hl }) end
     end

--- a/lua/avante/utils/init.lua
+++ b/lua/avante/utils/init.lua
@@ -921,6 +921,12 @@ function M.is_absolute_path(path)
   return path:match("^/") ~= nil
 end
 
+function M.to_absolute_path(path)
+  if not path or path == "" then return path end
+  if path:sub(1, 1) == "/" or path:sub(1, 7) == "term://" then return path end
+  return M.join_paths(M.get_project_root(), path)
+end
+
 function M.join_paths(...)
   local paths = { ... }
   local result = paths[1] or ""


### PR DESCRIPTION
fixes https://github.com/yetone/avante.nvim/issues/2046
fixes https://github.com/yetone/avante.nvim/issues/2143

Issue: adding files where project_root of file is not same as cwd creates error.
Fix: Store absolute path in selected_filepaths. While rendering, render them relative to project_root

Now, the selected files window looks like

![image](https://github.com/user-attachments/assets/5aefa1d2-7ec1-43c6-a7f3-17adb320a0a9)
