### PR TITLE
fix: handle invalid todos container

### DIFF
--- a/lua/avante/sidebar.lua
+++ b/lua/avante/sidebar.lua
@@ -3302,7 +3302,7 @@ function Sidebar:create_todos_container()
     self:refresh_winids()
     return
   end
-  if not self.todos_container then
+  if not Utils.is_valid_container(self.todos_container, true) then
     self.todos_container = Split({
       enter = false,
       relative = {


### PR DESCRIPTION
Resizing the neovim window while a todos container exists causes an error in the avante sidebar which hides the input. I have to close and reopen the sidebar to fix it. This fixes the issue in a better manner (as I did in other commits with similar fixes, e.g. https://github.com/yetone/avante.nvim/pull/2006).
