### PR TITLE
feat: Add mapping to delete avante history via snacks.nvim

### DIFF
--- a/lua/avante/ui/selector/providers/snacks.lua
+++ b/lua/avante/ui/selector/providers/snacks.lua
@@ -8,23 +8,26 @@ function M.show(selector)
     Utils.error("Snacks is not set up. Please install and set up Snacks to use it as a file selector.")
     return
   end
-  local finder_items = {}
-  for i, item in ipairs(selector.items) do
-    if not vim.list_contains(selector.selected_item_ids, item.id) then
-      table.insert(finder_items, {
-        formatted = item.title,
-        text = item.title,
-        item = item,
-        idx = i,
-        preview = selector.get_preview_content and (function()
-          local content, filetype = selector.get_preview_content(item.id)
-          return {
-            text = content,
-            ft = filetype,
-          }
-        end)() or nil,
-      })
+  local function snacks_finder()
+    local items = {}
+    for i, item in ipairs(selector.items) do
+      if not vim.list_contains(selector.selected_item_ids, item.id) then
+        table.insert(items, {
+          formatted = item.title,
+          text = item.title,
+          item = item,
+          idx = i,
+          preview = selector.get_preview_content and (function()
+            local content, filetype = selector.get_preview_content(item.id)
+            return {
+              text = content,
+              ft = filetype,
+            }
+          end)() or nil,
+        })
+      end
     end
+    return items
   end
 
   local completed = false
@@ -32,7 +35,8 @@ function M.show(selector)
   ---@diagnostic disable-next-line: undefined-global
   Snacks.picker.pick(vim.tbl_deep_extend("force", {
     source = "select",
-    items = finder_items,
+    live = true,
+    finder = snacks_finder,
     ---@diagnostic disable-next-line: undefined-global
     format = Snacks.picker.format.ui_select({ format_item = function(item, _) return item.title end }),
     title = selector.title,
@@ -53,6 +57,31 @@ function M.show(selector)
       completed = true
       vim.schedule(function() selector.on_select(nil) end)
     end,
+    actions = {
+      delete_selection = function(picker)
+        local selections = picker:selected({ fallback = true })
+        if #selections == 0 then return end
+        vim.ui.input({ prompt = "Remove·selection?·(" .. #selections .. " items) [y/N]" }, function(input)
+          if input and input:lower() == "y" then
+            for _, selection in ipairs(selections) do
+              selector.on_delete_item(selection.item.id)
+              for i, item in ipairs(selector.items) do
+                if item.id == selection.item.id then table.remove(selector.items, i) end
+              end
+            end
+            picker:refresh()
+          end
+        end)
+      end,
+    },
+
+    win = {
+      input = {
+        keys = {
+          ["<C-DEL>"] = { "delete_selection", mode = { "i", "n" } },
+        },
+      },
+    },
   }, selector.provider_opts))
 end
 


### PR DESCRIPTION
Like [feat: Add mapping to delete avante history via telescope.nvim](https://github.com/yetone/avante.nvim/pull/2867) , Add a shortcut key mapping (<C-DEL>) to delete chat history in snacks.nvim when using snacks.nvim as a selector.

![数据校验（下拉框）](https://github.com/user-attachments/assets/547ce262-7ac4-4dbe-8a84-3dbe90386f89)
