### PR TITLE
feat(providers): Defer execution of cmd: API keys

### DIFF
--- a/lua/avante/providers/init.lua
+++ b/lua/avante/providers/init.lua
@@ -176,6 +176,7 @@ M = setmetatable(M, {
     if rawget(t[k], "is_env_set") == nil then
       t[k].is_env_set = function()
         if not E.require_api_key(t[k]) then return true end
+        if type(t[k].api_key_name) == "string" and t[k].api_key_name:match("^cmd:") then return true end
         local ok, result = pcall(t[k].parse_api_key)
         if not ok then return false end
         return result ~= nil
@@ -185,7 +186,11 @@ M = setmetatable(M, {
     if rawget(t[k], "setup") == nil then
       local provider_conf = M.parse_config(t[k])
       t[k].setup = function()
-        if E.require_api_key(provider_conf) then t[k].parse_api_key() end
+        if E.require_api_key(provider_conf) then
+          if not (type(provider_conf.api_key_name) == "string" and provider_conf.api_key_name:match("^cmd:")) then
+            t[k].parse_api_key()
+          end
+        end
         require("avante.tokenizers").setup(t[k].tokenizer_id)
       end
     end


### PR DESCRIPTION
Previously, API keys specified with the `cmd:` prefix were executed at Neovim startup. This caused issues for users who rely on password managers, as it would trigger them unnecessarily (at Neovim startup).

This commit modifies the provider initialization logic to defer the execution of `cmd:`-prefixed API keys until they are actually required. This is achieved by:

- Modifying `is_env_set` to return true if the `api_key_name` starts with `cmd:`, preventing immediate execution.
- Updating the `setup` function to skip parsing the API key if it's a `cmd:`-prefixed string.

This ensures that commands for fetching API keys are only run when an Avante command is executed, improving the user experience and avoiding unnecessary startup processes.