### PR TITLE
fix: hangs on tool calling to read_todos

### DIFF
--- a/lua/avante/providers/claude.lua
+++ b/lua/avante/providers/claude.lua
@@ -215,7 +215,7 @@ function M:parse_response(ctx, data_stream, event_state, opts)
           type = "tool_use",
           name = content_block.name,
           id = content_block.id,
-          input = incomplete_json or {},
+          input = incomplete_json or { dummy = "" },
         })
         content_block.uuid = msg.uuid
         opts.on_messages_add({ msg })
@@ -281,15 +281,12 @@ function M:parse_response(ctx, data_stream, event_state, opts)
     elseif content_block.type == "tool_use" then
       if opts.on_messages_add then
         local ok_, complete_json = pcall(vim.json.decode, content_block.input_json)
-        if not ok_ then
-          Utils.warn("Failed to parse tool_use input_json: " .. content_block.input_json)
-          return
-        end
+        if not ok_ then complete_json = nil end
         local msg = new_assistant_message({
           type = "tool_use",
           name = content_block.name,
           id = content_block.id,
-          input = complete_json or {},
+          input = complete_json or { dummy = "" },
         }, content_block.uuid)
         opts.on_messages_add({ msg })
       end


### PR DESCRIPTION
When the `read_todos` tool is called with Bedrock (Claude), a warning message `Failed to parse tool_use input_json:` appears, and the agentic workflow hangs on tool calling. This issue can be reproduced by simply appending `read current todo first` to your prompt. See also #2647.

The workflow hangs because it stops at https://github.com/yetone/avante.nvim/blob/main/lua/avante/providers/claude.lua#L286 without performing the tool_use action. If the `return` statement is removed, an error from the LLM appears: `Input should be a valid dictionary`, and the agentic workflow still stops.

The root cause is that `{}` is interpreted as `[]` in Lua, so the message for tool_use looks like:

```
{
  "role": "assistant",
  "content": [
    {
      "id": "toolu_bdrk_019URoyj8tzPAmbVxGrQQ3Xg",
      "name": "read_todos",
      "type": "tool_use",
      "input": []
    }
  ]
},
```

The fix is to add a dummy field to the empty dictionary to force it to be a dictionary, like:

```
{
  "role": "assistant",
  "content": [
    {
      "id": "toolu_bdrk_01EiLyayWqmntnzAzrrArGGe",
      "name": "read_todos",
      "type": "tool_use",
      "input": {
        "dummy": ""
      }
    }
  ]
},
```
