### PR TITLE
feat(file_selector): handle parsing oil directory

### DIFF
--- a/lua/avante/file_selector.lua
+++ b/lua/avante/file_selector.lua
@@ -83,6 +83,7 @@ end
 
 function FileSelector:add_selected_file(filepath)
   if not filepath or filepath == "" or has_scheme(filepath) then return end
+  if filepath:match("^oil:") then filepath = filepath:gsub("^oil:", "") end
   local absolute_path = Utils.to_absolute_path(filepath)
   local stat = vim.loop.fs_stat(absolute_path)
   if stat and stat.type == "directory" then


### PR DESCRIPTION
#closes 2379

Before, adding an oil directory will not work because the routing of the oil directory is not parsed properly. This commit detects if the filepath is an oil directory, then parse it by removing the "oil:" from the string.