### PR TITLE
fix: ACP improvements - single-line retry, variable name, and cancel optimization

### DIFF
--- a/lua/avante/init.lua
+++ b/lua/avante/init.lua
@@ -33,6 +33,17 @@ function M.register_acp_client(client_id, client)
   Utils.debug("Registered ACP client: " .. client_id)
 end
 
+---Get all registered ACP clients
+---@return table<string, avante.acp.ACPClient>
+function M.get_registered_acp_clients()
+  return M.acp_clients or {}
+end
+
+---Clear all registered ACP clients
+function M.clear_acp_clients()
+  M.acp_clients = {}
+end
+
 ---Unregister an ACP client
 ---@param client_id string Unique identifier for the client
 function M.unregister_acp_client(client_id)

--- a/lua/avante/providers/openai.lua
+++ b/lua/avante/providers/openai.lua
@@ -176,7 +176,7 @@ function M:parse_messages(opts)
         elseif item.type == "tool_result" and has_tool_use and not use_ReAct_prompt then
           table.insert(
             tool_results,
-            { tool_call_id = item.tool_use_id, content = item.is_error and "Error: " .. item.content or item.content }
+            { tool_call_id = item.tool_use_id, content = item.is_error and "Error: " .. (item.content or "") or (item.content or "") }
           )
         end
       end

--- a/lua/avante/sidebar.lua
+++ b/lua/avante/sidebar.lua
@@ -196,7 +196,12 @@ function Sidebar:open(opts)
   end
 
   local acp_provider = Config.acp_providers[Config.provider]
-  if acp_provider then self:handle_submit("") end
+  -- Pre-connect ACP asynchronously to avoid blocking UI
+  if acp_provider then
+    vim.defer_fn(function()
+      self:handle_submit("")
+    end, 0)
+  end
 
   return self
 end
@@ -752,7 +757,10 @@ function Sidebar:get_current_user_request_block(position)
     end
   end
   if start_line == nil then return nil end
-  content_lines = vim.list_slice(content_lines, 1, #content_lines - 1)
+  -- Fix: Only remove last line if there are multiple lines (bug fix for single-line messages)
+  if #content_lines > 1 then
+    content_lines = vim.list_slice(content_lines, 1, #content_lines - 1)
+  end
   local content = table.concat(content_lines, "\n")
   return {
     start_line = current_resp_start_line + start_line - 1,


### PR DESCRIPTION
## Summary
This PR includes several ACP-related fixes and improvements:
1. **Fix single-line retry/edit returning empty content**
2. **Fix ACP client variable name inconsistency**
3. **Use `cancel_session` instead of stopping ACP client**
4. **Reset sidebar state after cancellation**
## Problems Fixed
### 1. Single-line retry/edit broken
When a user message is a single line, `get_current_user_request_block()` returns empty content because line 755 unconditionally removes the last element:
```lua
content_lines = vim.list_slice(content_lines, 1, #content_lines - 1)
```
For single-line messages, this results in an empty table.

2. ACP client stop not working
cancel_inflight_request() calls get_registered_acp_clients() which returns M._acp_clients, but register_acp_client() stores clients in M.acp_clients. This mismatch causes the stop function to never find any clients.

3. Full client stop causes reconnection delay
Previously, cancellation would stop the entire ACP client process, requiring a new connection for subsequent requests.

4. UI stuck in "generating" state after cancel
After cancelling, the sidebar state was not properly reset.

Solution
Only slice content_lines when there are multiple lines
Use acp_clients consistently (not _acp_clients)
Use cancel_session() to cancel the current session while keeping the connection alive
Reset current_state, scroll, and clear state extmarks after cancellation
Testing
Send a single-line message → retry/edit now works
Cancel during generation → UI properly resets
Send new message after cancel → responds without reconnection delay