### PR TITLE
feat: add automatic ACP session recovery with intelligent history truncation

### DIFF
--- a/lua/avante/libs/acp_client.lua
+++ b/lua/avante/libs/acp_client.lua
@@ -397,7 +397,12 @@ function ACPClient:_create_stdio_transport()
 
     -- Read stderr for debugging
     stderr:read_start(function(_, data)
-      if data then vim.schedule(function() vim.notify("ACP stderr: " .. data, vim.log.levels.DEBUG) end) end
+      if data then
+        -- Filter out common session recovery error messages to avoid user confusion
+        if not (data:match("Session not found") or data:match("session/prompt")) then
+          vim.schedule(function() vim.notify("ACP stderr: " .. data, vim.log.levels.DEBUG) end)
+        end
+      end
     end)
   end
 


### PR DESCRIPTION
## Summary
- Implement automatic ACP session recovery for avante.nvim's Claude Code integration
- Add intelligent history truncation to maintain context while avoiding token limits
- Filter ACP stderr messages to reduce user confusion during recovery
- Resolve "Session not found" errors when restarting Neovim

## Changes
- Enhanced `_stream_acp` function in `lua/avante/llm.lua` with automatic session recovery
- Added `truncate_history_for_recovery` function for intelligent message truncation
- Updated `lua/avante/libs/acp_client.lua` to filter session-related error messages
- Session recovery is user-configurable through `session_recovery` options

## Test plan
- [x] Test configuration compatibility
- [x] Test syntax validation
- [x] Test logic functionality
- [x] Test edge cases
- [x] Verify CI checks pass

Fixes #2710