### PR TITLE
fix(llm_tools): Improve the permissions logic

### DIFF
--- a/lua/avante/llm_tools/helpers.lua
+++ b/lua/avante/llm_tools/helpers.lua
@@ -112,9 +112,9 @@ function M.has_permission_to_access(abs_path)
   if not Path:new(abs_path):is_absolute() then return false end
   local project_root = Utils.get_project_root()
   -- allow if inside project root OR inside user config dir
-  local config_dir   = vim.fn.stdpath('config')
-  local in_project   = abs_path:sub(1, #project_root) == project_root
-  local in_config    = abs_path:sub(1, #config_dir) == config_dir
+  local config_dir = vim.fn.stdpath("config")
+  local in_project = abs_path:sub(1, #project_root) == project_root
+  local in_config = abs_path:sub(1, #config_dir) == config_dir
   if not in_project and not in_config then return false end
   return not M.is_ignored(abs_path)
 end


### PR DESCRIPTION
I've had an issue where the plugin thinks it doesn't have permissions within a folder.

This is partly due to the fact that my home directory is under version control, and some of the directories I work within are in .gitignore.

This fix seems to resolve the issue, which I found in one of the issues, and decided to add the fix to the repo.

This seems to be an edge case, but equally ... I'm sure I'm not the only one faced with this issue