### PR TITLE
Stop using vim.highlights and vim.loop

### DIFF
--- a/lua/avante/api.lua
+++ b/lua/avante/api.lua
@@ -296,7 +296,7 @@ end
 
 function M.remove_selected_file(filepath)
   ---@diagnostic disable-next-line: undefined-field
-  local stat = vim.loop.fs_stat(filepath)
+  local stat = vim.uv.fs_stat(filepath)
   local files
   if stat and stat.type == "directory" then
     files = Utils.scan_directory({ directory = filepath, add_dirs = true })

--- a/lua/avante/llm_tools/init.lua
+++ b/lua/avante/llm_tools/init.lua
@@ -1291,7 +1291,7 @@ function M.process_tool_use(tools, tool_use, opts)
   -- Set up a timer to periodically check for cancellation
   local cancel_timer
   if on_complete then
-    cancel_timer = vim.loop.new_timer()
+    cancel_timer = vim.uv.new_timer()
     if cancel_timer then
       cancel_timer:start(
         100,

--- a/lua/avante/repo_map.lua
+++ b/lua/avante/repo_map.lua
@@ -106,7 +106,7 @@ function RepoMap._get_repo_map(file_ext)
     build_and_save()
     if not repo_map then return end
   else
-    local timer = vim.loop.new_timer()
+    local timer = vim.uv.new_timer()
 
     if timer then
       timer:start(
@@ -147,7 +147,7 @@ function RepoMap._get_repo_map(file_ext)
     end
   end)
 
-  local handle = vim.loop.new_fs_event()
+  local handle = vim.uv.new_fs_event()
 
   if handle then
     handle:start(project_root, { recursive = true }, function(err, rel_filepath)

--- a/lua/avante/ui/prompt_input.lua
+++ b/lua/avante/ui/prompt_input.lua
@@ -196,7 +196,7 @@ function PromptInput:start_spinner()
     self.spinner_timer = nil
   end
 
-  self.spinner_timer = vim.loop.new_timer()
+  self.spinner_timer = vim.uv.new_timer()
   local spinner_timer = self.spinner_timer
 
   if self.spinner_timer then

--- a/lua/avante/utils/file.lua
+++ b/lua/avante/utils/file.lua
@@ -35,7 +35,7 @@ function M.read_content(filepath)
 end
 
 function M.exists(filepath)
-  local stat = vim.loop.fs_stat(filepath)
+  local stat = vim.uv.fs_stat(filepath)
   return stat ~= nil
 end
 

--- a/lua/avante/utils/init.lua
+++ b/lua/avante/utils/init.lua
@@ -56,9 +56,9 @@ function M.get_os_name()
 end
 
 function M.get_system_info()
-  local os_name = vim.loop.os_uname().sysname
-  local os_version = vim.loop.os_uname().release
-  local os_machine = vim.loop.os_uname().machine
+  local os_name = vim.uv.os_uname().sysname
+  local os_version = vim.uv.os_uname().release
+  local os_machine = vim.uv.os_uname().machine
   local lang = os.getenv("LANG")
   local shell = os.getenv("SHELL")
 
@@ -157,7 +157,7 @@ function M.shell_run_async(input_cmd, shell_cmd, on_complete, cwd, timeout)
 
   -- Set up timeout if specified
   if timeout and timeout > 0 then
-    timer = vim.loop.new_timer()
+    timer = vim.uv.new_timer()
     if timer then
       timer:start(timeout, 0, function()
         vim.schedule(function()

--- a/tests/utils/file_spec.lua
+++ b/tests/utils/file_spec.lua
@@ -8,18 +8,18 @@ describe("File", function()
 
   -- Mock vim API
   local api_mock
-  local loop_mock
+  local uv_mock
 
   before_each(function()
     -- Setup mocks
     api_mock = mock(vim.api, true)
-    loop_mock = mock(vim.loop, true)
+    uv_mock = mock(vim.uv, true)
   end)
 
   after_each(function()
     -- Clean up mocks
     mock.revert(api_mock)
-    mock.revert(loop_mock)
+    mock.revert(uv_mock)
   end)
 
   describe("read_content", function()
@@ -57,14 +57,14 @@ describe("File", function()
 
   describe("exists", function()
     it("should return true for existing file", function()
-      loop_mock.fs_stat.returns({ type = "file" })
+      uv_mock.fs_stat.returns({ type = "file" })
 
       assert.is_true(File.exists(test_file))
-      assert.stub(loop_mock.fs_stat).was_called_with(test_file)
+      assert.stub(uv_mock.fs_stat).was_called_with(test_file)
     end)
 
     it("should return false for non-existent file", function()
-      loop_mock.fs_stat.returns(nil)
+      uv_mock.fs_stat.returns(nil)
 
       assert.is_false(File.exists("nonexistent.txt"))
     end)


### PR DESCRIPTION
Remove references to  vim.loop in favor of new vim.uv. Since Avante requires neovim 0.10+ doing so should be safe now.