### PR TITLE
fix(sidebar): account for sidebar header on/off for selected code

### DIFF
--- a/lua/avante/sidebar.lua
+++ b/lua/avante/sidebar.lua
@@ -1017,23 +1017,15 @@ function Sidebar:render_input(ask)
 end
 
 function Sidebar:render_selected_code()
+  if not self.code.selection then return end
   if not Utils.is_valid_container(self.containers.selected_code) then return end
 
-  local selected_code_lines_count = 0
-  local selected_code_max_lines_count = 5
+  local count = Utils.count_lines(self.code.selection.content)
+  local max_shown = api.nvim_win_get_height(self.containers.selected_code.winid)
+  if Config.windows.sidebar_header.enabled then max_shown = max_shown - 1 end
 
-  if self.code.selection ~= nil then
-    local selected_code_lines = vim.split(self.code.selection.content, "\n")
-    selected_code_lines_count = #selected_code_lines
-  end
-
-  local header_text = Utils.icon(" ")
-    .. "Selected Code"
-    .. (
-      selected_code_lines_count > selected_code_max_lines_count
-        and " (Show only the first " .. tostring(selected_code_max_lines_count) .. " lines)"
-      or ""
-    )
+  local header_text = Utils.icon(" ") .. "Selected Code"
+  if max_shown < count then header_text = string.format("%s (%d/%d lines)", header_text, max_shown, count) end
 
   self:render_header(
     self.containers.selected_code.winid,
@@ -2844,17 +2836,14 @@ function Sidebar:get_input_value()
 end
 
 function Sidebar:get_selected_code_container_height()
-  local selected_code_max_lines_count = 5
+  if not self.code.selection then return 0 end
 
-  local selected_code_size = 0
+  local max_height = 5
 
-  if self.code.selection ~= nil then
-    local selected_code_lines = vim.split(self.code.selection.content, "\n")
-    local selected_code_lines_count = #selected_code_lines + 1
-    selected_code_size = math.min(selected_code_lines_count, selected_code_max_lines_count)
-  end
+  local count = Utils.count_lines(self.code.selection.content)
+  if Config.windows.sidebar_header.enabled then count = count + 1 end
 
-  return selected_code_size
+  return math.min(count, max_height)
 end
 
 function Sidebar:get_todos_container_height()


### PR DESCRIPTION
Current implementation always says that first 5 lines of code is shown when selected code does not fully fit into its window. This is not correct as the window can be resized, may have a header occupying one line, and the lines may not be the first ones. Also the wording is awkward.

Correct these issues by checking current window height, accounting for the potential header presence by checking sidebar.enabled config flag, and updating the message format to be more concise:

" Selected Code (4/15 lines)"

While at it switch to using Utils.count_lines() which does not need creating temporary tables.

Note that this does not deal with the header info being stale after resizing sidebar windows.