### PR TITLE
feat: allow overriding provider endpoint

### DIFF
--- a/lua/avante/providers/bedrock.lua
+++ b/lua/avante/providers/bedrock.lua
@@ -127,11 +127,18 @@ function M:parse_curl_args(prompt_opts)
     session_token = awsCreds.session_token
   end
 
-  local endpoint = string.format(
-    "https://bedrock-runtime.%s.amazonaws.com/model/%s/invoke-with-response-stream",
-    region,
-    provider_conf.model
-  )
+  local endpoint
+  if provider_conf.endpoint then
+    -- Use custom endpoint if provided
+    endpoint = provider_conf.endpoint
+  else
+    -- Default to AWS Bedrock endpoint
+    endpoint = string.format(
+      "https://bedrock-runtime.%s.amazonaws.com/model/%s/invoke-with-response-stream",
+      region,
+      provider_conf.model
+    )
+  end
 
   local headers = {
     ["Content-Type"] = "application/json",


### PR DESCRIPTION
Thank you for the wonderful avante.nvim. I use it all the time and really appreciate it.

I need to override the Bedrock endpoint for a proxy that uses a single, static URL independent of the AWS region and model. From what I can see, it looks like only the Bedrock provider doesn't allow the endpoint to be overridden.

I've implemented a change that allows users to specify a custom endpoint. For simplicity, this requires the user to provide the full API endpoint path if their proxy requires it.

Here is an example of how to use it with lazy.nvim:
```lua
return {
  {
    "yetone/avante.nvim",
    -- ...
    opts = {
      -- Register a custom provider name
      provider = "bedrock_via_proxy",
      providers = {
        -- Define the custom provider
        bedrock_via_proxy = {
          -- Inherit settings from the original "bedrock" provider
          __inherited_from = "bedrock",
          -- Override the endpoint to your proxy URL
          endpoint = "https://example.com/invoke-with-response-stream",
          -- If your proxy handles the full API path, you can just use the base URL
          -- endpoint = "https://example.com",
        },
      },
      -- ...
    },
    -- ...
  },
}
```
Is there anything else I need to do?