### PR TITLE
fix: support cancelling acp providers

### DIFF
--- a/lua/avante/sidebar.lua
+++ b/lua/avante/sidebar.lua
@@ -2813,7 +2813,11 @@ function Sidebar:handle_submit(request)
       return
     end
 
-    on_state_change("succeeded")
+    if stop_opts.reason == "cancelled" then
+      on_state_change("cancelled")
+    else
+      on_state_change("succeeded")
+    end
 
     self:update_content("", {
       callback = function() api.nvim_exec_autocmds("User", { pattern = VIEW_BUFFER_UPDATED_PATTERN }) end,


### PR DESCRIPTION
AvanteStop doesn't work with acp providers, so this PR adds support for it.
