### PR TITLE
Replace replace_in_file references with str_replace

### DIFF
--- a/README.md
+++ b/README.md
@@ -492,7 +492,7 @@ _See [config.lua#L9](./lua/avante/config.lua) for the full config_
     auto_approve_tool_permissions = true, -- Default: auto-approve all tools (no prompts)
     -- Examples:
     -- auto_approve_tool_permissions = false,                -- Show permission prompts for all tools
-    -- auto_approve_tool_permissions = {"bash", "replace_in_file"}, -- Auto-approve specific tools only
+    -- auto_approve_tool_permissions = {"bash", "str_replace"}, -- Auto-approve specific tools only
     ---@type "popup" | "inline_buttons"
     confirmation_ui_style = "inline_buttons",
     --- Whether to automatically open files and navigate to lines when ACP agent makes edits

--- a/lua/avante/llm_tools/init.lua
+++ b/lua/avante/llm_tools/init.lua
@@ -643,7 +643,6 @@ end
 
 ---@type AvanteLLMTool[]
 M._tools = {
-  require("avante.llm_tools.replace_in_file"),
   require("avante.llm_tools.dispatch_agent"),
   require("avante.llm_tools.glob"),
   {

--- a/lua/avante/templates/agentic.avanterules
+++ b/lua/avante/templates/agentic.avanterules
@@ -15,7 +15,7 @@
 
 EDITING FILES
 
-You have access to two tools for working with files: **write_to_file** and **replace_in_file**. Understanding their roles and selecting the right one for the job will help ensure efficient and accurate modifications.
+You have access to two tools for working with files: **write_to_file** and **str_replace**. Understanding their roles and selecting the right one for the job will help ensure efficient and accurate modifications.
 
 # write_to_file
 
@@ -27,16 +27,16 @@ You have access to two tools for working with files: **write_to_file** and **rep
 
 - Initial file creation, such as when scaffolding a new project.
 - Overwriting large boilerplate files where you want to replace the entire content at once.
-- When the complexity or number of changes would make replace_in_file unwieldy or error-prone.
+- When the complexity or number of changes would make str_replace unwieldy or error-prone.
 - When you need to completely restructure a file's content or change its fundamental organization.
 
 ## Important Considerations
 
 - Using write_to_file requires providing the file's complete final content.
-- If you only need to make small changes to an existing file, consider using replace_in_file instead to avoid unnecessarily rewriting the entire file.
+- If you only need to make small changes to an existing file, consider using str_replace instead to avoid unnecessarily rewriting the entire file.
 - While write_to_file should not be your default choice, don't hesitate to use it when the situation truly calls for it.
 
-# replace_in_file
+# str_replace
 
 ## Purpose
 
@@ -55,17 +55,17 @@ You have access to two tools for working with files: **write_to_file** and **rep
 
 # Choosing the Appropriate Tool
 
-- **Default to replace_in_file** for most changes. It's the safer, more precise option that minimizes potential issues.
+- **Default to str_replace** for most changes. It's the safer, more precise option that minimizes potential issues.
 - **Use write_to_file** when:
   - Creating new files
-  - The changes are so extensive that using replace_in_file would be more complex or risky
+  - The changes are so extensive that using str_replace would be more complex or risky
   - You need to completely reorganize or restructure a file
   - The file is relatively small and the changes affect most of its content
   - You're generating boilerplate or template files
 
 # Auto-formatting Considerations
 
-- After using either write_to_file or replace_in_file, the user's editor may automatically format the file
+- After using either write_to_file or str_replace, the user's editor may automatically format the file
 - This auto-formatting may modify the file contents, for example:
   - Breaking single lines into multiple lines
   - Adjusting indentation to match project style (e.g. 2 spaces vs 4 spaces vs tabs)
@@ -74,16 +74,16 @@ You have access to two tools for working with files: **write_to_file** and **rep
   - Adding/removing trailing commas in objects and arrays
   - Enforcing consistent brace style (e.g. same-line vs new-line)
   - Standardizing semicolon usage (adding or removing based on style)
-- The write_to_file and replace_in_file tool responses will include the final state of the file after any auto-formatting
-- Use this final state as your reference point for any subsequent edits. This is ESPECIALLY important when crafting SEARCH blocks for replace_in_file which require the content to match what's in the file exactly.
+- The write_to_file and str_replace tool responses will include the final state of the file after any auto-formatting
+- Use this final state as your reference point for any subsequent edits. This is ESPECIALLY important when crafting SEARCH blocks for str_replace which require the content to match what's in the file exactly.
 
 # Workflow Tips
 
 1. Before editing, assess the scope of your changes and decide which tool to use.
-2. For targeted edits, apply replace_in_file with carefully crafted SEARCH/REPLACE blocks. If you need multiple changes, you can stack multiple SEARCH/REPLACE blocks within a single replace_in_file call.
+2. For targeted edits, apply str_replace with carefully crafted SEARCH/REPLACE blocks. If you need multiple changes, you can stack multiple SEARCH/REPLACE blocks within a single str_replace call.
 3. For major overhauls or initial file creation, rely on write_to_file.
-4. Once the file has been edited with either write_to_file or replace_in_file, the system will provide you with the final state of the modified file. Use this updated content as the reference point for any subsequent SEARCH/REPLACE operations, since it reflects any auto-formatting or user-applied changes.
-By thoughtfully selecting between write_to_file and replace_in_file, you can make your file editing process smoother, safer, and more efficient.
+4. Once the file has been edited with either write_to_file or str_replace, the system will provide you with the final state of the modified file. Use this updated content as the reference point for any subsequent SEARCH/REPLACE operations, since it reflects any auto-formatting or user-applied changes.
+By thoughtfully selecting between write_to_file and str_replace, you can make your file editing process smoother, safer, and more efficient.
 
 {% endif %}
 ====
@@ -96,7 +96,7 @@ RULES
 
 - Always reply to the user in the same language they are using.
 
-- Don't just provide code suggestions, use the `replace_in_file` tool or `str_replace` tool to help users fulfill their needs.
+- Don't just provide code suggestions, use the `str_replace` tool to help users fulfill their needs.
 
 - After the tool call is complete, please do not output the entire file content.
 

--- a/lua/avante/utils/init.lua
+++ b/lua/avante/utils/init.lua
@@ -1691,7 +1691,7 @@ end
 
 ---@param tool_use AvanteLLMToolUse
 function M.is_edit_tool_use(tool_use)
-  return tool_use.name == "replace_in_file"
+  return tool_use.name == "str_replace"
     or tool_use.name == "edit_file"
     or (tool_use.name == "str_replace_editor" and tool_use.input.command == "str_replace")
     or (tool_use.name == "str_replace_based_edit_tool" and tool_use.input.command == "str_replace")

--- a/lua/avante/utils/prompts.lua
+++ b/lua/avante/utils/prompts.lua
@@ -126,7 +126,7 @@ Parameters:
 
 ## Example 3: Requesting to make targeted edits to a file
 
-<tool_use>{"name": "replace_in_file", "input": {"path": "src/components/App.tsx", "the_diff": "------- SEARCH\nimport React from 'react';\n=======\nimport React, { useState } from 'react';\n+++++++ REPLACE\n\n------- SEARCH\nfunction handleSubmit() {\n  saveData();\n  setLoading(false);\n}\n\n=======\n+++++++ REPLACE\n\n------- SEARCH\nreturn (\n  <div>\n=======\nfunction handleSubmit() {\n  saveData();\n  setLoading(false);\n}\n\nreturn (\n  <div>\n+++++++ REPLACE\n"}}</tool_use>
+<tool_use>{"name": "str_replace", "input": {"path": "src/components/App.tsx", "old_str": "import React from 'react';", "new_str": "import React, { useState } from 'react';"}}</tool_use>
 ]]
     end
 


### PR DESCRIPTION
## Summary
- align docs and templates with the str_replace tool name
- drop the deprecated replace_in_file tool registration
- refresh prompt example to show the str_replace input structure

## Testing
- pre-commit run --all-files