### PR TITLE
[vertex] Allow project to be set via env var

### DIFF
--- a/lua/avante/providers/vertex.lua
+++ b/lua/avante/providers/vertex.lua
@@ -49,7 +49,7 @@ function M:parse_curl_args(prompt_opts)
   local provider_conf, request_body = P.parse_config(self)
 
   local model_id = provider_conf.model or "default-model-id"
-  local project_id = parse_cmd("cmd:gcloud config get-value project")
+  local project_id = vim.fn.getenv("GOOGLE_CLOUD_PROJECT") or parse_cmd("cmd:gcloud config get-value project")
   local location = vim.fn.getenv("GOOGLE_CLOUD_LOCATION") -- same as gemini-cli
 
   if project_id == nil or project_id == vim.NIL then project_id = "default-project-id" end


### PR DESCRIPTION
This commit allows the GCP project for vertex AI to be provided via env var. As with the GCP location, the same variable that `gemini-cli` expects is honored. This allows `avante.nvim` to work predictably in environments that support multiple GCP projects, or otherwise separate the project being used for AI models from the project being used for, eg, terraform.