### PR TITLE
fix: avante.llm_tools.helpers.is_ignored error

### DIFF
--- a/lua/avante/llm_tools/helpers.lua
+++ b/lua/avante/llm_tools/helpers.lua
@@ -129,10 +129,8 @@ end
 ---@return boolean
 function M.is_ignored(abs_path)
   local project_root = Utils.get_project_root()
-  local cmd =
-    string.format("git -C %s check-ignore %s", vim.fn.shellescape(project_root), vim.fn.shellescape(abs_path))
-
-  local result = vim.fn.system(cmd)
+  local result =
+    vim.fn.system({ "git", "-C", vim.fn.shellescape(project_root), "check-ignore", vim.fn.shellescape(abs_path) })
   local exit_code = vim.v.shell_error
 
   -- If command failed or git is not available, fall back to old method


### PR DESCRIPTION
An error will be reported when calling "lua/avante/llm_tools/view.lua", for example:

view("README.md")  failed Error: No permission to access path: /home/waitzz/workspace/avante.nvim/README.md

I check that the permissions on the file are correct. After tracing code, I found the return result of  avante.llm_tools.helpers.is_ignored is wrong.

vim.fn.system("") can not return the expected results, but vim.fn.system({}) can. The results of my test in the old version :

test codes :
```lua
local result = vim.fn.system("git -C /home/waitzz/workspace/avante.nvim check-ignore test.log")
-- local result = vim.fn.system({"git", "-C", "/home/waitzz/workspace/avante.nvim", "check-ignore", "test.log"})
local code = vim.v.shell_error

print(code, result)
```

| Code | v0.11.5 | v0.11.0 | v0.10.4 |
|:------:|:--------:|:--------:|:--------:|
| vim.fn.system("git check-ignore xxx")        |  ❌  | ❌ | ❌ |
| vim.fn.system("git", "check-ignore", "xxx") | ✅ | ✅ | ✅ |
