### PR TITLE
Make Example LazyVim Config Automatically Handle Cross-Platform Installs

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,8 +74,15 @@ For building binary if you wish to build from source, then `cargo` is required. 
 {
   "yetone/avante.nvim",
   -- if you want to build from source then do `make BUILD_FROM_SOURCE=true`
-  build = "make",  -- ⚠️ must add this line! ! !
-  -- build = "powershell -ExecutionPolicy Bypass -File Build.ps1 -BuildFromSource false" -- for windows
+  -- ⚠️ must add this setting! ! !
+  build = function()
+    -- conditionally use the correct build system for the current OS
+    if vim.fn.has("win32") == 1 then
+      return "powershell -ExecutionPolicy Bypass -File Build.ps1 -BuildFromSource false"
+    else
+      return "make"
+    end
+  end,
   event = "VeryLazy",
   version = false, -- Never set this value to "*"! Never!
   ---@module 'avante'


### PR DESCRIPTION
I like using the same config across multiple os's without manually editing my config, so I changed up the example config to support that. Hurts readability slightly, but has the advantage of no longer needing to be readable anymore because it should just work in most cases.