### PR TITLE
chore: used native action-centric methods for testing

### DIFF
--- a/.github/workflows/lua.yaml
+++ b/.github/workflows/lua.yaml
@@ -40,6 +40,7 @@ jobs:
 
       - name: Download neovim ${{ matrix.rev }}
         env:
+          GH_TOKEN: ${{ github.token }}
           NEOVIM_VERSION: ${{ matrix.rev }}
         if: steps.cache-neovim.outputs.cache-hit != 'true'
         run: |


### PR DESCRIPTION
Just cleaned up the workflow to make better use of the platform.

* Updated `actions/checkout` action to latest
* switched to using `gh` CLI over `curl`
* Removed hash of date file in favor of using the date directly as a part of the cache `key`
* Made download conditionally based on cache hit vs directory existence
* Used environment variable for GitHub variables to remove injection vector