### PR TITLE
Revert "feat: obsoletes "require("avante_lib").load()""

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -13,7 +13,7 @@ endif
 
 LUA_VERSIONS := luajit lua51
 
-BUILD_DIR := lua
+BUILD_DIR := build
 BUILD_FROM_SOURCE ?= false
 TARGET_LIBRARY ?= all
 
@@ -68,7 +68,7 @@ $(BUILD_DIR):
 	@mkdir -p $(BUILD_DIR)
 
 clean:
-	@rm -rf $(BUILD_DIR)/*.$(EXT)
+	@rm -rf $(BUILD_DIR)
 
 luacheck:
 	@luacheck `find -name "*.lua"` --codes

--- a/build.sh
+++ b/build.sh
@@ -8,7 +8,7 @@ REPO_NAME="avante.nvim"
 SCRIPT_DIR="$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" &>/dev/null && pwd)"
 
 # Set the target directory to clone the artifact
-TARGET_DIR="${SCRIPT_DIR}/lua"
+TARGET_DIR="${SCRIPT_DIR}/build"
 
 # Get the artifact download URL based on the platform and Lua version
 case "$(uname -s)" in
@@ -79,10 +79,10 @@ fi
 
 fetch_remote_tags
 latest_tag="$(git describe --tags --abbrev=0 || true)" # will be empty in clone repos
-built_tag="$(cat "${TARGET_DIR}/.tag" 2>/dev/null || true)"
+built_tag="$(cat build/.tag 2>/dev/null || true)"
 
 save_tag() {
-  echo "$latest_tag" > "${TARGET_DIR}/.tag"
+  echo "$latest_tag" > build/.tag
 }
 
 if [[ "$latest_tag" = "$built_tag" && -n "$latest_tag" ]]; then
@@ -107,6 +107,6 @@ else
   echo "No latest tag found. Building from source."
   cargo build --release --features=$LUA_VERSION
   for f in target/release/lib*.$LIB_EXT; do
-    cp "$f" "${TARGET_DIR}/$(echo $f | sed 's#.*/lib##')"
+    cp "$f" "build/$(echo $f | sed 's#.*/lib##')"
   done
 fi


### PR DESCRIPTION
Reverts yetone/avante.nvim#2324


‌‌‌‌‌When I tested it at the time, it was working fine on Linux, but today I found that it doesn't work on macOS, so I might need to revert that PR.

