### PR TITLE
Fix: nvim-tree window becomes very narrow after toggle off Zen mode

### DIFF
--- a/lua/avante/api.lua
+++ b/lua/avante/api.lua
@@ -118,6 +118,9 @@ end
 function M.full_view_ask()
   M.ask({
     show_logo = true,
+    sidebar_pre_render = function(sidebar)
+      sidebar:store_code_window_stats()
+    end,
     sidebar_post_render = function(sidebar)
       sidebar:toggle_code_window()
       -- vim.wo[sidebar.containers.result.winid].number = true

--- a/lua/avante/sidebar.lua
+++ b/lua/avante/sidebar.lua
@@ -270,8 +270,8 @@ function Sidebar:close(opts)
   self:recover_code_winhl()
   self:close_input_hint()
 
-  if self.post_render then
-    self:post_render()
+  if self.is_in_full_view then
+    self:toggle_code_window()
   end
 end
 
@@ -1642,7 +1642,6 @@ end
 function Sidebar:toggle_code_window()
   local winids = api.nvim_tabpage_list_wins(self.id)
   local container_winids = vim.tbl_map(function(container) return container.winid end, self.containers)
-  local win_width = api.nvim_win_get_width(self.code.winid)
   if not self.code.visible then
     self.is_in_full_view = false
     for _, winid in ipairs(winids) do


### PR DESCRIPTION
Fix the issue: https://github.com/yetone/avante.nvim/issues/2729