### PR TITLE
fix(sidebar): do not error when selecting text from help window

### DIFF
--- a/lua/avante/sidebar.lua
+++ b/lua/avante/sidebar.lua
@@ -1364,9 +1364,8 @@ function Sidebar:on_mount(opts)
           -- Treesitter highlighting is active in the code buffer, activate it
           -- it in code selection buffer as well.
           local filetype = vim.bo[self.code.bufnr].filetype
-          if filetype and filetype ~= "" then
-            vim.treesitter.start(selected_code_buf, vim.bo[self.code.bufnr].filetype)
-          end
+          local lang = vim.treesitter.language.get_lang(filetype or "")
+          if lang and lang ~= "" then vim.treesitter.start(selected_code_buf, lang) end
         end
         -- Try the old syntax highlighting
         local syntax = api.nvim_get_option_value("syntax", { buf = self.code.bufnr })


### PR DESCRIPTION
"filetype" should not be passed directly to vim.treesitter.start() as "lang" argument. While it usually works, it breaks on help files whose filetype is "help" but language should be "vimdoc".

Use vim.treesitter.language.get_lang() to map filetype to language before passing it to treesitter's start() call.

Fixes: 10c0a8d ("feat(sidebar): allow external users identify selected code buffer")