### PR TITLE
fix: configure Git for unsafe repositories in Docker

### DIFF
--- a/py/rag-service/Dockerfile
+++ b/py/rag-service/Dockerfile
@@ -1,5 +1,7 @@
 FROM python:3.11-slim-bookworm
 
+COPY gitconfig /root/.gitconfig
+
 WORKDIR /app
 
 RUN apt-get update && apt-get install -y --no-install-recommends curl git \

--- a/py/rag-service/gitconfig
+++ b/py/rag-service/gitconfig
@@ -1,0 +1,2 @@
+[safe]
+        directory = *


### PR DESCRIPTION
The absence of a `.gitconfig` file in the container's `/root` directory causes the following error when running Git commands:

```
fatal: detected dubious ownership in repository at '/host/Projects/doodleEsc/godemo'
To add an exception for this directory, call:

        git config --global --add safe.directory /host/Projects/doodleEsc/godemo
```

This PR adds a `.gitconfig` file to the image to ensure that Git commands function correctly.