### PR TITLE
Add Goose as an ACP provider

### DIFF
--- a/lua/avante/config.lua
+++ b/lua/avante/config.lua
@@ -258,6 +258,10 @@ M._defaults = {
         ACP_PERMISSION_MODE = "bypassPermissions",
       },
     },
+    ["goose"] = {
+      command = "goose",
+      args = { "acp" }
+    }
   },
   ---To add support for custom provider, follow the format below
   ---See https://github.com/yetone/avante.nvim/wiki#custom-providers for more details

--- a/lua/avante/config.lua
+++ b/lua/avante/config.lua
@@ -260,8 +260,8 @@ M._defaults = {
     },
     ["goose"] = {
       command = "goose",
-      args = { "acp" }
-    }
+      args = { "acp" },
+    },
   },
   ---To add support for custom provider, follow the format below
   ---See https://github.com/yetone/avante.nvim/wiki#custom-providers for more details

--- a/lua/avante/libs/acp_client.lua
+++ b/lua/avante/libs/acp_client.lua
@@ -455,7 +455,7 @@ function ACPClient:_send_request(method, params, callback)
 
   if callback then self.callbacks[id] = callback end
 
-  local data = vim.json.encode(message) .. "\n"
+  local data = vim.json.encode(message)
   if self.debug_log_file then
     self.debug_log_file:write("request: " .. data .. string.rep("=", 100) .. "\n")
     self.debug_log_file:flush()
@@ -492,7 +492,7 @@ function ACPClient:_send_notification(method, params)
     params = params or {},
   }
 
-  local data = vim.json.encode(message) .. "\n"
+  local data = vim.json.encode(message)
   if self.debug_log_file then
     self.debug_log_file:write("notification: " .. data .. string.rep("=", 100) .. "\n")
     self.debug_log_file:flush()
@@ -507,7 +507,7 @@ end
 function ACPClient:_send_result(id, result)
   local message = { jsonrpc = "2.0", id = id, result = result }
 
-  local data = vim.json.encode(message) .. "\n"
+  local data = vim.json.encode(message)
   if self.debug_log_file then
     self.debug_log_file:write("request: " .. data .. string.rep("=", 100) .. "\n")
     self.debug_log_file:flush()
@@ -524,7 +524,7 @@ function ACPClient:_send_error(id, message, code)
   code = code or self.ERROR_CODES.TRANSPORT_ERROR
   local msg = { jsonrpc = "2.0", id = id, error = { code = code, message = message } }
 
-  local data = vim.json.encode(msg) .. "\n"
+  local data = vim.json.encode(msg)
   self.transport:send(data)
 end
 

--- a/lua/avante/llm.lua
+++ b/lua/avante/llm.lua
@@ -1134,9 +1134,7 @@ function M._stream_acp(opts)
     acp_client:connect()
     -- If we create a new client and it does not support sesion loading,
     -- remove the old session
-    if not acp_client.agent_capabilities.loadSession then
-      opts.acp_session_id = nil
-    end
+    if not acp_client.agent_capabilities.loadSession then opts.acp_session_id = nil end
     if opts.on_save_acp_client then opts.on_save_acp_client(acp_client) end
   end
   local session_id = opts.acp_session_id

--- a/lua/avante/llm.lua
+++ b/lua/avante/llm.lua
@@ -1132,6 +1132,11 @@ function M._stream_acp(opts)
     })
     acp_client = ACPClient:new(acp_config)
     acp_client:connect()
+    -- If we create a new client and it does not support sesion loading,
+    -- remove the old session
+    if not acp_client.agent_capabilities.loadSession then
+      opts.acp_session_id = nil
+    end
     if opts.on_save_acp_client then opts.on_save_acp_client(acp_client) end
   end
   local session_id = opts.acp_session_id


### PR DESCRIPTION
This adds [goose](https://block.github.io/goose/) as an ACP provider. 

To get goose to work appropriately I had to:
- make sure that the previously session ids aren't passed in, because the goose acp doesn't currently support session loading
- make sure that multiple '\n' are not passed in, this causes the zed ACP library that goose uses to complain.