### PR TITLE
fix(utils): fix gsub in trim_line_numbers()

### DIFF
--- a/lua/avante/utils/init.lua
+++ b/lua/avante/utils/init.lua
@@ -731,7 +731,7 @@ end
 ---@param content string[]
 ---@return string[]
 function M.trim_line_numbers(content)
-  return vim.iter(content):map(function(line) return line:gsub("^L%d+: ", "") end):totable()
+  return vim.iter(content):map(function(line) return (line:gsub("^L%d+: ", "")) end):totable()
 end
 
 function M.debounce(func, delay)


### PR DESCRIPTION
fix #2458

The issue occurs because `string.gsub()` returns two values: `(result_string, number_of_substitutions)`. When you return `line:gsub("^L%d+: ", "")` directly from the map function, the `totable()` method captures both return values as a table {string, number}.

This causes [table.concat()](https://github.com/yetone/avante.nvim/blob/ca1271c996c19d525fcb81333fa1f7debc82e3eb/lua/avante/suggestion.lua#L114) to fail because it receives an array of tables `{ { "line1", 0 }, { "line2", 0 } }` instead of an array of strings `{ "line1", "line2" }`.

### One-line reproduction

```lua
:lua local d={"test"}; print("Broken:", vim.inspect(vim.iter(d):map(function(x) return x:gsub("a", "b") end):totable())); print("Works:", vim.inspect(vim.iter(d):map(function(x) return (x:gsub("a", "b")) end):totable()))

-- Broken: { { "test", 0 } }
-- Works: { "test" }
```

### Fix

Add parentheses to force single return value from gsub()