### PR TITLE
fix: enable think tool when acp provider is configured

### DIFF
--- a/lua/avante/llm_tools/think.lua
+++ b/lua/avante/llm_tools/think.lua
@@ -11,6 +11,8 @@ M.name = "think"
 function M.enabled()
   local Providers = require("avante.providers")
   local Config = require("avante.config")
+  local acp_provider = Config.acp_providers[Config.provider]
+  if acp_provider then return true end
   local provider = Providers[Config.provider]
   local model = provider.model
   if model and model:match("gpt%-5") then return false end


### PR DESCRIPTION
## Summary
- Fix #2809 
- ensure the think tool stays available when an ACP provider is configured so users can still trigger reflective steps

## Testing
- not run