### PR TITLE
feat!(selection): do not display hint immediately

### DIFF
--- a/README.md
+++ b/README.md
@@ -452,7 +452,10 @@ _See [config.lua#L9](./lua/avante/config.lua) for the full config_
       close_from_input = nil, -- e.g., { normal = "<Esc>", insert = "<C-d>" }
     },
   },
-  hints = { enabled = true },
+  selection = {
+    enabled = true,
+    hint_display = "delayed",
+  },
   windows = {
     ---@type "right" | "left" | "top" | "bottom"
     position = "right", -- the position of the sidebar

--- a/README_zh.md
+++ b/README_zh.md
@@ -405,7 +405,10 @@ _请参见 [config.lua#L9](./lua/avante/config.lua) 以获取完整配置_
       close_from_input = nil, -- 例如，{ normal = "<Esc>", insert = "<C-d>" }
     },
   },
-  hints = { enabled = true },
+  selection = {
+    enabled = true,
+    hint_display = "delayed",
+  },
   windows = {
     ---@type "right" | "left" | "top" | "bottom"
     position = "right", -- 侧边栏的位置

--- a/lua/avante/config.lua
+++ b/lua/avante/config.lua
@@ -528,7 +528,7 @@ M._defaults = {
     toggle = {
       default = "<leader>at",
       debug = "<leader>ad",
-      hint = "<leader>ah",
+      selection = "<leader>aC",
       suggestion = "<leader>as",
       repomap = "<leader>aR",
     },
@@ -645,9 +645,14 @@ M._defaults = {
     --- Disable by setting to -1.
     override_timeoutlen = 500,
   },
-  --- @class AvanteHintsConfig
-  hints = {
+  --- Allows selecting code or other data in a buffer and ask LLM questions about it or
+  --- to perform edits/transformations.
+  --- @class AvanteSelectionConfig
+  --- @field enabled boolean
+  --- @field hint_display "delayed" | "immediate" | "none" When to show key map hints.
+  selection = {
     enabled = true,
+    hint_display = "delayed",
   },
   --- @class AvanteRepoMapConfig
   repo_map = {

--- a/lua/avante/init.lua
+++ b/lua/avante/init.lua
@@ -75,7 +75,7 @@ function H.keymaps()
   vim.keymap.set("n", "<Plug>(AvanteBuild)", function() require("avante.api").build() end, { noremap = true })
   vim.keymap.set("n", "<Plug>(AvanteToggle)", function() M.toggle() end, { noremap = true })
   vim.keymap.set("n", "<Plug>(AvanteToggleDebug)", function() M.toggle.debug() end)
-  vim.keymap.set("n", "<Plug>(AvanteToggleHint)", function() M.toggle.hint() end)
+  vim.keymap.set("n", "<Plug>(AvanteToggleSelection)", function() M.toggle.selection() end)
   vim.keymap.set("n", "<Plug>(AvanteToggleSuggestion)", function() M.toggle.suggestion() end)
 
   vim.keymap.set({ "n", "v" }, "<Plug>(AvanteConflictOurs)", function() Diff.choose("ours") end)
@@ -134,9 +134,9 @@ function H.keymaps()
     )
     Utils.safe_keymap_set(
       "n",
-      Config.mappings.toggle.hint,
+      Config.mappings.toggle.selection,
       function() M.toggle.hint() end,
-      { desc = "avante: toggle hint" }
+      { desc = "avante: toggle selection" }
     )
     Utils.safe_keymap_set(
       "n",
@@ -230,7 +230,7 @@ function H.autocmds()
     callback = function(ev)
       local tab = tonumber(ev.file)
       M._init(tab or api.nvim_get_current_tabpage())
-      if Config.hints.enabled and not M.current.selection.did_setup then M.current.selection:setup_autocmds() end
+      if Config.selection.enabled and not M.current.selection.did_setup then M.current.selection:setup_autocmds() end
     end,
   })
 
@@ -287,7 +287,7 @@ function H.autocmds()
 
   vim.schedule(function()
     M._init(api.nvim_get_current_tabpage())
-    if Config.hints.enabled then M.current.selection:setup_autocmds() end
+    if Config.selection.enabled then M.current.selection:setup_autocmds() end
   end)
 
   local function setup_colors()
@@ -405,10 +405,10 @@ M.toggle.debug = H.api(Utils.toggle_wrap({
   set = function(state) Config.override({ debug = state }) end,
 }))
 
-M.toggle.hint = H.api(Utils.toggle_wrap({
-  name = "hint",
-  get = function() return Config.hints.enabled end,
-  set = function(state) Config.override({ hints = { enabled = state } }) end,
+M.toggle.selection = H.api(Utils.toggle_wrap({
+  name = "selection",
+  get = function() return Config.selection.enabled end,
+  set = function(state) Config.override({ selection = { enabled = state } }) end,
 }))
 
 M.toggle.suggestion = H.api(Utils.toggle_wrap({


### PR DESCRIPTION
Selection hint that is displayed immediately upon entering visual mode ([<leader>aa: ask, <leader>ae: edit]) gets old pretty quickly. Add a config option to control when the hint is displayed:

  selection = {
    enabled = true,
    hint_display = "delayed",
  },

The "hint_display" option recognizes the following values:

- "immediate" results in the hint being shown immediately after entering visual mode. This is the old behavior.
- "delayed" causes the hint be displayed only if the cursor has not been moved for vim.o.updatetime milliseconds. This is the new default.
- "none" suppresses showing the hint completely.

Unfortunately "CursorHold" event is not emitted in visual mode so we have to emulate it using Utils.debounce().

This is a breaking change because selection behavior was controller by "hints" config entry which makes little sense, so the config section and associated commands were renamed to "selection".

Additionally the "hints"/"selection" was mapped to "<leader>ah", but the very same key combination was used to select from old Avante chat histories, which overrode the toggle. New selection toggle keymap is "<leader>aC".