### PR TITLE
fix(sidebar): avoid crashing in WinNew handler

### DIFF
--- a/lua/avante/sidebar.lua
+++ b/lua/avante/sidebar.lua
@@ -211,8 +211,8 @@ function Sidebar:setup_colors()
         if not vim.api.nvim_win_is_valid(winid) or self:is_sidebar_winid(winid) then goto continue end
         local winhl = vim.wo[winid].winhl
         if
-          winhl:find(Highlights.AVANTE_SIDEBAR_WIN_SEPARATOR)
-          and not Utils.should_hidden_border(self.code.winid, winid)
+          winhl:find("WinSeparator:" .. Highlights.AVANTE_SIDEBAR_WIN_SEPARATOR)
+          and not (vim.api.nvim_win_is_valid(self.code.winid) and Utils.should_hidden_border(self.code.winid, winid))
         then
           vim.wo[winid].winhl = self.code.old_winhl or ""
         end


### PR DESCRIPTION
If "WinNew" autocommand set up in Sidebar:setup_colors() fires at an inopportune time it will reference self.code.winid and error out with "Invalid window ID".

Fix this by adding check to test if code window is valid before attempting to use it. This should fix with the stack trace in #2770.