### PR TITLE
fix: statusline hidden in Avante

### DIFF
--- a/lua/avante/sidebar.lua
+++ b/lua/avante/sidebar.lua
@@ -928,7 +928,7 @@ local base_win_options = {
     .. ",Normal:"
     .. Highlights.AVANTE_SIDEBAR_NORMAL,
   winbar = "",
-  statusline = " ",
+  statusline = vim.o.laststatus == 0 and " " or "",
 }
 
 function Sidebar:render_header(winid, bufnr, header_text, hl, reverse_hl)


### PR DESCRIPTION
Show statusbar for vim.laststatus different from zero