### PR TITLE
fix rag-service requirements

### DIFF
--- a/py/rag-service/requirements.txt
+++ b/py/rag-service/requirements.txt
@@ -177,3 +177,4 @@ websockets==14.2
 wrapt==1.17.2
 yarl==1.18.3
 zipp==3.21.0
+nbconvert==7.16.6


### PR DESCRIPTION
In response to the issue raised in #2081 , I have added a dependency of 'nbconvert' to the Python dependency list of the avaent rag server, hoping to fix the problem