### PR TITLE
feat: fetch ollama models to display in the model selector

### DIFF
--- a/lua/avante/model_selector.lua
+++ b/lua/avante/model_selector.lua
@@ -75,6 +75,9 @@ function M.open()
     ::continue::
   end
 
+  -- Sort models by name for stable display
+  table.sort(models, function(a, b) return (a.name or "") < (b.name or "") end)
+
   if #models == 0 then
     Utils.warn("No models available in config")
     return

--- a/lua/avante/types.lua
+++ b/lua/avante/types.lua
@@ -290,6 +290,19 @@ vim.g.avante_login = vim.g.avante_login
 ---@alias AvanteLLMStopCallback fun(opts: AvanteLLMStopCallbackOptions): nil
 ---@alias AvanteLLMConfigHandler fun(opts: AvanteSupportedProvider): AvanteDefaultBaseProvider, table<string, any>
 ---
+---@class AvanteProviderModel
+---@field id string
+---@field name string
+---@field display_name string
+---@field provider_name string
+---@field version string
+---@field tokenizer? string
+---@field max_input_tokens? integer
+---@field max_output_tokens? integer
+---@field policy? boolean
+---
+---@alias AvanteProviderModelList AvanteProviderModel[]
+---
 ---@class AvanteProvider: AvanteSupportedProvider
 ---@field parse_curl_args? AvanteCurlArgsParser
 ---@field parse_stream_data? AvanteStreamParser
@@ -314,6 +327,7 @@ vim.g.avante_login = vim.g.avante_login
 ---@field on_error? fun(result: table<string, any>): nil
 ---@field transform_tool? fun(self: AvanteProviderFunctor, tool: AvanteLLMTool): AvanteOpenAITool | AvanteClaudeTool
 ---@field get_rate_limit_sleep_time? fun(self: AvanteProviderFunctor, headers: table<string, string>): integer | nil
+---@field models_list? fun(self): AvanteProviderModelList | nil
 ---
 ---@alias AvanteBedrockPayloadBuilder fun(self: AvanteBedrockModelHandler | AvanteBedrockProviderFunctor, prompt_opts: AvantePromptOptions, request_body: table<string, any>): table<string, any>
 ---


### PR DESCRIPTION
Rework or https://github.com/yetone/avante.nvim/pull/1841 on dynamic getter for copilot models.

Also sorts models just before displaying the picker so the model list is stable when initially presented.

Note that ollama provider needs `is_env_set` to return true before models are fetched. Ie,

```lua
provider = 'ollama',
providers = {
  ollama = {
    model = 'qwen2.5-coder:32b',
    is_env_set = function()
      return true
    end,
  },
},
```

Resulting list appears like:

<img width="1791" alt="Screenshot 2025-06-21 at 5 11 52 pm" src="https://github.com/user-attachments/assets/e3bb9c05-b668-49ee-aebd-c54c6b09fce9" />
