### PR TITLE
improve: support to customize the avanterules directories for project/global

### DIFF
--- a/README.md
+++ b/README.md
@@ -1137,6 +1137,23 @@ The rules for root hierarchy:
 - root pattern of filename of the current buffer
 - root pattern of cwd
 
+You can also configure custom directories for your `avanterules` files using the `rules` option:
+
+```lua
+require('avante').setup({
+  rules = {
+    project_dir = '.avante/rules', -- relative to project root, can also be an absolute path
+    global_dir = '~/.config/avante/rules', -- absolute path
+  },
+})
+```
+
+The loading priority is as follows:
+
+1.  `rules.project_dir`
+2.  `rules.global_dir`
+3.  Project root
+
 <details>
 
   <summary>Example folder structure for custom prompt</summary>

--- a/README_zh.md
+++ b/README_zh.md
@@ -960,6 +960,23 @@ vim.keymap.set("n", "<leader>am", function() vim.api.nvim_exec_autocmds("User", 
 - 当前缓冲区的文件名的根模式
 - cwd 的根模式
 
+您还可以使用 `rules` 选项为您的 `avanterules` 文件配置自定义目录：
+
+```lua
+require('avante').setup({
+  rules = {
+    project_dir = '.avante/rules', -- 相对于项目根目录，也可以是绝对路径
+    global_dir = '~/.config/avante/rules', -- 绝对路径
+  },
+})
+```
+
+加载优先级如下：
+
+1.  `rules.project_dir`
+2.  `rules.global_dir`
+3.  项目根目录
+
 <details>
 
   <summary>自定义提示的示例文件夹结构</summary>

--- a/lua/avante/config.lua
+++ b/lua/avante/config.lua
@@ -40,6 +40,10 @@ M._defaults = {
   tokenizer = "tiktoken",
   ---@type string | (fun(): string) | nil
   system_prompt = nil,
+  rules = {
+    project_dir = nil, ---@type string | nil (could be relative dirpath)
+    global_dir = nil, ---@type string | nil (absolute dirpath)
+  },
   rag_service = { -- RAG service configuration
     enabled = false, -- Enables the RAG service
     host_mount = os.getenv("HOME"), -- Host mount path for the RAG service (Docker will mount this path)


### PR DESCRIPTION
I don't want to checkin the `*.avanterules` in some repo and neither to add it into .gitignore, so I wish there is a chance to customize the rules locations. In additional, I also wish there is a global rules works for all projects as fallback. such as:

```lua
rules = {
  project_dir = "local/",
  global_dir = "/home/alice/nvim/airules/",
},
```