### PR TITLE
fix: stabilize ACP streaming updates

### DIFF
--- a/lua/avante/config.lua
+++ b/lua/avante/config.lua
@@ -266,6 +266,7 @@ M._defaults = {
       command = "codex-acp",
       env = {
         NODE_NO_WARNINGS = "1",
+        HOME = os.getenv("HOME"),
         OPENAI_API_KEY = os.getenv("OPENAI_API_KEY"),
       },
     },

--- a/lua/avante/llm.lua
+++ b/lua/avante/llm.lua
@@ -1087,7 +1087,7 @@ function M._stream_acp(opts)
             if update.status == "pending" or update.status == "in_progress" then
               tool_call_message.is_calling = true
               tool_call_message.state = "generating"
-            else
+            elseif update.status == "completed" or update.status == "failed" then
               tool_call_message.is_calling = false
               tool_call_message.state = "generated"
               tool_result_message = History.Message:new("assistant", {

--- a/lua/avante/utils/init.lua
+++ b/lua/avante/utils/init.lua
@@ -1301,12 +1301,17 @@ function M.update_buffer_lines(ns_id, bufnr, old_lines, new_lines, skip_line_cou
 
     local changed_lines = vim.list_slice(new_lines, diff_start_idx)
     local text_lines = vim.tbl_map(function(line) return tostring(line) end, changed_lines)
+    local cleaned_text_lines = {}
+    for _, line in ipairs(text_lines) do
+      local lines_ = vim.split(line, "\n")
+      cleaned_text_lines = vim.list_extend(cleaned_text_lines, lines_)
+    end
     vim.api.nvim_buf_set_lines(
       bufnr,
       skip_line_count + diff_start_idx - 1,
       skip_line_count + diff_start_idx + #changed_lines,
       false,
-      text_lines
+      cleaned_text_lines
     )
     for i, line in ipairs(changed_lines) do
       -- Apply highlights


### PR DESCRIPTION
## Summary
- pass HOME through ACP env so subprocess resolves user directory
- ensure ACP tool messages leave calling state only on completion or failure
- normalize multi-line buffer updates by splitting embedded newlines
- add fibonacci helper script used during debugging

## Testing
- [x] pre-commit