### PR TITLE
chore: remove dead code and commented out blocks

### DIFF
--- a/lua/avante/libs/jsonparser.lua
+++ b/lua/avante/libs/jsonparser.lua
@@ -75,11 +75,6 @@ function StreamParser:getStatus()
   }
 end
 
--- 辅助函数：去除字符串首尾空白（保留以备后用）
--- local function trim(s)
---   return s:match("^%s*(.-)%s*$")
--- end
-
 -- 辅助函数：检查字符是否为空白字符
 local function isWhitespace(char) return char == " " or char == "\t" or char == "\n" or char == "\r" end
 

--- a/lua/avante/llm_tools/dispatch_agent.lua
+++ b/lua/avante/llm_tools/dispatch_agent.lua
@@ -238,7 +238,6 @@ When you're done, provide a clear and concise summary of what you found.]]):gsub
           end
         end
       end
-      -- if session_ctx.on_messages_add then session_ctx.on_messages_add(msgs) end
     end,
     session_ctx = session_ctx,
     on_start = session_ctx.on_start,

--- a/lua/avante/llm_tools/replace_in_file.lua
+++ b/lua/avante/llm_tools/replace_in_file.lua
@@ -588,7 +588,6 @@ For example:
           return { { line_, Highlights.TO_BE_DELETED_WITHOUT_STRIKETHROUGH } }
         end)
         :totable()
-      -- local extmark_line = math.max(0, start_line - 2)
       local end_row = start_line + #diff_block.new_lines - 1
       local delete_extmark_id =
         vim.api.nvim_buf_set_extmark(bufnr, NAMESPACE, math.min(math.max(end_row - 1, 0), line_count - 1), 0, {

--- a/lua/avante/llm_tools/str_replace.lua
+++ b/lua/avante/llm_tools/str_replace.lua
@@ -8,7 +8,6 @@ M.name = "str_replace"
 M.description =
   "The str_replace tool allows you to replace a specific string in a file with a new string. This is used for making precise edits."
 
--- function M.enabled() return Config.provider:match("ollama") ~= nil end
 function M.enabled() return false end
 
 ---@type AvanteLLMToolParam


### PR DESCRIPTION
## Summary
- Removed commented out code blocks that were no longer serving any purpose
- Cleaned up 4 files to improve code clarity and maintainability
- No functional changes, only dead code removal

## Changes
- 🧹 Removed unused commented out `trim` function in `jsonparser.lua`
- 🧹 Removed commented out function implementation in `str_replace.lua`
- 🧹 Removed commented out `extmark_line` variable in `replace_in_file.lua`
- 🧹 Removed commented out callback invocation in `dispatch_agent.lua`

## Test plan
- [x] Verified all tests still pass
- [x] No functional changes made, only commented code removal
- [x] Confirmed the removed code was not referenced anywhere
