### PR TITLE
fix: gracefully handle utf8 errors

### DIFF
--- a/lua/avante/tokenizers.lua
+++ b/lua/avante/tokenizers.lua
@@ -52,7 +52,13 @@ function M.encode(prompt)
   if not prompt or prompt == "" then return nil end
   if type(prompt) ~= "string" then error("Prompt is not type string", 2) end
 
-  return tokenizers.encode(prompt)
+  local success, result = pcall(tokenizers.encode, prompt)
+  -- Some output like terminal command output might not be utf-8 encoded, which will cause an error here
+  if not success then
+    Utils.warn("Failed to encode prompt: " .. result)
+    return nil
+  end
+  return result
 end
 
 ---@param prompt string


### PR DESCRIPTION
was getting utf8 errors when calling the tokenizer. one command it ran was outputting some weird characters at the end of each line (i think because we were capturing output from a command running a container). not sure how to solve this in a generic way but we shouldn't prevent the model from continuing so at least gracefully handle and log a warning
