### PR TITLE
fix: don't throw errors when closing code window

### DIFF
--- a/lua/avante/sidebar.lua
+++ b/lua/avante/sidebar.lua
@@ -218,7 +218,9 @@ end
 
 function Sidebar:recover_code_winhl()
   if self.code.old_winhl ~= nil then
-    vim.wo[self.code.winid].winhl = self.code.old_winhl
+    if self.code.winid and api.nvim_win_is_valid(self.code.winid) then
+      vim.wo[self.code.winid].winhl = self.code.old_winhl
+    end
     self.code.old_winhl = nil
   end
 end


### PR DESCRIPTION
Before using stored window ID in Sidebar:recover_code_winhl() we should check that it is valid, otherwise we may get the following error:

Error detected while processing WinClosed Autocommands for "*": Error executing lua callback: ...le/home/dtor/projects/avante.nvim/lua/avante/sidebar.lua:221: Invalid window id: 1008

This happens when closing code window while sidebar is open/visible.