### PR TITLE
fix(xdg): properly take into account xdg

### DIFF
--- a/lua/avante/config.lua
+++ b/lua/avante/config.lua
@@ -799,7 +799,7 @@ M._defaults = {
 ---@diagnostic disable-next-line: missing-fields
 M._options = {}
 
-local function get_config_dir_path() return Utils.join_paths(vim.fn.expand("~"), ".config", "avante.nvim") end
+local function get_config_dir_path() return Utils.join_paths(vim.fn.stdpath("config"), "avante.nvim") end
 local function get_config_file_path() return Utils.join_paths(get_config_dir_path(), "config.json") end
 
 --- Function to save the last used model


### PR DESCRIPTION
get_config_dir_path would just use $HOME/.config instead of $XDG_CONFIG_HOME like neovim does. Also avante wont adapt to a neovim flavor set with NVIM_APPNAME without this change.