### PR TITLE
fix: when initialize the avante, dont mark the current buffer as selected if it's a directory path

### DIFF
--- a/lua/avante/sidebar.lua
+++ b/lua/avante/sidebar.lua
@@ -1437,7 +1437,8 @@ function Sidebar:initialize()
 
   self.file_selector:reset()
 
-  if Utils.path.is_exist_filepath(filepath) then self.file_selector:add_selected_file(filepath) end
+  local stat = vim.uv.fs_stat(filepath)
+  if stat == nil or stat.type == "file" then self.file_selector:add_selected_file(filepath) end
 
   self:reload_chat_history()
 

--- a/lua/avante/sidebar.lua
+++ b/lua/avante/sidebar.lua
@@ -1436,7 +1436,8 @@ function Sidebar:initialize()
   Utils.debug("Sidebar:initialize adding buffer to file selector", buf_path)
 
   self.file_selector:reset()
-  self.file_selector:add_selected_file(filepath)
+
+  if Utils.path.is_exist_filepath(filepath) then self.file_selector:add_selected_file(filepath) end
 
   self:reload_chat_history()
 


### PR DESCRIPTION
This pull request updates the `Sidebar:initialize` function in `lua/avante/sidebar.lua` to improve file selection behavior. Specifically, it adds a check to ensure the provided file path exists before adding it to the file selector.

* [`lua/avante/sidebar.lua`](diffhunk://#diff-ddcb4139fbc53f068a08051ae32665c76507f66698fe427fcfdd384a36dce2fcL1439-R1440): Updated the `Sidebar:initialize` method to verify the existence of `filepath` using `Utils.path.is_exist_filepath` before calling `add_selected_file`.