### PR TITLE
Refine buffer updates and tool call metadata

### DIFF
--- a/lua/avante/llm.lua
+++ b/lua/avante/llm.lua
@@ -983,6 +983,8 @@ function M._stream_acp(opts)
       id = update.toolCallId,
       name = update.kind,
       input = update.rawInput or {},
+    }, {
+      uuid = update.toolCallId,
     })
     last_tool_call_message = message
     message.acp_tool_call = update


### PR DESCRIPTION
## Summary
- ensure tool call messages carry uuid metadata for tool calls
- replace diff-based buffer updates with full rewrite that rebinds events safely

## Testing
- not run