### PR TITLE
fix: filter out completions to relevant completion source

### DIFF
--- a/lua/cmp_avante/commands.lua
+++ b/lua/cmp_avante/commands.lua
@@ -18,7 +18,16 @@ function CommandsSource:get_trigger_characters() return { "/" } end
 
 function CommandsSource:get_keyword_pattern() return [[\%(@\|#\|/\)\k*]] end
 
-function CommandsSource:complete(_, callback)
+---@param params cmp.SourceCompletionApiParams
+function CommandsSource:complete(params, callback)
+  ---@type string?
+  local trigger_character
+  if params.completion_context.triggerKind == 1 then
+    trigger_character = string.match(params.context.cursor_before_line, "%s*(/)%S*$")
+  elseif params.completion_context.triggerKind == 2 then
+    trigger_character = params.completion_context.triggerCharacter
+  end
+  if not trigger_character or trigger_character ~= "/" then return callback({ items = {}, isIncomplete = false }) end
   local Utils = require("avante.utils")
   local kind = require("cmp").lsp.CompletionItemKind.Variable
   local commands = Utils.get_commands()

--- a/lua/cmp_avante/mentions.lua
+++ b/lua/cmp_avante/mentions.lua
@@ -24,8 +24,17 @@ function MentionsSource:get_trigger_characters() return { "@" } end
 
 function MentionsSource:get_keyword_pattern() return [[\%(@\|#\|/\)\k*]] end
 
-function MentionsSource:complete(_, callback)
+---@param params cmp.SourceCompletionApiParams
+function MentionsSource:complete(params, callback)
+  ---@type string?
+  local trigger_character
   local kind = require("cmp").lsp.CompletionItemKind.Variable
+  if params.completion_context.triggerKind == 1 then
+    trigger_character = string.match(params.context.cursor_before_line, "%s*(@)%S*$")
+  elseif params.completion_context.triggerKind == 2 then
+    trigger_character = params.completion_context.triggerCharacter
+  end
+  if not trigger_character or trigger_character ~= "@" then return callback({ items = {}, isIncomplete = false }) end
 
   local items = {}
 

--- a/lua/cmp_avante/shortcuts.lua
+++ b/lua/cmp_avante/shortcuts.lua
@@ -17,7 +17,16 @@ function ShortcutsSource:get_trigger_characters() return { "#" } end
 
 function ShortcutsSource:get_keyword_pattern() return [[\%(@\|#\|/\)\k*]] end
 
-function ShortcutsSource:complete(_, callback)
+---@param params cmp.SourceCompletionApiParams
+function ShortcutsSource:complete(params, callback)
+  ---@type string?
+  local trigger_character
+  if params.completion_context.triggerKind == 1 then
+    trigger_character = string.match(params.context.cursor_before_line, "%s*(#)%S*$")
+  elseif params.completion_context.triggerKind == 2 then
+    trigger_character = params.completion_context.triggerCharacter
+  end
+  if not trigger_character or trigger_character ~= "#" then return callback({ items = {}, isIncomplete = false }) end
   local Utils = require("avante.utils")
   local kind = require("cmp").lsp.CompletionItemKind.Variable
   local shortcuts = Utils.get_shortcuts()


### PR DESCRIPTION
I added completions recently and found that the completions were showing every time I typed and between commands and mentions, even though I didn't type the trigger character. Not sure if this is an issue with blink, but this seemed to fix the issue pretty well. mention completions are only shown on `@` and filter as i continue to type
