### PR TITLE
feat: toggle code window from result container in sidebar

### DIFF
--- a/lua/avante/config.lua
+++ b/lua/avante/config.lua
@@ -540,6 +540,7 @@ M._defaults = {
       edit_user_request = "e",
       switch_windows = "<Tab>",
       reverse_switch_windows = "<S-Tab>",
+      toggle_code_window = "x",
       remove_file = "d",
       add_file = "@",
       close = { "q" },

--- a/lua/avante/sidebar.lua
+++ b/lua/avante/sidebar.lua
@@ -54,6 +54,7 @@ Sidebar.__index = Sidebar
 ---@field bufnr integer
 ---@field selection avante.SelectionResult | nil
 ---@field old_winhl string | nil
+---@field win_width integer | nil
 
 ---@class avante.Sidebar
 ---@field id integer
@@ -1476,6 +1477,16 @@ function Sidebar:resize()
   self:render_input()
   self:render_selected_code()
   vim.defer_fn(function() vim.cmd("AvanteRefresh") end, 200)
+end
+
+function Sidebar:toggleCodeWindow()
+  local win_width = api.nvim_win_get_width(self.code.winid)
+  if win_width == 0 then
+    api.nvim_win_set_width(self.code.winid, self.code.win_width)
+  else
+    self.code.win_width = win_width
+    api.nvim_win_set_width(self.code.winid, 0)
+  end
 end
 
 --- Initialize the sidebar instance.
@@ -2905,6 +2916,7 @@ function Sidebar:render(opts)
   end)
 
   self.containers.result:map("n", Config.mappings.sidebar.close, function() self:shutdown() end)
+  self.containers.result:map("n", Config.mappings.sidebar.toggle_code_window, function() self:toggleCodeWindow() end)
 
   self:create_input_container()
 


### PR DESCRIPTION
Enable user to use `x` to toggle code window, so that user can view result in sidebar with a wide window. User can also use `x` to restore the code window.