### PR TITLE
fix(sidebar): respect input height from config

### DIFF
--- a/lua/avante/sidebar.lua
+++ b/lua/avante/sidebar.lua
@@ -3095,7 +3095,7 @@ function Sidebar:get_result_container_height()
       - selected_files_container_height
       - selected_code_container_height
       - todos_container_height
-      - 6
+      - Config.windows.input.height
   )
 end
 


### PR DESCRIPTION
Looks like the result container height is not respecting the input height from config `windows.input.height`
closes https://github.com/yetone/avante.nvim/issues/2377, https://github.com/yetone/avante.nvim/issues/2323
