### PR TITLE
fix: never attempt to concatenate nil values, use empty strings (#2692)

### DIFF
--- a/lua/avante/llm_tools/str_replace.lua
+++ b/lua/avante/llm_tools/str_replace.lua
@@ -59,13 +59,9 @@ function M.func(input, opts)
   local replace_in_file = require("avante.llm_tools.replace_in_file")
   local Utils = require("avante.utils")
 
-  if input.new_str == nil then
-    input.new_str = ""
-  end
+  if input.new_str == nil then input.new_str = "" end
 
-  if input.old_str == nil then
-    input.old_str = ""
-  end
+  if input.old_str == nil then input.old_str = "" end
 
   -- Remove trailing spaces from the new string
   input.new_str = Utils.remove_trailing_spaces(input.new_str)


### PR DESCRIPTION
The error described in #2692 popped up every time when the LLM made a tool call to change code (so very often). This fixes that for me and has been working great so far. No more nasty red errors. Tested on latest commit.