### PR TITLE
fix: fix formatting of `embed_extra` and `llm_extra`

### DIFF
--- a/lua/avante/rag_service.lua
+++ b/lua/avante/rag_service.lua
@@ -67,12 +67,12 @@ function M.launch_rag_service(cb)
 
   local embed_extra = "{}" -- Default to empty JSON object string
   if Config.rag_service and Config.rag_service.embed and Config.rag_service.embed.extra then
-    embed_extra = vim.json.encode(Config.rag_service.embed.extra):gsub('"', '\\"')
+    embed_extra = string.format("%q", vim.json.encode(Config.rag_service.embed.extra))
   end
 
   local llm_extra = "{}" -- Default to empty JSON object string
   if Config.rag_service and Config.rag_service.llm and Config.rag_service.llm.extra then
-    llm_extra = vim.json.encode(Config.rag_service.llm.extra):gsub('"', '\\"')
+    llm_extra = string.format("%q", vim.json.encode(Config.rag_service.llm.extra))
   end
 
   local port = M.get_rag_service_port()


### PR DESCRIPTION
- fix string formatting for `embed_extra` and `llm_extra` variables
#2177 

I've switched from using gsub() to string.format to handle the data. This ensures that the JSON is escaped correctly and prevents potential formatting errors.

