### PR TITLE
fix(sidebar): fix handling of multiple windows when toggling full view

### DIFF
--- a/lua/avante/sidebar.lua
+++ b/lua/avante/sidebar.lua
@@ -261,6 +261,10 @@ end
 function Sidebar:close(opts)
   opts = vim.tbl_extend("force", { goto_code_win = true }, opts or {})
 
+  -- If sidebar was maximized make it normal size so that other windows
+  -- will not be left minimized.
+  if self.is_in_full_view then self:toggle_code_window() end
+
   self:delete_autocmds()
   self:delete_containers()
 


### PR DESCRIPTION
Sidebar:toggle_code_window() attempts to handle case when there are multiple non-sidebar windows are present but there are several issues with it:

- checking whether we are running in "full" mode by checking width of the code window is not reliable as it may be only partially hidden (i.e. if transitioning from 3 windows formed by :split :vsplit sequence and going back to original larger window in which case it's width will be 2)

- it is not enough to only manipulate widths of windows, in vertical layout we need to reduce heights instead.

- trying to collect window sizes and minimize them in one pass may result in incorrect window sizes stored (they are changing as we are minimizing other ones)

- table containing old window sizes is not reset and may grow with time

Fix the issues by executing the toggle solely bases on the self.is_in_full_view flag, manipulate with both width and height of windows, and resetting stored sizes table and doing 2 passes over the window list when minimizing.

Additionally do not try to collect window ids of sidebar containers and use it do filter them out later (since vim.tbl_contains() is implemented as a simple scan over elements in a table), but filter them out from the beginning using vim.iter(), filter(), and
Sidebar:is_sidebar_container().

Fixes PR #2660