### PR TITLE
fix: typo in vertex claude endpoint url

### DIFF
--- a/lua/avante/config.lua
+++ b/lua/avante/config.lua
@@ -425,7 +425,7 @@ M._defaults = {
 
     ---@type AvanteSupportedProvider
     vertex_claude = {
-      endpoint = "https://LOCATION-aiplatform.googleapis.com/v1/projects/PROJECT_ID/locations/LOCATION/publishers/antrhopic/models",
+      endpoint = "https://LOCATION-aiplatform.googleapis.com/v1/projects/PROJECT_ID/locations/LOCATION/publishers/anthropic/models",
       model = "claude-3-5-sonnet-v2@20241022",
       timeout = 30000, -- Timeout in milliseconds
       extra_request_body = {


### PR DESCRIPTION
There is a typo in the value assigned for the endpoint for vertex claude in the config file, which breaks the connection to all claude models.