### PR TITLE
feat: add project_root in AskOptions so that project root can be spec…

### DIFF
--- a/lua/avante/api.lua
+++ b/lua/avante/api.lua
@@ -112,10 +112,12 @@ end
 ---@field without_selection? boolean whether to open a new chat without selection
 ---@field sidebar_pre_render? fun(sidebar: avante.Sidebar)
 ---@field sidebar_post_render? fun(sidebar: avante.Sidebar)
+---@field project_root? string optional project root
 
 ---@param opts? AskOptions
 function M.ask(opts)
   opts = opts or {}
+  Config.ask_opts = opts
   if type(opts) == "string" then
     Utils.warn("passing 'ask' as string is deprecated, do {question = '...'} instead", { once = true })
     opts = { question = opts }

--- a/lua/avante/config.lua
+++ b/lua/avante/config.lua
@@ -704,6 +704,8 @@ M._defaults = {
   slash_commands = {},
   ---@type AvanteShortcut[]
   shortcuts = {},
+  ---@type AskOptions
+  ask_opts = {},
 }
 
 ---@type avante.Config

--- a/lua/avante/sidebar.lua
+++ b/lua/avante/sidebar.lua
@@ -71,7 +71,6 @@ Sidebar.__index = Sidebar
 ---@field state_extmark_id integer | nil
 ---@field scroll boolean
 ---@field input_hint_window integer | nil
----@field ask_opts AskOptions
 ---@field old_result_lines avante.ui.Line[]
 ---@field token_count integer | nil
 
@@ -99,7 +98,6 @@ function Sidebar:new(id)
     state_extmark_id = nil,
     scroll = true,
     input_hint_window = nil,
-    ask_opts = {},
     old_result_lines = {},
     token_count = nil,
     -- Cache-related fields
@@ -2358,7 +2356,7 @@ function Sidebar:get_generate_prompts_options(request, cb)
 
   local selected_filepaths = self.file_selector.selected_filepaths or {}
 
-  local ask = self.ask_opts.ask
+  local ask = Config.ask_opts.ask
   if ask == nil then ask = true end
 
   ---@type AvanteGeneratePromptsOptions
@@ -2891,7 +2889,6 @@ end
 
 ---@param opts AskOptions
 function Sidebar:render(opts)
-  self.ask_opts = opts
   if opts.sidebar_pre_render then opts.sidebar_pre_render(self) end
 
   local function get_position()

--- a/lua/avante/utils/root.lua
+++ b/lua/avante/utils/root.lua
@@ -193,6 +193,7 @@ local buf_names = {}
 ---@param opts? {normalize?:boolean, buf?:number}
 ---@return string
 function M.get(opts)
+  if Config.ask_opts.project_root then return Config.ask_opts.project_root end
   local cwd = vim.uv.cwd()
   if Config.behaviour.use_cwd_as_project_root then
     if cwd and cwd ~= "" then return cwd end


### PR DESCRIPTION
add project_root in AskOptions so that project root can be specified from api, also move `AskOptions` from `Sidebar` to `Config` so that it can be used beyond `Sidebar`.