### PR TITLE
fix: allow lazy loading AvanteAskNew

### DIFF
--- a/lua/avante/api.lua
+++ b/lua/avante/api.lua
@@ -137,6 +137,7 @@ function M.ask(opts)
       sidebar:close({ goto_code_win = false })
     end
     require("avante").open_sidebar(opts)
+    sidebar = require("avante").get()
     if new_chat then sidebar:new_chat() end
     if opts.without_selection then
       sidebar.code.selection = nil


### PR DESCRIPTION
When I lazy load AvanteAskNew, I get an error that the sidebar is `nil`. This fixes that error.
