### PR TITLE
fix: set the content property to the empty string

### DIFF
--- a/lua/avante/providers/openai.lua
+++ b/lua/avante/providers/openai.lua
@@ -158,8 +158,12 @@ function M:parse_messages(opts)
           local last_message = messages[#messages]
           if last_message and last_message.role == self.role_map["assistant"] and last_message.tool_calls then
             last_message.tool_calls = vim.list_extend(last_message.tool_calls, tool_calls)
+
+            if not last_message.content then
+              last_message.content = ""
+            end
           else
-            table.insert(messages, { role = self.role_map["assistant"], tool_calls = tool_calls })
+            table.insert(messages, { role = self.role_map["assistant"], tool_calls = tool_calls, content = "" })
           end
         end
         if #tool_results > 0 then

--- a/lua/avante/providers/openai.lua
+++ b/lua/avante/providers/openai.lua
@@ -159,9 +159,7 @@ function M:parse_messages(opts)
           if last_message and last_message.role == self.role_map["assistant"] and last_message.tool_calls then
             last_message.tool_calls = vim.list_extend(last_message.tool_calls, tool_calls)
 
-            if not last_message.content then
-              last_message.content = ""
-            end
+            if not last_message.content then last_message.content = "" end
           else
             table.insert(messages, { role = self.role_map["assistant"], tool_calls = tool_calls, content = "" })
           end


### PR DESCRIPTION
Hi everyone!

I'm submitting this patch to fix an HTTP 422 error that is produced when running avante against open-webui and LiteLLM. My company insists that I use our LLMs through this and I was only able to get it to work with this patch. I tested against my company's setup and also against my personal OpenAI account and was able to do what I normally do (chat and make some edits from visual mode).

Review and feedback appreciated. Thank you!