### PR TITLE
fix: handle user-declined tool executions separately from errors

### DIFF
--- a/lua/avante/llm.lua
+++ b/lua/avante/llm.lua
@@ -682,6 +682,7 @@ function M._stream(opts)
                   tool_use_id = tool_result.tool_use_id,
                   content = tool_result.content,
                   is_error = tool_result.is_error,
+                  is_user_declined = tool_result.is_user_declined,
                 },
               },
             })
@@ -726,10 +727,12 @@ function M._stream(opts)
             return opts.on_stop({ reason = "cancelled" })
           end
 
+          local is_user_declined = error and error:match("^User declined")
           local tool_result = {
             tool_use_id = partial_tool_use.id,
             content = error ~= nil and error or result,
-            is_error = error ~= nil,
+            is_error = error ~= nil, -- Keep this as error to prevent processing as success
+            is_user_declined = is_user_declined ~= nil,
           }
           table.insert(tool_results, tool_result)
           return handle_next_tool_use(partial_tool_use_list, tool_use_index + 1, tool_results)

--- a/lua/avante/types.lua
+++ b/lua/avante/types.lua
@@ -116,6 +116,7 @@ vim.g.avante_login = vim.g.avante_login
 ---@field tool_use_id string
 ---@field content string
 ---@field is_error? boolean
+---@field is_user_declined? boolean
 ---
 ---@class AvantePromptOptions: table<[string], string>
 ---@field system_prompt string


### PR DESCRIPTION
Previously, when users declined tool executions (like file edits), these were treated the same as actual tool errors. This caused user-declined operations to be incorrectly tracked as failed edits and affected history message processing.

This fix introduces an `is_user_declined` field to distinguish between:
- Actual tool execution errors
- User-declined tool executions
- Successful tool executions

Changes:
- Add `is_user_declined` field to tool result types
- Detect user decline messages in LLM streaming
- Update history processing to exclude user-declined operations from failed edit tracking
- Ensure proper context handling for AI interactions

Fixes the issue where user declining an operation would incorrectly be treated as a tool failure.