### PR TITLE
fix: enforce role order for Mistral API compatibility #2562

### DIFF
--- a/lua/avante/providers/openai.lua
+++ b/lua/avante/providers/openai.lua
@@ -203,6 +203,10 @@ function M:parse_messages(opts)
       else
         table.insert(final_messages, { role = self.role_map["assistant"], content = "Ok, I understand." })
       end
+    else
+      if role == "user" and prev_role == "tool" and M.is_mistral(provider_conf.endpoint) then
+        table.insert(final_messages, { role = self.role_map["assistant"], content = "Ok, I understand." })
+      end
     end
     prev_role = role
     table.insert(final_messages, message)


### PR DESCRIPTION
**Fix Mistral AI API error: "Unexpected role 'user' after role 'tool'"**

**Issue**
When continuing a discussion with Mistral AI (using OpenAI-compatible API), the plugin would sometimes send a `user` role message immediately after a `tool` role message, resulting in a `400 Bad Request` error:
```
Error: API request failed with status 400. Body: "{"object":"error","message":"Unexpected role 'user' after role 'tool',"type":"invalid_request_message_order","param":null,"code":"3230"}"
```
This occurs because Mistral’s API enforces a stricter role order than OpenAI, requiring an `assistant` message after a `tool` message.

**Solution**
This PR adds a check in `parse_messages` to insert a placeholder `assistant` message (`"Ok, I understand."`) when a `user` message follows a `tool` message, but only for Mistral endpoints. This ensures compatibility with Mistral’s role order requirements.

**Changes**
- Added a conditional check in `lua/avante/providers/openai.lua` to detect and fix invalid role sequences for Mistral providers.

**Related Issue**
#2562