### PR TITLE
Auto select Copilot Response API for GPT-5 Codex models

### DIFF
--- a/lua/avante/config.lua
+++ b/lua/avante/config.lua
@@ -6,6 +6,11 @@
 
 local Utils = require("avante.utils")
 
+local function copilot_use_response_api(opts)
+  local model = opts and opts.model
+  return type(model) == "string" and model:match("gpt%-5%-codex") ~= nil
+end
+
 ---@class avante.file_selector.IParams
 ---@field public title      string
 ---@field public filepaths  string[]
@@ -286,7 +291,7 @@ M._defaults = {
       model = "gpt-4o",
       timeout = 30000, -- Timeout in milliseconds, increase this for reasoning models
       context_window = 128000, -- Number of tokens to send to the model for context
-      use_response_api = false, -- Set to true to use OpenAI's new Response API (/responses) instead of Chat Completions API (/chat/completions)
+      use_response_api = copilot_use_response_api, -- Automatically switch to Response API for GPT-5 Codex models
       support_previous_response_id = true, -- OpenAI Response API supports previous_response_id for stateful conversations
       -- NOTE: Response API automatically manages conversation state using previous_response_id for tool calling
       extra_request_body = {
@@ -305,7 +310,7 @@ M._defaults = {
       allow_insecure = false, -- Allow insecure server connections
       timeout = 30000, -- Timeout in milliseconds
       context_window = 64000, -- Number of tokens to send to the model for context
-      use_response_api = true, -- Copilot uses Response API input format
+      use_response_api = copilot_use_response_api, -- Automatically switch to Response API for GPT-5 Codex models
       support_previous_response_id = false, -- Copilot doesn't support previous_response_id, must send full history
       -- NOTE: Copilot doesn't support previous_response_id, always sends full conversation history including tool_calls
       -- NOTE: Response API doesn't support some parameters like top_p, frequency_penalty, presence_penalty

--- a/lua/avante/providers/init.lua
+++ b/lua/avante/providers/init.lua
@@ -256,6 +256,22 @@ function M.parse_config(opts)
   return provider_opts, request_body
 end
 
+---@param provider_conf table | nil
+---@param ctx any
+---@return boolean
+function M.resolve_use_response_api(provider_conf, ctx)
+  if not provider_conf then return false end
+  local value = provider_conf.use_response_api
+  if type(value) ~= "function" then value = provider_conf._use_response_api_resolver or value end
+  if type(value) == "function" then
+    provider_conf._use_response_api_resolver = value
+    local ok, result = pcall(value, provider_conf, ctx)
+    if not ok then error("Failed to evaluate use_response_api: " .. result, 2) end
+    return result == true
+  end
+  return value == true
+end
+
 ---@param provider_name avante.ProviderName
 function M.get_config(provider_name)
   provider_name = provider_name or Config.provider

--- a/lua/avante/sidebar.lua
+++ b/lua/avante/sidebar.lua
@@ -2527,8 +2527,10 @@ function Sidebar:get_history_messages_for_api(opts)
     end
 
     if not Config.acp_providers[Config.provider] then
+      local provider = Providers[Config.provider]
+      local use_response_api = Providers.resolve_use_response_api(provider, nil)
       local tool_limit
-      if Providers[Config.provider].use_ReAct_prompt or Providers[Config.provider].use_response_api then
+      if provider.use_ReAct_prompt or use_response_api then
         tool_limit = nil
       else
         tool_limit = 25

--- a/lua/avante/types.lua
+++ b/lua/avante/types.lua
@@ -263,7 +263,7 @@ vim.g.avante_login = vim.g.avante_login
 ---@field hide_in_model_selector? boolean
 ---@field use_ReAct_prompt? boolean
 ---@field context_window? integer
----@field use_response_api? boolean
+---@field use_response_api? boolean | fun(provider: AvanteDefaultBaseProvider, ctx?: any): boolean
 ---@field support_previous_response_id? boolean
 ---
 ---@class AvanteSupportedProvider: AvanteDefaultBaseProvider


### PR DESCRIPTION
## Summary
- evaluate provider.use_response_api dynamically so Copilot only opts into the response API for GPT-5 Codex models
- share the resolver across Copilot, OpenAI, and sidebar consumers
- keep tool limits intact for non-response API providers

## Testing
- [x] pre-commit (via commit hook)