### PR TITLE
openai provider add empty parameters to tool call

### DIFF
--- a/lua/avante/providers/openai.lua
+++ b/lua/avante/providers/openai.lua
@@ -25,15 +25,12 @@ function M:is_disable_stream() return false end
 function M:transform_tool(tool)
   local input_schema_properties, required = Utils.llm_tool_param_fields_to_json_schema(tool.param.fields)
   ---@type AvanteOpenAIToolFunctionParameters
-  local parameters = nil
-  if not vim.tbl_isempty(input_schema_properties) then
-    parameters = {
-      type = "object",
-      properties = input_schema_properties,
-      required = required,
-      additionalProperties = false,
-    }
-  end
+  local parameters = {
+    type = "object",
+    properties = input_schema_properties,
+    required = required,
+    additionalProperties = false,
+  }
   ---@type AvanteOpenAITool
   local res = {
     type = "function",


### PR DESCRIPTION
Addresses https://github.com/yetone/avante.nvim/issues/2825

It seems like https://github.com/yetone/avante.nvim/commit/b95e27b5a60d81814929764f9f6acf3768b98be3 added `read_todos.lua` which has empty fields.  
This translates to no parameters being set for the tool, which is not valid in the xAI API tool call.

Please help verify with other providers.

`llm_tool_param_fields_to_json_schema` already guarantees empty dicts for both, so directly applying it should be okay.