### PR TITLE
doc: the `build` opt must return a string value

### DIFF
--- a/README.md
+++ b/README.md
@@ -75,14 +75,9 @@ For building binary if you wish to build from source, then `cargo` is required. 
   "yetone/avante.nvim",
   -- if you want to build from source then do `make BUILD_FROM_SOURCE=true`
   -- ⚠️ must add this setting! ! !
-  build = function()
-    -- conditionally use the correct build system for the current OS
-    if vim.fn.has("win32") == 1 then
-      return "powershell -ExecutionPolicy Bypass -File Build.ps1 -BuildFromSource false"
-    else
-      return "make"
-    end
-  end,
+  build = vim.fn.has("win32")
+      and "powershell -ExecutionPolicy Bypass -File Build.ps1 -BuildFromSource false"
+      or "make",
   event = "VeryLazy",
   version = false, -- Never set this value to "*"! Never!
   ---@module 'avante'

--- a/README_zh.md
+++ b/README_zh.md
@@ -59,8 +59,10 @@
 {
   "yetone/avante.nvim",
   -- 如果您想从源代码构建，请执行 `make BUILD_FROM_SOURCE=true`
-  build = "make", -- ⚠️ 一定要加上这一行配置！！！！！
-  -- build = "powershell -ExecutionPolicy Bypass -File Build.ps1 -BuildFromSource false" -- 对于 Windows
+  -- ⚠️ 一定要加上这一行配置！！！！！
+  build = vim.fn.has("win32")
+      and "powershell -ExecutionPolicy Bypass -File Build.ps1 -BuildFromSource false"
+      or "make",
   event = "VeryLazy",
   version = false, -- 永远不要将此值设置为 "*"！永远不要！
   ---@module 'avante'


### PR DESCRIPTION
The `build` opt must be fun(LazyPlugin) or string or false or a list of
build commands, not fun():string

Ref: https://lazy.folke.io/spec
