### PR TITLE
fix: wrap user input in task only in agentic mode

### DIFF
--- a/lua/avante/llm.lua
+++ b/lua/avante/llm.lua
@@ -404,16 +404,18 @@ function M.generate_prompts(opts)
     if msg.is_user_submission then
       message = vim.deepcopy(message)
       local content = message.content
-      if type(content) == "string" then
-        message.content = "<task>" .. content .. "</task>"
-      elseif type(content) == "table" then
-        for idx, item in ipairs(content) do
-          if type(item) == "string" then
-            item = "<task>" .. item .. "</task>"
-            content[idx] = item
-          elseif type(item) == "table" and item.type == "text" then
-            item.content = "<task>" .. item.content .. "</task>"
-            content[idx] = item
+      if Config.mode == "agentic" then
+        if type(content) == "string" then
+          message.content = "<task>" .. content .. "</task>"
+        elseif type(content) == "table" then
+          for idx, item in ipairs(content) do
+            if type(item) == "string" then
+              item = "<task>" .. item .. "</task>"
+              content[idx] = item
+            elseif type(item) == "table" and item.type == "text" then
+              item.content = "<task>" .. item.content .. "</task>"
+              content[idx] = item
+            end
           end
         end
       end


### PR DESCRIPTION
User input is wrapped in tag `<task>`, which seems to be not necessary and causing unwanted behavior in `legacy` mode.