### PR TITLE
feat: add mappings to toggle code window from input in sidebar

### DIFF
--- a/lua/avante/config.lua
+++ b/lua/avante/config.lua
@@ -548,6 +548,9 @@ M._defaults = {
       ---@alias AvanteCloseFromInput { normal: string | nil, insert: string | nil }
       ---@type AvanteCloseFromInput | nil
       close_from_input = nil, -- e.g., { normal = "<Esc>", insert = "<C-d>" }
+      ---@alias AvanteToggleCodeWindowFromInput { normal: string | nil, insert: string | nil }
+      ---@type AvanteToggleCodeWindowFromInput | nil
+      toggle_code_window_from_input = nil, -- e.g., { normal = "x", insert = "<C-;>" }
     },
     files = {
       add_current = "<leader>ac", -- Add current buffer to selected files

--- a/lua/avante/sidebar.lua
+++ b/lua/avante/sidebar.lua
@@ -2729,6 +2729,23 @@ function Sidebar:create_input_container()
     end
   end
 
+  if Config.mappings.sidebar.toggle_code_window_from_input ~= nil then
+    if Config.mappings.sidebar.toggle_code_window_from_input.normal ~= nil then
+      self.containers.input:map(
+        "n",
+        Config.mappings.sidebar.toggle_code_window_from_input.normal,
+        function() self:toggleCodeWindow() end
+      )
+    end
+    if Config.mappings.sidebar.toggle_code_window_from_input.insert ~= nil then
+      self.containers.input:map(
+        "i",
+        Config.mappings.sidebar.toggle_code_window_from_input.insert,
+        function() self:toggleCodeWindow() end
+      )
+    end
+  end
+
   api.nvim_set_option_value("filetype", "AvanteInput", { buf = self.containers.input.bufnr })
 
   -- Setup completion


### PR DESCRIPTION
Enable user to toggle code window from input in sidebar, disabled by default, user need add below config to turn it on


        opts = {
            mappings = {
                sidebar = {
                    toggle_code_window_from_input = {
                      normal = "x",
                      insert = "<C-;>",
                    },
                },
            },
        },
