### PR TITLE
feat(provider): support to use azuredatabricks

### DIFF
--- a/README.md
+++ b/README.md
@@ -723,6 +723,7 @@ Given its early stage, `avante.nvim` currently supports the following basic func
 > export AVANTE_ANTHROPIC_API_KEY=your-claude-api-key
 > export AVANTE_OPENAI_API_KEY=your-openai-api-key
 > export AVANTE_AZURE_OPENAI_API_KEY=your-azure-api-key
+> export AVANTE_DATABRICKS_TOKEN=your-databricks-token
 > export AVANTE_GEMINI_API_KEY=your-gemini-api-key
 > export AVANTE_CO_API_KEY=your-cohere-api-key
 > export AVANTE_AIHUBMIX_API_KEY=your-aihubmix-api-key
@@ -936,6 +937,38 @@ providers = {
   },
 }
 ```
+
+## Azure Databricks
+
+Azure Databricks is a built-in provider for avante.nvim. It uses the OpenAI-compatible API provided by Azure Databricks serving endpoints. To use Azure Databricks:
+
+1. Set up your Azure Databricks workspace and create a serving endpoint
+2. Set your Databricks token in environment variables:
+
+```bash
+export DATABRICKS_TOKEN=your_databricks_token
+```
+
+3. Configure the provider in your setup:
+
+```lua
+provider = "azuredatabricks",
+providers = {
+  azuredatabricks = {
+    endpoint = "https://adb-2222222222222222.2.azuredatabricks.net/serving-endpoints",
+    model = "your-model-name",
+    timeout = 30000, -- Timeout in milliseconds
+    extra_request_body = {
+      temperature = 0.7,
+      max_tokens = 4096,
+    },
+  },
+},
+```
+
+> [!IMPORTANT]
+>
+> Make sure to replace the endpoint URL with your actual Azure Databricks workspace URL and serving endpoint path. The endpoint should point to your Databricks serving endpoints URL.
 
 ## Custom providers
 

--- a/README_zh.md
+++ b/README_zh.md
@@ -558,6 +558,7 @@ _请参见 [config.lua#L9](./lua/avante/config.lua) 以获取完整配置_
 > export AVANTE_ANTHROPIC_API_KEY=your-claude-api-key
 > export AVANTE_OPENAI_API_KEY=your-openai-api-key
 > export AVANTE_AZURE_OPENAI_API_KEY=your-azure-api-key
+> export AVANTE_DATABRICKS_TOKEN=your-databricks-token
 > export AVANTE_GEMINI_API_KEY=your-gemini-api-key
 > export AVANTE_CO_API_KEY=your-cohere-api-key
 > export AVANTE_AIHUBMIX_API_KEY=your-aihubmix-api-key
@@ -748,6 +749,38 @@ providers = {
   },
 }
 ```
+
+## Azure Databricks
+
+Azure Databricks 是 avante.nvim 的内置提供者。它使用 Azure Databricks 服务端点提供的 OpenAI 兼容 API。使用 Azure Databricks：
+
+1. 设置您的 Azure Databricks 工作区并创建服务端点
+2. 在环境变量中设置您的 Databricks 令牌：
+
+```bash
+export DATABRICKS_TOKEN=your_databricks_token
+```
+
+3. 在您的设置中配置提供者：
+
+```lua
+provider = "azuredatabricks",
+providers = {
+  azuredatabricks = {
+    endpoint = "https://adb-2222222222222222.2.azuredatabricks.net/serving-endpoints",
+    model = "your-model-name",
+    timeout = 30000, -- 超时时间（毫秒）
+    extra_request_body = {
+      temperature = 0.7,
+      max_tokens = 4096,
+    },
+  },
+},
+```
+
+> [!IMPORTANT]
+>
+> 确保将端点 URL 替换为您实际的 Azure Databricks 工作区 URL 和服务端点路径。端点应指向您的 Databricks 服务端点 URL。
 
 ## 自定义提供者
 

--- a/lua/avante/config.lua
+++ b/lua/avante/config.lua
@@ -23,7 +23,7 @@ M._defaults = {
   ---@alias avante.Mode "agentic" | "legacy"
   ---@type avante.Mode
   mode = "agentic",
-  ---@alias avante.ProviderName "claude" | "openai" | "azure" | "gemini" | "vertex" | "cohere" | "copilot" | "bedrock" | "ollama" | string
+  ---@alias avante.ProviderName "claude" | "openai" | "azure" | "azuredatabricks" | "gemini" | "vertex" | "cohere" | "copilot" | "bedrock" | "ollama" | string
   ---@type avante.ProviderName
   provider = "claude",
   -- WARNING: Since auto-suggestions are a high-frequency operation and therefore expensive,
@@ -267,6 +267,17 @@ M._defaults = {
         temperature = 0.75,
         max_completion_tokens = 20480, -- Increase this to include reasoning tokens (for reasoning models)
         reasoning_effort = "medium", -- low|medium|high, only used for reasoning models
+      },
+    },
+    ---@type AvanteSupportedProvider
+    azuredatabricks = {
+      endpoint = "", -- REQUIRED: Set to your Databricks serving endpoint URL, e.g., "https://adb-2222222222222222.2.azuredatabricks.net/serving-endpoints"
+      model = "databricks-claude-sonnet-4", -- REQUIRED: Set to your model name available in Databricks
+      timeout = 30000, -- Timeout in milliseconds
+      context_window = 200000,
+      extra_request_body = {
+        temperature = 0.75,
+        max_tokens = 20480, -- Databricks uses max_tokens instead of max_completion_tokens
       },
     },
     ---@type AvanteSupportedProvider

