### PR TITLE
fix: failed to write correct entry into prompt log file at very begin…

### DIFF
--- a/lua/avante/config.lua
+++ b/lua/avante/config.lua
@@ -460,6 +460,7 @@ M._defaults = {
   prompt_logger = { -- logs prompts to disk (timestamped, for replay/debugging)
     enabled = true, -- toggle logging entirely
     log_dir = vim.fn.stdpath("cache"), -- directory where logs are saved
+    max_entries = 100, -- the uplimit of entries that can be sotred
     next_prompt = {
       normal = "<C-n>", -- load the next (newer) prompt log in normal mode
       insert = "<C-n>",

--- a/lua/avante/sidebar.lua
+++ b/lua/avante/sidebar.lua
@@ -2740,11 +2740,6 @@ function Sidebar:create_input_container()
       place_sign_at_first_line(self.containers.input.bufnr)
     end,
   })
-  api.nvim_create_autocmd({ "TextChanged", "TextChangedI" }, {
-    group = self.augroup,
-    buffer = self.containers.input.bufnr,
-    callback = function() PromptLogger.update_current_input() end,
-  })
 
   api.nvim_create_autocmd("QuitPre", {
     group = self.augroup,

--- a/lua/avante/utils/promptLogger.lua
+++ b/lua/avante/utils/promptLogger.lua
@@ -38,11 +38,12 @@ function M.log_prompt(request)
   }
 
   -- Remove any existing entries with the same input
-  if #entries > 1 then
-    for i = #entries - 1, 1, -1 do
-      if entries[i].input == entry.input then table.remove(entries, i) end
-    end
-    -- Add the new entry
+  for i = #entries - 1, 1, -1 do
+    if entries[i].input == entry.input then table.remove(entries, i) end
+  end
+
+  -- Add the new entry
+  if #entries > 0 then
     table.insert(entries, #entries, entry)
     idx = #entries - 1
   else

--- a/lua/avante/utils/promptLogger.lua
+++ b/lua/avante/utils/promptLogger.lua
@@ -50,6 +50,19 @@ function M.log_prompt(request)
     table.insert(entries, entry)
   end
 
+  local max = Config.prompt_logger.max_entries
+
+  -- Left trim entries if the count exceeds max_entries
+  -- We need to keep the last entry (current input) and trim from the beginning
+  if max > 0 and #entries > max + 1 then
+    -- Calculate how many entries to remove
+    local to_remove = #entries - max - 1
+    -- Remove oldest entries from the beginning
+    for _ = 1, to_remove do
+      table.remove(entries, 1)
+    end
+  end
+
   local file = io.open(log_file, "w")
   if file then
     -- Write all entries to the log file, except the last one
@@ -69,8 +82,16 @@ local function _read_log(delta)
   return entries[idx + 1]
 end
 
+local function update_current_input()
+  if idx == #entries - 1 then
+    local lines = vim.api.nvim_buf_get_lines(0, 0, -1, false)
+    entries[#entries].input = table.concat(lines, "\n")
+  end
+end
+
 function M.on_log_retrieve(delta)
   return function()
+    update_current_input()
     local res = _read_log(delta)
     if not res or not res.input then
       vim.notify("No log entry found.", vim.log.levels.WARN)
@@ -81,13 +102,6 @@ function M.on_log_retrieve(delta)
       0,
       { vim.api.nvim_buf_line_count(0), #vim.api.nvim_buf_get_lines(0, -2, -1, false)[1] }
     )
-  end
-end
-
-function M.update_current_input()
-  if idx == #entries - 1 then
-    local lines = vim.api.nvim_buf_get_lines(0, 0, -1, false)
-    entries[#entries].input = table.concat(lines, "\n")
   end
 end
 


### PR DESCRIPTION
What are in this PR.

1. fix an error: When the prompt log file `/.cache/nvim/avante_prompts.log` is empty, it fails write correct entry into the log file.
1. Some improvments on prompt logger
    
    * Left trim entries if the count exceeds max_entries -- `Config.prompt_logger.max_entries`
    * Update current input on cycling through history instead of hooking on `TextChanged` and `TextChangedI`.
 

