### PR TITLE
fix: get diagnostics tool

### DIFF
--- a/lua/avante/llm_tools/get_diagnostics.lua
+++ b/lua/avante/llm_tools/get_diagnostics.lua
@@ -48,7 +48,7 @@ function M.func(opts, on_log, on_complete, session_ctx)
   if not on_complete then return false, "on_complete is required" end
   local diagnostics = Utils.lsp.get_diagnostics_from_filepath(abs_path)
   local jsn_str = vim.json.encode(diagnostics)
-  on_complete(true, jsn_str)
+  on_complete(jsn_str, nil)
 end
 
 return M


### PR DESCRIPTION
Was not properly returning the diagnostics from the get_diagnostics function.

One idea here as well is to properly use the diagnostic pull method `textDocument/diagnostic` so that we can request diagnostics on demand for files that haven't been opened yet.
