### PR TITLE
refactor(promptLogger): move highlight definition into promptLogger code

### DIFF
--- a/lua/avante/sidebar.lua
+++ b/lua/avante/sidebar.lua
@@ -2928,15 +2928,7 @@ function Sidebar:create_input_container()
     local group = "avante_input_prompt_group"
 
     fn.sign_unplace(group, { buffer = bufnr })
-
     fn.sign_place(0, group, "AvanteInputPromptSign", bufnr, { lnum = 1 })
-    vim.api.nvim_set_hl(0, "AvantePromptInputHL", {
-      fg = "#ff7700",
-      bg = "#333333",
-      bold = true,
-      italic = true,
-      underline = true,
-    })
   end
 
   place_sign_at_first_line(self.containers.input.bufnr)

--- a/lua/avante/utils/promptLogger.lua
+++ b/lua/avante/utils/promptLogger.lua
@@ -1,6 +1,8 @@
 local Config = require("avante.config")
 local Utils = require("avante.utils")
 
+local AVANTE_PROMPT_INPUT_HL = "AvantePromptInputHL"
+
 -- last one in entries is always to hold current input
 local entries, idx = {}, 0
 local filtered_entries = {}
@@ -9,6 +11,14 @@ local filtered_entries = {}
 local M = {}
 
 function M.init()
+  vim.api.nvim_set_hl(0, AVANTE_PROMPT_INPUT_HL, {
+    fg = "#ff7700",
+    bg = "#333333",
+    bold = true,
+    italic = true,
+    underline = true,
+  })
+
   entries = {}
   local dir = Config.prompt_logger.log_dir
   local log_file = Utils.join_paths(dir, "avante_prompts.log")
@@ -102,7 +112,7 @@ local function update_current_input()
       -- Add the current input as the last entry
       table.insert(filtered_entries, entries[#entries])
 
-      vim.fn.matchadd("AvantePromptInputHL", user_input)
+      vim.fn.matchadd(AVANTE_PROMPT_INPUT_HL, user_input)
     else
       filtered_entries = entries
     end


### PR DESCRIPTION
Separate managing of a sign (">") placement for the input buffer and defining a highlight for prompt logger and move the latter into PromptLogger.init().