### PR TITLE
Refactor sidebar code to avoid maintaining separate winid table

### DIFF
--- a/lua/avante/api.lua
+++ b/lua/avante/api.lua
@@ -141,7 +141,7 @@ function M.ask(opts)
     if opts.without_selection then
       sidebar.code.selection = nil
       sidebar.file_selector:reset()
-      if sidebar.selected_files_container then sidebar.selected_files_container:unmount() end
+      if sidebar.containers.selected_files then sidebar.containers.selected_files:unmount() end
     end
     if input == nil or input == "" then return true end
     vim.api.nvim_exec_autocmds("User", { pattern = "AvanteInputSubmitted", data = { request = input } })
@@ -192,7 +192,7 @@ function M.refresh(opts)
   if not sidebar:is_open() then return end
   local curbuf = vim.api.nvim_get_current_buf()
 
-  local focused = sidebar.result_container.bufnr == curbuf or sidebar.input_container.bufnr == curbuf
+  local focused = sidebar.containers.result.bufnr == curbuf or sidebar.containers.input.bufnr == curbuf
   if focused or not sidebar:is_open() then return end
   local listed = vim.api.nvim_get_option_value("buflisted", { buf = curbuf })
 
@@ -216,20 +216,20 @@ function M.focus(opts)
   local curwin = vim.api.nvim_get_current_win()
 
   if sidebar:is_open() then
-    if curbuf == sidebar.input_container.bufnr then
+    if curbuf == sidebar.containers.input.bufnr then
       if sidebar.code.winid and sidebar.code.winid ~= curwin then vim.api.nvim_set_current_win(sidebar.code.winid) end
-    elseif curbuf == sidebar.result_container.bufnr then
+    elseif curbuf == sidebar.containers.result.bufnr then
       if sidebar.code.winid and sidebar.code.winid ~= curwin then vim.api.nvim_set_current_win(sidebar.code.winid) end
     else
-      if sidebar.input_container.winid and sidebar.input_container.winid ~= curwin then
-        vim.api.nvim_set_current_win(sidebar.input_container.winid)
+      if sidebar.containers.input.winid and sidebar.containers.input.winid ~= curwin then
+        vim.api.nvim_set_current_win(sidebar.containers.input.winid)
       end
     end
   else
     if sidebar.code.winid then vim.api.nvim_set_current_win(sidebar.code.winid) end
     ---@cast opts SidebarOpenOptions
     sidebar:open(opts)
-    if sidebar.input_container.winid then vim.api.nvim_set_current_win(sidebar.input_container.winid) end
+    if sidebar.containers.input.winid then vim.api.nvim_set_current_win(sidebar.containers.input.winid) end
   end
 end
 

--- a/lua/avante/llm_tools/helpers.lua
+++ b/lua/avante/llm_tools/helpers.lua
@@ -48,12 +48,12 @@ function M.confirm(message, callback, confirm_opts, session_ctx, tool_name)
   end
   local Confirm = require("avante.ui.confirm")
   local sidebar = require("avante").get()
-  if not sidebar or not sidebar.input_container or not sidebar.input_container.winid then
+  if not sidebar or not sidebar.containers.input or not sidebar.containers.input.winid then
     Utils.error("Avante sidebar not found", { title = "Avante" })
     callback(false)
     return
   end
-  confirm_opts = vim.tbl_deep_extend("force", { container_winid = sidebar.input_container.winid }, confirm_opts or {})
+  confirm_opts = vim.tbl_deep_extend("force", { container_winid = sidebar.containers.input.winid }, confirm_opts or {})
   if M.confirm_popup then M.confirm_popup:close() end
   M.confirm_popup = Confirm:new(message, function(type, reason)
     if type == "yes" then

--- a/lua/avante/sidebar.lua
+++ b/lua/avante/sidebar.lua
@@ -1506,20 +1506,6 @@ function Sidebar:initialize()
   return self
 end
 
-function Sidebar:is_focused()
-  if not self:is_open() then return false end
-
-  local current_winid = api.nvim_get_current_win()
-  if self.winids.result_container and self.winids.result_container == current_winid then return true end
-  if self.winids.selected_files_container and self.winids.selected_files_container == current_winid then
-    return true
-  end
-  if self.winids.selected_code_container and self.winids.selected_code_container == current_winid then return true end
-  if self.winids.input_container and self.winids.input_container == current_winid then return true end
-
-  return false
-end
-
 function Sidebar:is_focused_on_result()
   return self:is_open() and self.result_container and self.result_container.winid == api.nvim_get_current_win()
 end

--- a/lua/avante/ui/confirm.lua
+++ b/lua/avante/ui/confirm.lua
@@ -190,17 +190,15 @@ function M:open()
 
   vim.keymap.set("n", Config.mappings.confirm.resp, function()
     local sidebar = require("avante").get()
-    if not sidebar then return end
-    if sidebar.winids.result_container and vim.api.nvim_win_is_valid(sidebar.winids.result_container) then
-      vim.api.nvim_set_current_win(sidebar.winids.result_container)
+    if sidebar and sidebar.containers.result and vim.api.nvim_win_is_valid(sidebar.containers.result.winid) then
+      vim.api.nvim_set_current_win(sidebar.containers.result.winid)
     end
   end, { buffer = popup.bufnr, nowait = true })
 
   vim.keymap.set("n", Config.mappings.confirm.input, function()
     local sidebar = require("avante").get()
-    if not sidebar then return end
-    if sidebar.winids.input_container and vim.api.nvim_win_is_valid(sidebar.winids.input_container) then
-      vim.api.nvim_set_current_win(sidebar.winids.input_container)
+    if sidebar and sidebar.containers.input and vim.api.nvim_win_is_valid(sidebar.containers.input.winid) then
+      vim.api.nvim_set_current_win(sidebar.containers.input.winid)
     end
   end, { buffer = popup.bufnr, nowait = true })
 

--- a/lua/cmp_avante/commands.lua
+++ b/lua/cmp_avante/commands.lua
@@ -51,7 +51,7 @@ function CommandsSource:execute(item, callback)
 
   local sidebar = require("avante").get()
   command.callback(sidebar, nil, function()
-    local bufnr = sidebar.input_container.bufnr ---@type integer
+    local bufnr = sidebar.containers.input.bufnr ---@type integer
     local content = table.concat(api.nvim_buf_get_lines(bufnr, 0, -1, false), "\n")
 
     vim.defer_fn(function()


### PR DESCRIPTION
Maintaining a separate winids table and keeping it in sync with winids in NuiSplits is cumbersome, let's rework sidebar to only rely on data in splits.