--- a/lua/avante/providers/azuredatabricks.lua
+++ b/lua/avante/providers/azuredatabricks.lua
@@ -1,0 +1,83 @@
+---@class AvanteAzureDatabricksExtraRequestBody
+---@field temperature number
+---@field max_tokens number
+
+---@class AvanteAzureDatabricksProvider: AvanteDefaultBaseProvider
+---@field databricks_base_url string
+---@field extra_request_body AvanteAzureDatabricksExtraRequestBody
+
+local Utils = require("avante.utils")
+local P = require("avante.providers")
+local O = require("avante.providers").openai
+
+---@class AvanteProviderFunctor
+local M = {}
+
+M.api_key_name = "DATABRICKS_TOKEN"
+
+-- Inherit from OpenAI class since Databricks uses OpenAI-compatible API
+setmetatable(M, { __index = O })
+
+function M.set_allowed_params(provider_conf, request_body)
+  -- Databricks doesn't support max_completion_tokens, use max_tokens instead
+  if request_body.max_completion_tokens then
+    request_body.max_tokens = request_body.max_completion_tokens
+    request_body.max_completion_tokens = nil
+  end
+  -- Remove unsupported parameters
+  request_body.reasoning_effort = nil
+  request_body.stream_options = nil
+end
+
+function M:parse_curl_args(prompt_opts)
+  local provider_conf, request_body = P.parse_config(self)
+  local disable_tools = provider_conf.disable_tools or false
+
+  -- Validate endpoint configuration
+  if not provider_conf.endpoint or provider_conf.endpoint == "" then
+    error(
+      'Azure Databricks endpoint is not configured. Please set the endpoint in your provider configuration.\nExample: endpoint = "https://adb-2222222222222222.2.azuredatabricks.net/serving-endpoints"'
+    )
+  end
+
+  local headers = {
+    ["Content-Type"] = "application/json",
+  }
+
+  if P.env.require_api_key(provider_conf) then
+    local api_key = self.parse_api_key()
+    if api_key == nil then
+      error(
+        "Databricks API token is not set, please set it in your DATABRICKS_TOKEN environment variable or config file"
+      )
+    end
+    headers["Authorization"] = "Bearer " .. api_key
+  end
+
+  self.set_allowed_params(provider_conf, request_body)
+
+  local use_ReAct_prompt = provider_conf.use_ReAct_prompt == true
+
+  local tools = nil
+  if not disable_tools and prompt_opts.tools and not use_ReAct_prompt then
+    tools = {}
+    for _, tool in ipairs(prompt_opts.tools) do
+      table.insert(tools, self:transform_tool(tool))
+    end
+  end
+
+  return {
+    url = Utils.url_join(provider_conf.endpoint, "/chat/completions"),
+    proxy = provider_conf.proxy,
+    insecure = provider_conf.allow_insecure,
+    headers = Utils.tbl_override(headers, self.extra_headers),
+    body = vim.tbl_deep_extend("force", {
+      model = provider_conf.model,
+      messages = self:parse_messages(prompt_opts),
+      stream = true,
+      tools = tools,
+    }, request_body),
+  }
+end
+
+return M

--- a/lua/avante/providers/init.lua
+++ b/lua/avante/providers/init.lua
@@ -8,6 +8,7 @@ local Utils = require("avante.utils")
 ---@field claude AvanteProviderFunctor
 ---@field copilot AvanteProviderFunctor
 ---@field azure AvanteProviderFunctor
+---@field azuredatabricks AvanteProviderFunctor
 ---@field gemini AvanteProviderFunctor
 ---@field cohere AvanteProviderFunctor
 ---@field bedrock AvanteBedrockProviderFunctor


### PR DESCRIPTION
This pull request introduces support for Azure Databricks as a new provider in `avante.nvim`. The changes include updates to documentation, configuration files, and the addition of a dedicated provider implementation. Below is a summary of the most important changes grouped by theme:

### Documentation Updates:
* Added instructions to `README.md` and `README_zh.md` for configuring Azure Databricks as a provider, including environment variable setup and sample Lua configuration. [[1]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R941-R972) [[2]](diffhunk://#diff-bc53aca037f8d406f619f15cf2c5c905a7a61f81f89cab98dd52f7ff65725f6eR753-R784)

### Configuration Enhancements:
* Updated `lua/avante/config.lua` to include `azuredatabricks` as a supported provider and added its default configuration, such as endpoint, model, timeout, and request body parameters. [[1]](diffhunk://#diff-4f9ab2121e449ed4df68152ef7ca083a1cc5eaf429c39348f73119abd75a6edbL26-R26) [[2]](diffhunk://#diff-4f9ab2121e449ed4df68152ef7ca083a1cc5eaf429c39348f73119abd75a6edbR273-R283)

### Provider Implementation:
* Added a new file `lua/avante/providers/azuredatabricks.lua` to implement the Azure Databricks provider. This includes methods for setting allowed parameters, parsing curl arguments, and handling API token validation.

### Initialization Updates:
* Updated `lua/avante/providers/init.lua` to register `azuredatabricks` as a provider in the global provider list.