### PR TITLE
docs: update mini.pick organization name

### DIFF
--- a/README.md
+++ b/README.md
@@ -219,7 +219,7 @@ For building binary if you wish to build from source, then `cargo` is required. 
     "nvim-lua/plenary.nvim",
     "MunifTanjim/nui.nvim",
     --- The below dependencies are optional,
-    "echasnovski/mini.pick", -- for file_selector provider mini.pick
+    "nvim-mini/mini.pick", -- for file_selector provider mini.pick
     "nvim-telescope/telescope.nvim", -- for file_selector provider telescope
     "hrsh7th/nvim-cmp", -- autocompletion for avante commands and mentions
     "ibhagwan/fzf-lua", -- for file_selector provider fzf


### PR DESCRIPTION
This PR updates the Avante.nvim documentation to reflect the new repository location for the `mini.pick` plugin.

- The plugin `echasnovski/mini.pick` has been moved/renamed to `nvim-mini/mini.pick`.
- Updated reference in the README.
- No functional changes to the code; this is purely a documentation update to prevent confusion and deprecation warnings in LazyVim setups.

This ensures users following the documentation will install the correct plugin and avoid errors when setting up Avante.nvim.
