### PR TITLE
chore: remove all references to nvim-treesitter

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -60,7 +60,6 @@ body:
           build = "make",
           -- build = "powershell -ExecutionPolicy Bypass -File Build.ps1 -BuildFromSource false" -- for windows
           dependencies = {
-            "nvim-treesitter/nvim-treesitter",
             "nvim-lua/plenary.nvim",
             "MunifTanjim/nui.nvim",
           },

--- a/.github/workflows/.luarc.json
+++ b/.github/workflows/.luarc.json
@@ -12,7 +12,6 @@
       "${3rd}/luv/library",
       "$DEPS_PATH/luvit-meta/library",
       "$DEPS_PATH/lazy.nvim/lua",
-      "$DEPS_PATH/nvim-treesitter/lua",
       "$DEPS_PATH/dressing.nvim/lua",
       "$DEPS_PATH/snacks.nvim/lua",
       "$DEPS_PATH/plenary.nvim/lua",

--- a/.github/workflows/lua.yaml
+++ b/.github/workflows/lua.yaml
@@ -81,7 +81,6 @@ jobs:
           mkdir -p deps
           DEPS=(
             "folke/neodev.nvim"
-            "nvim-treesitter/nvim-treesitter"
             "nvim-lua/plenary.nvim"
             "MunifTanjim/nui.nvim"
             "stevearc/dressing.nvim"

--- a/README.md
+++ b/README.md
@@ -104,7 +104,6 @@ For building binary if you wish to build from source, then `cargo` is required. 
     },
   },
   dependencies = {
-    "nvim-treesitter/nvim-treesitter",
     "nvim-lua/plenary.nvim",
     "MunifTanjim/nui.nvim",
     --- The below dependencies are optional,
@@ -154,7 +153,6 @@ For building binary if you wish to build from source, then `cargo` is required. 
 ```vim
 
 " Deps
-Plug 'nvim-treesitter/nvim-treesitter'
 Plug 'nvim-lua/plenary.nvim'
 Plug 'MunifTanjim/nui.nvim'
 Plug 'MeanderingProgrammer/render-markdown.nvim'
@@ -187,7 +185,6 @@ add({
   source = 'yetone/avante.nvim',
   monitor = 'main',
   depends = {
-    'nvim-treesitter/nvim-treesitter',
     'nvim-lua/plenary.nvim',
     'MunifTanjim/nui.nvim',
     'echasnovski/mini.icons'
@@ -217,7 +214,6 @@ end)
 ```vim
 
   -- Required plugins
-  use 'nvim-treesitter/nvim-treesitter'
   use 'nvim-lua/plenary.nvim'
   use 'MunifTanjim/nui.nvim'
   use 'MeanderingProgrammer/render-markdown.nvim'

--- a/README_zh.md
+++ b/README_zh.md
@@ -82,8 +82,6 @@
     },
   },
   dependencies = {
-    "nvim-treesitter/nvim-treesitter",
-
     "nvim-lua/plenary.nvim",
     "MunifTanjim/nui.nvim",
     --- 以下依赖项是可选的，
@@ -131,8 +129,6 @@
 ```vim
 
 " 依赖项
-Plug 'nvim-treesitter/nvim-treesitter'
-
 Plug 'nvim-lua/plenary.nvim'
 Plug 'MunifTanjim/nui.nvim'
 Plug 'MeanderingProgrammer/render-markdown.nvim'
@@ -163,8 +159,6 @@ add({
   source = 'yetone/avante.nvim',
   monitor = 'main',
   depends = {
-    'nvim-treesitter/nvim-treesitter',
-
     'nvim-lua/plenary.nvim',
     'MunifTanjim/nui.nvim',
     'echasnovski/mini.icons'
@@ -194,8 +188,6 @@ end)
 ```vim
 
   -- 必需插件
-  use 'nvim-treesitter/nvim-treesitter'
-
   use 'nvim-lua/plenary.nvim'
   use 'MunifTanjim/nui.nvim'
   use 'MeanderingProgrammer/render-markdown.nvim'

--- a/lua/avante/health.lua
+++ b/lua/avante/health.lua
@@ -8,10 +8,6 @@ function M.check()
 
   -- Required dependencies with their module names
   local required_plugins = {
-    ["nvim-treesitter"] = {
-      path = "nvim-treesitter/nvim-treesitter",
-      module = "nvim-treesitter",
-    },
     ["plenary.nvim"] = {
       path = "nvim-lua/plenary.nvim",
       module = "plenary",
@@ -72,31 +68,16 @@ end
 function M.check_treesitter()
   H.start("TreeSitter Dependencies")
 
-  -- Check if TreeSitter is available
-  local has_ts, _ = pcall(require, "nvim-treesitter.configs")
-  if not has_ts then
-    H.error("TreeSitter not available. Make sure nvim-treesitter is properly installed")
-    return
-  end
-
-  H.ok("TreeSitter core functionality is available")
-
-  -- Check for essential parsers
-  local has_parsers, parsers = pcall(require, "nvim-treesitter.parsers")
-  if not has_parsers then
-    H.error("TreeSitter parsers module not available")
-    return
-  end
-
   -- List of important parsers for avante.nvim
   local essential_parsers = {
     "markdown",
   }
 
-  local missing_parsers = {}
+  local missing_parsers = {} ---@type string[]
 
-  for _, parser in ipairs(essential_parsers) do
-    if parsers.has_parser and not parsers.has_parser(parser) then table.insert(missing_parsers, parser) end
+  for _, parser_name in ipairs(essential_parsers) do
+    local loaded_parser = vim.treesitter.language.add(parser_name)
+    if not loaded_parser then missing_parsers[#missing_parsers + 1] = parser_name end
   end
 
   if #missing_parsers == 0 then

--- a/lua/avante/utils/init.lua
+++ b/lua/avante/utils/init.lua
@@ -358,7 +358,6 @@ function M.notify(msg, opts)
   n(msg, opts.level or vim.log.levels.INFO, {
     on_open = function(win)
       local ok = pcall(function() vim.treesitter.language.add("markdown") end)
-      if not ok then pcall(require, "nvim-treesitter") end
       vim.wo[win].conceallevel = 3
       vim.wo[win].concealcursor = ""
       vim.wo[win].spell = false


### PR DESCRIPTION
Followup to [comment on this PR](https://github.com/yetone/avante.nvim/pull/2316#issuecomment-3000382046) where we remove all references to nvim-treesitter.
