### PR TITLE
Fixed error on calling transform_anthropic_usage on a nil value from …

### DIFF
--- a/lua/avante/providers/claude.lua
+++ b/lua/avante/providers/claude.lua
@@ -329,13 +329,13 @@ function M:parse_response(ctx, data_stream, event_state, opts)
     if not ok then return end
     if jsn.usage and ctx.usage then ctx.usage.output_tokens = ctx.usage.output_tokens + jsn.usage.output_tokens end
     if jsn.delta.stop_reason == "end_turn" then
-      opts.on_stop({ reason = "complete", usage = self.transform_anthropic_usage(ctx.usage) })
+      opts.on_stop({ reason = "complete", usage = M.transform_anthropic_usage(ctx.usage) })
     elseif jsn.delta.stop_reason == "max_tokens" then
-      opts.on_stop({ reason = "max_tokens", usage = self.transform_anthropic_usage(ctx.usage) })
+      opts.on_stop({ reason = "max_tokens", usage = M.transform_anthropic_usage(ctx.usage) })
     elseif jsn.delta.stop_reason == "tool_use" then
       opts.on_stop({
         reason = "tool_use",
-        usage = self.transform_anthropic_usage(ctx.usage),
+        usage = M.transform_anthropic_usage(ctx.usage),
       })
     end
     return


### PR DESCRIPTION
…bedrock

Failed with bedrock

    Error executing vim.schedule lua callback: ...re/nvim/lazy/avante.nvim/lua/avante/providers/claude.lua:332: attempt to call field 'transform_anthropic_usage' (a nil value)
    stack traceback:
        ...re/nvim/lazy/avante.nvim/lua/avante/providers/claude.lua:332: in function 'parse_response'
        ...e/nvim/lazy/avante.nvim/lua/avante/providers/bedrock.lua:84: in function 'parse_stream_data'
        ...ng/.local/share/nvim/lazy/avante.nvim/lua/avante/llm.lua:533: in function <...ng/.local/share/nvim/lazy/avante.nvim/lua/avante/llm.lua:531>