### PR TITLE
fix(mlua-sys): specify lua engine version

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,7 +22,7 @@ minijinja = { version = "2.4.0", features = [
   "custom_syntax",
   "loop_controls",
 ] }
-mlua = { version = "0.10.0", features = ["module", "serialize"] }
+mlua = { version = "0.10.0", features = ["module", "serialize", "lua54"] }
 tiktoken-rs = { version = "0.6.0" }
 tokenizers = { version = "0.20.0", features = [
   "esaxx_fast",


### PR DESCRIPTION
Before, building avante from scratch was failing because the lua engine is not set for `mlua-sys`. This PR sets `lua54` as the lua engine for the build.