### PR TITLE
Add support for Claude Sonnet 4.5

### DIFF
--- a/lua/avante/providers/claude.lua
+++ b/lua/avante/providers/claude.lua
@@ -348,7 +348,12 @@ function M:parse_curl_args(prompt_opts)
   end
 
   if prompt_opts.tools and #prompt_opts.tools > 0 and Config.mode == "agentic" then
-    if provider_conf.model:match("claude%-sonnet%-4") then
+    if provider_conf.model:match("claude%-sonnet%-4%-5") then
+      table.insert(tools, {
+        type = "text_editor_20250728",
+        name = "str_replace_based_edit_tool",
+      })
+    elseif provider_conf.model:match("claude%-sonnet%-4") then
       table.insert(tools, {
         type = "text_editor_20250429",
         name = "str_replace_based_edit_tool",


### PR DESCRIPTION
When using Claude Sonnet 4.5 I got an error that `text_editor_20250429` is not supported by this model. The API response suggested to switch to `text_editor_20250728` which I did locally and it started working 🎉 