### PR TITLE
feat: add xai, glm, and qwen providers to default config

### DIFF
--- a/lua/avante/config.lua
+++ b/lua/avante/config.lua
@@ -445,6 +445,24 @@ M._defaults = {
       model = "kimi-k2-0711-preview",
       api_key_name = "MOONSHOT_API_KEY",
     },
+    xai = {
+      __inherited_from = "openai",
+      endpoint = "https://api.x.ai/v1",
+      model = "grok-code-fast-1",
+      api_key_name = "XAI_API_KEY",
+    },
+    glm = {
+      __inherited_from = "openai",
+      endpoint = "https://open.bigmodel.cn/api/coding/paas/v4",
+      model = "glm-4.5",
+      api_key_name = "GLM_API_KEY",
+    },
+    qwen = {
+      __inherited_from = "openai",
+      endpoint = "https://dashscope.aliyuncs.com/compatible-mode/v1",
+      model = "qwen3-coder-plus",
+      api_key_name = "DASHSCOPE_API_KEY",
+    },
   },
   ---Specify the special dual_boost mode
   ---1. enabled: Whether to enable dual_boost mode. Default to false.


### PR DESCRIPTION
## Summary
- Add xAI provider with grok-code-fast-1 model and XAI_API_KEY authentication
- Add GLM provider with glm-4.5 model for BigModel API compatibility  
- Add Qwen provider with qwen3-coder-plus model for Aliyun DashScope compatibility
- All providers inherit from openai for full OpenAI API compatibility
- Users can now use these providers by simply setting the appropriate API keys

## Test plan
- [x] Verify default configurations load correctly
- [x] Test provider inheritance from openai
- [ ] Test actual API calls with real API keys

Resolves #2712