### PR TITLE
feat: filter prompt history by user input

### DIFF
--- a/lua/avante/sidebar.lua
+++ b/lua/avante/sidebar.lua
@@ -2930,6 +2930,13 @@ function Sidebar:create_input_container()
     fn.sign_unplace(group, { buffer = bufnr })
 
     fn.sign_place(0, group, "AvanteInputPromptSign", bufnr, { lnum = 1 })
+    vim.api.nvim_set_hl(0, "AvantePromptInputHL", {
+      fg = "#ff7700",
+      bg = "#333333",
+      bold = true,
+      italic = true,
+      underline = true,
+    })
   end
 
   place_sign_at_first_line(self.containers.input.bufnr)

--- a/lua/avante/utils/promptLogger.lua
+++ b/lua/avante/utils/promptLogger.lua
@@ -3,6 +3,7 @@ local Utils = require("avante.utils")
 
 -- last one in entries is always to hold current input
 local entries, idx = {}, 0
+local filtered_entries = {}
 
 ---@class avante.utils.promptLogger
 local M = {}
@@ -24,6 +25,7 @@ function M.init()
   end
   table.insert(entries, { input = "" })
   idx = #entries - 1
+  filtered_entries = entries
 end
 
 function M.log_prompt(request)
@@ -46,6 +48,7 @@ function M.log_prompt(request)
   if #entries > 0 then
     table.insert(entries, #entries, entry)
     idx = #entries - 1
+    filtered_entries = entries
   else
     table.insert(entries, entry)
   end
@@ -77,15 +80,33 @@ end
 
 local function _read_log(delta)
   -- index of array starts from 1 in lua, while this idx starts from 0
-  idx = ((idx - delta) % #entries + #entries) % #entries
+  idx = ((idx - delta) % #filtered_entries + #filtered_entries) % #filtered_entries
 
-  return entries[idx + 1]
+  return filtered_entries[idx + 1]
 end
 
 local function update_current_input()
-  if idx == #entries - 1 then
-    local lines = vim.api.nvim_buf_get_lines(0, 0, -1, false)
-    entries[#entries].input = table.concat(lines, "\n")
+  local user_input = table.concat(vim.api.nvim_buf_get_lines(0, 0, -1, false), "\n")
+  if idx == #filtered_entries - 1 or filtered_entries[idx + 1].input ~= user_input then
+    entries[#entries].input = user_input
+
+    vim.fn.clearmatches()
+    -- Apply filtering if there's user input
+    if user_input and user_input ~= "" then
+      filtered_entries = {}
+      for i = 1, #entries - 1 do
+        if entries[i].input:lower():find(user_input:lower(), 1, true) then
+          table.insert(filtered_entries, entries[i])
+        end
+      end
+      -- Add the current input as the last entry
+      table.insert(filtered_entries, entries[#entries])
+
+      vim.fn.matchadd("AvantePromptInputHL", user_input)
+    else
+      filtered_entries = entries
+    end
+    idx = #filtered_entries - 1
   end
 end
 


### PR DESCRIPTION
This PR enables users to navigate through prompt history items that contain a substring matching the current user input. This makes the prompt logger function similarly to zsh with the `zsh-history-substring-search` plugin.
