### PR TITLE
feat: include hidden files when scanning directories

### DIFF
--- a/lua/avante/utils/init.lua
+++ b/lua/avante/utils/init.lua
@@ -896,21 +896,43 @@ function M.scan_directory(options)
   local cmd_supports_max_depth = true
   local cmd = (function()
     if vim.fn.executable("rg") == 1 then
-      local cmd = { "rg", "--files", "--color", "never", "--no-require-git", "--no-ignore-parent" }
+      local cmd = {
+        "rg",
+        "--files",
+        "--color",
+        "never",
+        "--no-require-git",
+        "--no-ignore-parent",
+        "--hidden",
+        "--glob",
+        "!.git/",
+      }
+
       if options.max_depth ~= nil then vim.list_extend(cmd, { "--max-depth", options.max_depth }) end
       table.insert(cmd, options.directory)
+
       return cmd
     end
-    if vim.fn.executable("fd") == 1 then
-      local cmd = { "fd", "--type", "f", "--color", "never", "--no-require-git" }
+
+    -- fd is called 'fdfind' on Debian/Ubuntu due to naming conflicts
+    local fd_executable = vim.fn.executable("fd") == 1 and "fd"
+      or (vim.fn.executable("fdfind") == 1 and "fdfind" or nil)
+    if fd_executable then
+      local cmd = {
+        fd_executable,
+        "--type",
+        "f",
+        "--color",
+        "never",
+        "--no-require-git",
+        "--hidden",
+        "--exclude",
+        ".git",
+      }
+
       if options.max_depth ~= nil then vim.list_extend(cmd, { "--max-depth", options.max_depth }) end
       vim.list_extend(cmd, { "--base-directory", options.directory })
-      return cmd
-    end
-    if vim.fn.executable("fdfind") == 1 then
-      local cmd = { "fdfind", "--type", "f", "--color", "never", "--no-require-git" }
-      if options.max_depth ~= nil then vim.list_extend(cmd, { "--max-depth", options.max_depth }) end
-      vim.list_extend(cmd, { "--base-directory", options.directory })
+
       return cmd
     end
   end)()


### PR DESCRIPTION
Without including hidden files in the scan, we're unable to add files in hidden directories to the context using the `@` keybinding. 

Files under were not shown before:
- `.github/` - actions and pipelines
- `.claude/` | `.gemini/` - AI configuration files

In case `fd` or `rg` isn't available in the system, the fallback command is:

```bash
git ls-files -co --exclude-standard
```

Which would already include these hidden files and folders, causing an inconsistent behaviour. 