### PR TITLE
fix: do not run luacheck over files in ./target directory

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -71,7 +71,7 @@ clean:
 	@rm -rf $(BUILD_DIR)
 
 luacheck:
-	@luacheck `find -name "*.lua"` --codes
+	@luacheck `find \( -path './target' -prune \) -o -name "*.lua" -print` --codes
 
 luastylecheck:
 	@stylua --check lua/ plugin/ tests/


### PR DESCRIPTION
We install number of plugin dependencies, as well as lua language server and neovim runtime under ./target/... so skip it when executing luacheck since not all dependencies are warning-free and we do not control their code.