### PR TITLE
fix(fix_diff): added a replace substring logic

### DIFF
--- a/lua/avante/llm_tools/replace_in_file.lua
+++ b/lua/avante/llm_tools/replace_in_file.lua
@@ -102,6 +102,10 @@ M.returns = {
 ---@param diff string
 ---@return string
 local function fix_diff(diff)
+  -- Normalize block headers to the expected ones (fix for some LLMs output)
+  diff = diff:gsub("<<<<<<<%s*SEARCH", "------- SEARCH")
+  diff = diff:gsub(">>>>>>>%s*REPLACE", "+++++++ REPLACE")
+
   local has_search_line = diff:match("^%s*-------* SEARCH") ~= nil
   if has_search_line then return diff end
 


### PR DESCRIPTION
### PR: Normalize SEARCH/REPLACE Block Headers in fix_diff

This PR improves the robustness of the `fix_diff` function in `replace_in_file.lua` by normalizing block headers for SEARCH/REPLACE operations.

#### Summary of Changes
- Added logic to `fix_diff` to automatically convert alternate block header formats (e.g., `<<<<<<< SEARCH` and `>>>>>>> REPLACE`) to the expected `------- SEARCH` and `+++++++ REPLACE` forms.
- This ensures compatibility with LLM-generated diffs that may output non-standard headers, preventing parsing errors and making the tool more resilient to format variations.

#### Motivation
Some LLMs like GPT-4.1 sometimes generate SEARCH/REPLACE block headers using different symbols (such as `<<<<<<<` and `>>>>>>>`). Previously, this could cause the tool to fail to recognize and apply these diffs correctly. The normalization logic guarantees that these alternate headers are handled seamlessly.

#### Impact
- Makes the diff replacement tool more robust and user-friendly.
- Reduces errors caused by format inconsistencies in AI-generated diffs.

No other changes were made beyond this normalization improvement.
