### PR TITLE
feat: obsoletes "require("avante_lib").load()"

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -13,7 +13,7 @@ endif
 
 LUA_VERSIONS := luajit lua51
 
-BUILD_DIR := build
+BUILD_DIR := lua
 BUILD_FROM_SOURCE ?= false
 TARGET_LIBRARY ?= all
 
@@ -68,7 +68,7 @@ $(BUILD_DIR):
 	@mkdir -p $(BUILD_DIR)
 
 clean:
-	@rm -rf $(BUILD_DIR)
+	@rm -rf $(BUILD_DIR)/*.$(EXT)
 
 luacheck:
 	@luacheck `find -name "*.lua"` --codes

--- a/build.sh
+++ b/build.sh
@@ -8,7 +8,7 @@ REPO_NAME="avante.nvim"
 SCRIPT_DIR="$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" &>/dev/null && pwd)"
 
 # Set the target directory to clone the artifact
-TARGET_DIR="${SCRIPT_DIR}/build"
+TARGET_DIR="${SCRIPT_DIR}/lua"
 
 # Get the artifact download URL based on the platform and Lua version
 case "$(uname -s)" in
@@ -79,10 +79,10 @@ fi
 
 fetch_remote_tags
 latest_tag="$(git describe --tags --abbrev=0 || true)" # will be empty in clone repos
-built_tag="$(cat build/.tag 2>/dev/null || true)"
+built_tag="$(cat "${TARGET_DIR}/.tag" 2>/dev/null || true)"
 
 save_tag() {
-  echo "$latest_tag" > build/.tag
+  echo "$latest_tag" > "${TARGET_DIR}/.tag"
 }
 
 if [[ "$latest_tag" = "$built_tag" && -n "$latest_tag" ]]; then
@@ -107,6 +107,6 @@ else
   echo "No latest tag found. Building from source."
   cargo build --release --features=$LUA_VERSION
   for f in target/release/lib*.$LIB_EXT; do
-    cp "$f" "build/$(echo $f | sed 's#.*/lib##')"
+    cp "$f" "${TARGET_DIR}/$(echo $f | sed 's#.*/lib##')"
   done
 fi


### PR DESCRIPTION
Fixes https://github.com/yetone/avante.nvim/issues/1983

I had trouble using avante.nvim because it wouldn't load the rust libraries. https://github.com/yetone/avante.nvim/blob/main/lua/avante_lib.lua massages the package.cpath to be able to find the libraries.

If you drop the libraries in lua/, neovim will find them automatically see :h lua-module-load. As a consequence you dont need https://github.com/yetone/avante.nvim/blob/main/lua/avante_lib.lua anymore.

For instance in nixpkgs this NixOS/nixpkgs#403991 made the plugin work out of the box for me.

I went with minimal changes for now but there are several followup possible:
- build.sh is misnamed since it does the opposite: it fetches prebuilt library instead of compiling them
- I feel like the `.tag` file should live in `stdpath('state')` or stdpath('cache') instead (under an avante.tag or a folder).
- the library checks are a bit weak, they don't try to load the library, just check the .tag. I feel it might be better to encode the version in the library name and check if such libraries exist (with the drawback one would need to clean older libraries).
- AvanteBuild without debug gives  little information to the user and is not blocking, maybe it should.

