### PR TITLE
feat: allow switching between acp providers with AvanteSwitchProvider

### DIFF
--- a/lua/avante/providers/init.lua
+++ b/lua/avante/providers/init.lua
@@ -229,9 +229,13 @@ end
 function M.refresh(provider_name)
   require("avante.config").override({ provider = provider_name })
 
-  ---@type AvanteProviderFunctor | AvanteBedrockProviderFunctor
-  local p = M[Config.provider]
-  E.setup({ provider = p, refresh = true })
+  if Config.acp_providers[provider_name] then
+    Config.provider = provider_name
+  else
+    ---@type AvanteProviderFunctor | AvanteBedrockProviderFunctor
+    local p = M[Config.provider]
+    E.setup({ provider = p, refresh = true })
+  end
   Utils.info("Switch to provider: " .. provider_name, { once = true, title = "Avante" })
 end
 

--- a/plugin/avante.lua
+++ b/plugin/avante.lua
@@ -128,8 +128,15 @@ cmd("SwitchProvider", function(opts) require("avante.api").switch_provider(vim.t
   desc = "avante: switch provider",
   complete = function(_, line, _)
     local prefix = line:match("AvanteSwitchProvider%s*(.*)$") or ""
-    ---@param key string
-    return vim.tbl_filter(function(key) return key:find(prefix, 1, true) == 1 end, vim.tbl_keys(Config.providers))
+    local providers = vim.tbl_filter(
+      ---@param key string
+      function(key) return key:find(prefix, 1, true) == 1 end,
+      vim.tbl_keys(Config.providers)
+    )
+    for acp_provider_name, _ in pairs(Config.acp_providers) do
+      if acp_provider_name:find(prefix, 1, true) == 1 then providers[#providers + 1] = acp_provider_name end
+    end
+    return providers
   end,
 })
 cmd(


### PR DESCRIPTION
Trying out the new acp providers and want the ability to easily swap between those and the native providers. this change adds support for that while updating the autocomplete accordingly
