### PR TITLE
fix(history): use vim.inspect() instead of direct string concatenation

### DIFF
--- a/lua/avante/history/render.lua
+++ b/lua/avante/history/render.lua
@@ -398,7 +398,7 @@ function M.get_tool_display_name(message)
         param = param:gsub(project_root .. "/?", "")
       end)
     end
-    if param then tool_name = native_tool_name .. "(" .. param .. ")" end
+    if param then tool_name = native_tool_name .. "(" .. vim.inspect(param) .. ")" end
   end
 
   ---@cast tool_name string


### PR DESCRIPTION
When the parameter type is a table, string concatenation will cause a crash.