### PR TITLE
fix: sanitize loaded chat history

### DIFF
--- a/lua/avante/llm_tools/update_todo_status.lua
+++ b/lua/avante/llm_tools/update_todo_status.lua
@@ -48,7 +48,7 @@ function M.func(input, opts)
   local sidebar = require("avante").get()
   if not sidebar then return false, "Avante sidebar not found" end
   local todos = sidebar.chat_history.todos
-  if not todos or #todos == 0 then return false, "No todos found" end
+  if #todos == 0 then return false, "No todos found" end
   for _, todo in ipairs(todos) do
     if tostring(todo.id) == tostring(input.id) then
       todo.status = input.status

--- a/lua/avante/sidebar.lua
+++ b/lua/avante/sidebar.lua
@@ -2832,7 +2832,7 @@ function Sidebar:create_input_container()
         get_history_messages = function(opts) return self:get_history_messages_for_api(opts) end,
         get_todos = function()
           local history = Path.history.load(self.code.bufnr)
-          return history and history.todos or {}
+          return history.todos
         end,
         update_todos = function(todos) self:update_todos(todos) end,
         session_ctx = {},
@@ -3098,7 +3098,7 @@ end
 
 function Sidebar:get_todos_container_height()
   local history = Path.history.load(self.code.bufnr)
-  if not history or not history.todos or #history.todos == 0 then return 0 end
+  if #history.todos == 0 then return 0 end
   return 3
 end
 
@@ -3374,7 +3374,7 @@ end
 
 function Sidebar:create_todos_container()
   local history = Path.history.load(self.code.bufnr)
-  if not history or not history.todos or #history.todos == 0 then
+  if #history.todos == 0 then
     if self.containers.todos and Utils.is_valid_container(self.containers.todos) then
       self.containers.todos:unmount()
     end
@@ -3423,10 +3423,6 @@ function Sidebar:create_todos_container()
   local total_count = #history.todos
   local focused_idx = 1
   local todos_content_lines = {}
-  if type(history.todos) ~= "table" then
-    Utils.debug("Invalid todos type", history.todos)
-    history.todos = {}
-  end
   for idx, todo in ipairs(history.todos) do
     local status_content = "[ ]"
     if todo.status == "done" then

--- a/lua/avante/types.lua
+++ b/lua/avante/types.lua
@@ -503,9 +503,9 @@ vim.g.avante_login = vim.g.avante_login
 ---@class avante.ChatHistory
 ---@field title string
 ---@field timestamp string
----@field messages avante.HistoryMessage[] | nil
----@field entries avante.ChatHistoryEntry[] | nil
----@field todos avante.TODO[] | nil
+---@field messages avante.HistoryMessage[]
+---@field entries avante.ChatHistoryEntry[]
+---@field todos avante.TODO[]
 ---@field memory avante.ChatMemory | nil
 ---@field filename string
 ---@field system_prompt string | nil


### PR DESCRIPTION
Ensure that chat history loaded from a file has resemblance of correct data. Namely title and timestamp are present and are strings, and entires, messages, and todos are lists. In case of inconsistencies replace with empty/default data.

This should help with #2584.

More changes are needed to sanitize individual entries.