### PR TITLE
feat(git): Add configuration option for 'Generated-by' line in commit

### DIFF
--- a/lua/avante/config.lua
+++ b/lua/avante/config.lua
@@ -491,6 +491,7 @@ M._defaults = {
     auto_approve_tool_permissions = true, -- Default: show permission prompts for all tools
     auto_check_diagnostics = true,
     enable_fastapply = false,
+    include_generated_by_commit_line = false, -- Controls if 'Generated-by: <provider/model>' line is added to git commit message
   },
   prompt_logger = { -- logs prompts to disk (timestamped, for replay/debugging)
     enabled = true, -- toggle logging entirely

--- a/lua/avante/llm_tools/init.lua
+++ b/lua/avante/llm_tools/init.lua
@@ -462,6 +462,13 @@ function M.git_commit(input, opts)
     commit_msg_lines[#commit_msg_lines + 1] = line:gsub('"', '\\"')
   end
   commit_msg_lines[#commit_msg_lines + 1] = ""
+  -- add Generated-by line using provider and model name
+  if Config.behaviour and Config.behaviour.include_generated_by_commit_line then
+    local provider_name = Config.provider or "unknown"
+    local model_name = (Config.providers and Config.providers[provider_name] and Config.providers[provider_name].model)
+      or "unknown"
+    commit_msg_lines[#commit_msg_lines + 1] = string.format("Generated-by: %s/%s", provider_name, model_name)
+  end
   if git_user ~= "" and git_email ~= "" then
     commit_msg_lines[#commit_msg_lines + 1] = string.format("Signed-off-by: %s <%s>", git_user, git_email)
   end


### PR DESCRIPTION
This pull request adds support for optionally including a "Generated-by" line in git commit messages, indicating the provider and model used for generation. The feature is controlled by a new configuration option.

Configuration changes:

* Added the `include_generated_by_commit_line` option to the `behaviour` section in `config.lua` to control whether the "Generated-by" line is included in commit messages.

Commit message generation changes:

* Updated the `git_commit` tool to append a `Generated-by: <provider>/<model>` line to commit messages when the new configuration option is enabled.