### PR TITLE
feat: Add mapping to delete avante history via telescope.nvim

### DIFF
--- a/lua/avante/history_selector.lua
+++ b/lua/avante/history_selector.lua
@@ -69,13 +69,8 @@ function M.open(bufnr, cb)
         return
       end
       Path.history.delete(bufnr, item_id_to_delete) -- bufnr from M.open's scope
-      -- The native provider handles the UI flow; we just need to refresh.
-      M.open(bufnr, cb) -- Re-open the selector to refresh the list
     end,
-    on_action_cancel = function()
-      -- If the user cancels the open/delete prompt, re-open the history selector.
-      M.open(bufnr, cb)
-    end,
+    on_open = function() M.open(bufnr, cb) end,
   })
   current_selector:open()
 end

--- a/lua/avante/ui/selector/init.lua
+++ b/lua/avante/ui/selector/init.lua
@@ -14,7 +14,7 @@ local Utils = require("avante.utils")
 ---@field on_select fun(item_ids: string[] | nil)
 ---@field get_preview_content fun(item_id: string): (string, string) | nil
 ---@field on_delete_item fun(item_id: string): (nil) | nil
----@field on_action_cancel fun(): (nil) | nil
+---@field on_open fun(): (nil) | nil
 
 ---@class avante.ui.Selector
 ---@field provider avante.SelectorProvider
@@ -26,7 +26,7 @@ local Utils = require("avante.utils")
 ---@field selected_item_ids string[] | nil
 ---@field get_preview_content fun(item_id: string): (string, string) | nil
 ---@field on_delete_item fun(item_id: string): (nil) | nil
----@field on_action_cancel fun(): (nil) | nil
+---@field on_open fun(): (nil) | nil
 local Selector = {}
 Selector.__index = Selector
 
@@ -50,7 +50,7 @@ function Selector:new(opts)
   o.selected_item_ids = opts.selected_item_ids or {}
   o.get_preview_content = opts.get_preview_content
   o.on_delete_item = opts.on_delete_item
-  o.on_action_cancel = opts.on_action_cancel
+  o.on_open = opts.on_open
   return o
 end
 

--- a/lua/avante/ui/selector/providers/native.lua
+++ b/lua/avante/ui/selector/providers/native.lua
@@ -27,16 +27,18 @@ function M.show(selector)
           local choice = input:lower()
           if choice == "d" or choice == "delete" then
             selector.on_delete_item(item.id)
+            -- The native provider handles the UI flow; we just need to refresh.
+            selector.on_open() -- Re-open the selector to refresh the list
           elseif choice == "" or choice == "o" or choice == "open" then
             selector.on_select({ item.id })
           elseif choice == "c" or choice == "cancel" then
-            if type(selector.on_action_cancel) == "function" then
-              selector.on_action_cancel()
+            if type(selector.on_open) == "function" then
+              selector.on_open()
             else
-              selector.on_select(nil) -- Fallback if on_action_cancel is not defined
+              selector.on_select(nil) -- Fallback if on_open is not defined
             end
           else -- c or any other input, treat as cancel
-            selector.on_select(nil) -- Fallback if on_action_cancel is not defined
+            selector.on_select(nil) -- Fallback if on_open is not defined
           end
         end
       )


### PR DESCRIPTION
Avante can delete chat history via native selector only. when I choose telescope.nvim as my selector, I can not to delete chat history via telescope.nvim. I add a mapping (<C+DEL>) to delete chat history via telescope.nvim.

![522804110-3a0a0889-66bf-4191-9cd4-81d334cb95c1](https://github.com/user-attachments/assets/3694cac0-88fd-422b-b168-c6f874391643)
