### PR TITLE
Fix - Don’t execute incomplete streaming commands

### DIFF
--- a/lua/avante/llm_tools/attempt_completion.lua
+++ b/lua/avante/llm_tools/attempt_completion.lua
@@ -74,7 +74,15 @@ function M.func(opts, on_log, on_complete, session_ctx)
   if not on_complete then return false, "on_complete not provided" end
   local sidebar = require("avante").get()
   if not sidebar then return false, "Avante sidebar not found" end
+
+  local is_streaming = opts.streaming or false
+  if is_streaming then
+    -- wait for stream completion as command may not be complete yet
+    return
+  end
+
   session_ctx.attempt_completion_is_called = true
+
   if opts.command and opts.command ~= vim.NIL and opts.command ~= "" and not vim.startswith(opts.command, "open ") then
     session_ctx.always_yes = false
     require("avante.llm_tools.bash").func({ command = opts.command }, on_log, on_complete, session_ctx)

--- a/lua/avante/llm_tools/bash.lua
+++ b/lua/avante/llm_tools/bash.lua
@@ -216,11 +216,18 @@ M.returns = {
 
 ---@type AvanteLLMToolFunc<{ path: string, command: string }>
 function M.func(opts, on_log, on_complete, session_ctx)
+  local is_streaming = opts.streaming or false
+  if is_streaming then
+    -- wait for stream completion as command may not be complete yet
+    return
+  end
+
   local abs_path = Helpers.get_abs_path(opts.path)
   if not Helpers.has_permission_to_access(abs_path) then return false, "No permission to access path: " .. abs_path end
   if not Path:new(abs_path):exists() then return false, "Path not found: " .. abs_path end
   if not opts.command then return false, "Command is required" end
   if on_log then on_log("command: " .. opts.command) end
+
   ---change cwd to abs_path
   ---@param output string
   ---@param exit_code integer

--- a/lua/avante/llm_tools/bash.lua
+++ b/lua/avante/llm_tools/bash.lua
@@ -214,7 +214,7 @@ M.returns = {
   },
 }
 
----@type AvanteLLMToolFunc<{ path: string, command: string }>
+---@type AvanteLLMToolFunc<{ path: string, command: string, streaming?: boolean }>
 function M.func(opts, on_log, on_complete, session_ctx)
   local is_streaming = opts.streaming or false
   if is_streaming then


### PR DESCRIPTION
Both the bash and attempt_completion tools weren’t checking if the arguments were partial / still being streamed, resulting in multiple confirmation popups with incomplete commands