### PR TITLE
feat(sidebar): add keymap to navigate between prompts

### DIFF
--- a/lua/avante/config.lua
+++ b/lua/avante/config.lua
@@ -511,6 +511,8 @@ M._defaults = {
       repomap = "<leader>aR",
     },
     sidebar = {
+      next_prompt = "]p",
+      prev_prompt = "[p",
       apply_all = "A",
       apply_cursor = "a",
       retry_user_request = "r",


### PR DESCRIPTION
I often find myself scrolling to look for the previous prompt to execute it. I thought that this was less intrusive than overriding `<c-p>` and `<c-n>` in the input buffer to substitute the prompts and works well with the existing retry/edit keymaps.

Also fixes a bug where the retry/edit keymaps wouldn't work + the hint wouldn't show up.
