### PR TITLE
fix(utils): ensure empty tool properties encode as JSON object

### DIFF
--- a/lua/avante/utils/init.lua
+++ b/lua/avante/utils/init.lua
@@ -1546,6 +1546,7 @@ function M.llm_tool_param_fields_to_json_schema(fields)
     end
     if not field.optional then table.insert(required, field.name) end
   end
+  if vim.tbl_isempty(properties) then properties = vim.empty_dict() end
   return properties, required
 end
 


### PR DESCRIPTION
When tools have no parameters, llm_tool_param_fields_to_json_schema returns an empty Lua table {}. vim.json.encode serializes empty tables as JSON arrays [] instead of objects {}, causing Anthropic API to reject requests with "tools.N.custom.input_schema.properties: Input should be a valid dictionary" error.

Solution: Use vim.empty_dict() for empty properties to ensure correct JSON object {} serialization instead of array [].

Tested with Claude Sonnet 4.5 - tools now work correctly without schema validation errors.