### PR TITLE
Fix: Snacks picker formatting

### DIFF
--- a/lua/avante/ui/selector/providers/snacks.lua
+++ b/lua/avante/ui/selector/providers/snacks.lua
@@ -34,7 +34,7 @@ function M.show(selector)
     source = "select",
     items = finder_items,
     ---@diagnostic disable-next-line: undefined-global
-    format = Snacks.picker.format.ui_select({}),
+    format = Snacks.picker.format.ui_select({ format_item = function(item, _) return item.title end }),
     title = selector.title,
     preview = selector.get_preview_content and "preview" or nil,
     layout = {


### PR DESCRIPTION
Fixes snacks picker format config, which was trying to display lua tables rather than the filename/model name.

# Before:
<img width="3808" height="2310" alt="2025-11-09-220343_hyprshot" src="https://github.com/user-attachments/assets/9a6cb8ae-7300-45c2-b8ac-7e71733f4782" />

# After:
<img width="3804" height="2301" alt="2025-11-09-220621_hyprshot" src="https://github.com/user-attachments/assets/cdbb05c1-5c45-441d-bc88-ab0b069bc8c5" />
