### PR TITLE
fix: rag service include git files

### DIFF
--- a/py/rag-service/src/main.py
+++ b/py/rag-service/src/main.py
@@ -682,10 +682,6 @@ def get_pathspec(directory: Path) -> pathspec.PathSpec | None:
     patterns = get_gitignore_files(directory)
     patterns.extend(get_gitcrypt_files(directory))
 
-    # Return None if no patterns were found
-    if len(patterns) <= 1:  # Only .git/ is in the list
-        return None
-
     return pathspec.GitIgnoreSpec.from_lines(patterns)
 
 


### PR DESCRIPTION
**Bug Description**

Files within the `.git` directory are not being correctly ignored when a repository does not contain a `.gitignore` or `git-crypt` file.

**Root Cause**

This issue stems from the interaction between the `scan_directory` and `get_pathspec` functions.

1.  `get_pathspec` is responsible for building a `pathspec` object from ignore patterns. It always adds `".git/"` to its list of patterns by default.
2.  However, it contains a condition: `if len(patterns) <= 1: return None`.
3.  In a repository without a `.gitignore` or other ignore files, the `patterns` list only contains the default `".git/"` entry. Its length is 1, triggering the condition and causing `get_pathspec` to return `None`.
4.  The calling function, `scan_directory`, receives `None` for its `spec` variable and consequently bypasses all file filtering logic.
5.  As a result, files in the `.git` directory, which should always be ignored, are included in the final list of matched files.


```python
def get_pathspec(directory: Path) -> pathspec.PathSpec | None:
    """Get pathspec for the directory."""
    # Collect patterns from both sources
    patterns = get_gitignore_files(directory)
    patterns.extend(get_gitcrypt_files(directory))

    # Return None if no patterns were found
    if len(patterns) <= 1:  # Only .git/ is in the list
        return None    # !!! spec in scan_directory will be None

    return pathspec.GitIgnoreSpec.from_lines(patterns)
```


```python
def scan_directory(directory: Path) -> list[str]:
    """Scan directory and return a list of matched files."""
    spec = get_pathspec(directory)  # !!! spec is None

    # extensions list
    # ...

    matched_files = []

    for root, _, files in os.walk(directory):
        file_paths = [str(Path(root) / file) for file in files]
        for file in file_paths:
            file_ext = Path(file).suffix.lower()
            if file_ext in binary_extensions:
                logger.debug("Skipping binary file: %s", file)
                continue

            # !!! spec is None, code runs in else
            if spec and spec.match_file(os.path.relpath(file, directory)):
                logger.debug("Ignoring file: %s", file)
            else:
                matched_files.append(file)

    return matched_files

```