### PR TITLE
chore: deprecate require'avante_lib'.load()

### DIFF
--- a/README.md
+++ b/README.md
@@ -250,7 +250,6 @@ programs.neovim = {
       plugin = pkgs.vimPlugins.avante-nvim;
       type = "lua";
       config = ''
-              require("avante_lib").load()
               require("avante").setup()
       '' # or builtins.readFile ./plugins/avante.lua;
     }

--- a/README_zh.md
+++ b/README_zh.md
@@ -222,7 +222,6 @@ programs.neovim = {
       plugin = pkgs.vimPlugins.avante-nvim;
       type = "lua";
       config = ''
-              require("avante_lib").load()
               require("avante").setup()
       '' # 或 builtins.readFile ./plugins/avante.lua;
     }

--- a/lua/avante_lib.lua
+++ b/lua/avante_lib.lua
@@ -1,20 +1,8 @@
 local M = {}
 
-local function get_library_path()
-  local os_name = require("avante.utils").get_os_name()
-  local ext = os_name == "linux" and "so" or (os_name == "darwin" and "dylib" or "dll")
-  local dirname = string.sub(debug.getinfo(1).source, 2, #"/avante_lib.lua" * -1)
-  return dirname .. ("../build/?.%s"):format(ext)
-end
-
----@type fun(s: string): string
-local function trim_semicolon(s) return s:sub(-1) == ";" and s:sub(1, -2) or s end
-
+--- @deprecated You do not need to call this function anymore
 function M.load()
-  local library_path = get_library_path()
-  if not string.find(package.cpath, library_path, 1, true) then
-    package.cpath = trim_semicolon(package.cpath) .. ";" .. library_path
-  end
+  -- noop
 end
 
 return M


### PR DESCRIPTION
mark it as deprecated to avoid breaking user configs but it is now a noop (does nothing). Updated README to reflect changes in https://github.com/yetone/avante.nvim/pull/2324

linked PR got reverted in https://github.com/yetone/avante.nvim/pull/2353