### PR TITLE
fix: wrap nvim_del_autocmd in vim.schedule to avoid fast event context error

### DIFF
--- a/lua/avante/llm.lua
+++ b/lua/avante/llm.lua
@@ -1562,7 +1562,7 @@ function M._stream_acp(opts)
   })
   acp_client:send_prompt(session_id, prompt, function(_, err_)
     if cancelled then return end
-    api.nvim_del_autocmd(stop_cmd_id)
+    vim.schedule(function() api.nvim_del_autocmd(stop_cmd_id) end)
     if err_ then
       -- ACP-specific session recovery: Check for session not found error
       -- Check for session recovery conditions


### PR DESCRIPTION
nvim_del_autocmd was being called in a callback from acp_client, which is a fast event context where it's not allowed. Wrapping it with vim.schedule() defers the execution to a safe context.