### PR TITLE
fix: error when editing a modified buffer

### DIFF
--- a/lua/avante/utils/init.lua
+++ b/lua/avante/utils/init.lua
@@ -1015,8 +1015,12 @@ function M.open_buffer(path, set_current_buf)
 
   local abs_path = M.join_paths(M.get_project_root(), path)
 
-  local bufnr
+  local bufnr ---@type integer
   if set_current_buf then
+    bufnr = vim.fn.bufnr(abs_path)
+    if bufnr ~= -1 and vim.api.nvim_buf_is_loaded(bufnr) and vim.bo[bufnr].modified then
+      vim.api.nvim_buf_call(bufnr, function() vim.cmd("noautocmd write") end)
+    end
     vim.cmd("noautocmd edit " .. abs_path)
     bufnr = vim.api.nvim_get_current_buf()
   else


### PR DESCRIPTION
The `replace_in_file` tool can fail if the file being edited is modified. This makes sure to write the file before editing it to circumvent this error.
