### PR TITLE
feat: scoped API key support with AVANTE_ prefix

### DIFF
--- a/README.md
+++ b/README.md
@@ -694,6 +694,24 @@ Given its early stage, `avante.nvim` currently supports the following basic func
 > For most consistency between neovim session, it is recommended to set the environment variables in your shell file.
 > By default, `Avante` will prompt you at startup to input the API key for the provider you have selected.
 >
+> **Scoped API Keys (Recommended for Isolation)**
+>
+> Avante now supports scoped API keys, allowing you to isolate API keys specifically for Avante without affecting other applications. Simply prefix any API key with `AVANTE_`:
+>
+> ```sh
+> # Scoped keys (recommended)
+> export AVANTE_ANTHROPIC_API_KEY=your-claude-api-key
+> export AVANTE_OPENAI_API_KEY=your-openai-api-key
+> export AVANTE_AZURE_OPENAI_API_KEY=your-azure-api-key
+> export AVANTE_GEMINI_API_KEY=your-gemini-api-key
+> export AVANTE_CO_API_KEY=your-cohere-api-key
+> export AVANTE_AIHUBMIX_API_KEY=your-aihubmix-api-key
+> ```
+>
+> **Global API Keys (Legacy)**
+>
+> You can still use the traditional global API keys if you prefer:
+>
 > For Claude:
 >
 > ```sh

--- a/README_zh.md
+++ b/README_zh.md
@@ -549,6 +549,24 @@ _请参见 [config.lua#L9](./lua/avante/config.lua) 以获取完整配置_
 > 为了在 neovim 会话之间保持一致性，建议在 shell 文件中设置环境变量。
 > 默认情况下，`Avante` 会在启动时提示您输入所选提供者的 API 密钥。
 >
+> **作用域 API 密钥（推荐用于隔离）**
+>
+> Avante 现在支持作用域 API 密钥，允许您专门为 Avante 隔离 API 密钥，而不影响其他应用程序。只需在任何 API 密钥前加上 `AVANTE_` 前缀：
+>
+> ```sh
+> # 作用域密钥（推荐）
+> export AVANTE_ANTHROPIC_API_KEY=your-claude-api-key
+> export AVANTE_OPENAI_API_KEY=your-openai-api-key
+> export AVANTE_AZURE_OPENAI_API_KEY=your-azure-api-key
+> export AVANTE_GEMINI_API_KEY=your-gemini-api-key
+> export AVANTE_CO_API_KEY=your-cohere-api-key
+> export AVANTE_AIHUBMIX_API_KEY=your-aihubmix-api-key
+> ```
+>
+> **全局 API 密钥（传统方式）**
+>
+> 如果您愿意，仍然可以使用传统的全局 API 密钥：
+>
 > 对于 Claude：
 >
 > ```sh

--- a/lua/avante/providers/init.lua
+++ b/lua/avante/providers/init.lua
@@ -33,7 +33,7 @@ function E.parse_envvar(Opts)
       scoped_key_name = "AVANTE_" .. Opts.api_key_name
     end
   end
-  
+
   -- Try scoped key first if available
   if scoped_key_name then
     local scoped_value = Utils.environment.parse(scoped_key_name, Opts._shellenv)
@@ -42,7 +42,7 @@ function E.parse_envvar(Opts)
       return scoped_value
     end
   end
-  
+
   -- Fall back to the original global key
   local value = Utils.environment.parse(Opts.api_key_name, Opts._shellenv)
   if value ~= nil then

--- a/lua/avante/providers/init.lua
+++ b/lua/avante/providers/init.lua
@@ -25,6 +25,25 @@ E.cache = {}
 ---@param Opts AvanteSupportedProvider | AvanteProviderFunctor | AvanteBedrockProviderFunctor
 ---@return string | nil
 function E.parse_envvar(Opts)
+  -- First try the scoped version (e.g., AVANTE_ANTHROPIC_API_KEY)
+  local scoped_key_name = nil
+  if Opts.api_key_name and type(Opts.api_key_name) == "string" and Opts.api_key_name ~= "" then
+    -- Only add AVANTE_ prefix if it's a regular environment variable (not a cmd: or already prefixed)
+    if not Opts.api_key_name:match("^cmd:") and not Opts.api_key_name:match("^AVANTE_") then
+      scoped_key_name = "AVANTE_" .. Opts.api_key_name
+    end
+  end
+  
+  -- Try scoped key first if available
+  if scoped_key_name then
+    local scoped_value = Utils.environment.parse(scoped_key_name, Opts._shellenv)
+    if scoped_value ~= nil then
+      vim.g.avante_login = true
+      return scoped_value
+    end
+  end
+  
+  -- Fall back to the original global key
   local value = Utils.environment.parse(Opts.api_key_name, Opts._shellenv)
   if value ~= nil then
     vim.g.avante_login = true


### PR DESCRIPTION
Add support for scoped API keys by prefixing with AVANTE_ (e.g., AVANTE_ANTHROPIC_API_KEY)

Scoped keys take precedence over global keys for better isolation

Maintain full backward compatibility with existing global API keys

Update README.md and README_zh.md with comprehensive documentation

Smart handling to avoid double-prefixing and preserve command-based keys

Closes #2286