### PR TITLE
Add config to limit max height for selected files

### DIFF
--- a/lua/avante/config.lua
+++ b/lua/avante/config.lua
@@ -624,6 +624,9 @@ M._defaults = {
       prefix = "> ",
       height = 8, -- Height of the input window in vertical layout
     },
+    selected_files = {
+      height = 6, -- Maximum height of the selected files window
+    },
     edit = {
       border = { " ", " ", " ", " ", " ", " ", " ", " " },
       start_insert = true, -- Start insert mode when opening the edit window

--- a/lua/avante/sidebar.lua
+++ b/lua/avante/sidebar.lua
@@ -2963,7 +2963,7 @@ end
 
 function Sidebar:get_selected_files_container_height()
   local selected_filepaths_ = self.file_selector:get_selected_filepaths()
-  return math.min(vim.o.lines - 2, #selected_filepaths_ + 1)
+  return math.min(Config.windows.selected_files.height, #selected_filepaths_ + 1)
 end
 
 function Sidebar:adjust_selected_files_container_layout()


### PR DESCRIPTION
This commit adds a configuration option to set a maximum height for the selected files window. This is because at the moment, if you attached a lot of selected files, it would end up taking the whole chat buffer which made the user experience really rough.

After adding this configuration option, I just modified the sidebar logic so that instead of deciding between the minimum of the maximum number of height lines in the vim window, or the number of selected files, we are now picking between the configured max lines height, and the number of selected files, which should make the UX much better.

Closes #2615 