### PR TITLE
fix: error on calling transform_anthropic_usage on a nil with bedrock

### DIFF
--- a/lua/avante/providers/bedrock/claude.lua
+++ b/lua/avante/providers/bedrock/claude.lua
@@ -22,6 +22,7 @@ M.is_disable_stream = Claude.is_disable_stream
 M.parse_messages = Claude.parse_messages
 M.parse_response = Claude.parse_response
 M.transform_tool = Claude.transform_tool
+M.transform_anthropic_usage = Claude.transform_anthropic_usage
 
 ---@param provider AvanteProviderFunctor
 ---@param prompt_opts AvantePromptOptions


### PR DESCRIPTION
This fixes https://github.com/yetone/avante.nvim/issues/2345

Tested working on my local machine, tools are called successfully