### PR TITLE
fix: remove dependency on nvim-treesitter

### DIFF
--- a/lua/avante/utils/lsp.lua
+++ b/lua/avante/utils/lsp.lua
@@ -43,7 +43,12 @@ local function get_full_definition(location)
   local filetype = vim.filetype.match({ filename = filepath, buf = buf }) or ""
 
   --- use tree-sitter to get the full definition
-  local parser = require("nvim-treesitter.parsers").get_parser(buf, filetype)
+  local lang = vim.treesitter.language.get_lang(filetype)
+  local parser = vim.treesitter.get_parser(buf, lang)
+  if not parser then
+    vim.api.nvim_buf_delete(buf, { force = true })
+    return {}
+  end
   local tree = parser:parse()[1]
   local root = tree:root()
   local node = root:named_descendant_for_range(


### PR DESCRIPTION
nvim-treesitter is moving to a new `main` branch which removes a lot of APIs that are currently on `master`. The current usage in avante is not compatible with the `main` branch. Luckily we should be able to remove the dependency all together with this change.
