### PR TITLE
feat(acp): support mcp_servers in acp_providers config

### DIFF
--- a/lua/avante/llm.lua
+++ b/lua/avante/llm.lua
@@ -1338,7 +1338,9 @@ end
 ---@param acp_client avante.acp.ACPClient
 function M._create_acp_session_and_continue(opts, acp_client)
   local project_root = Utils.root.get()
-  acp_client:create_session(project_root, {}, function(session_id_, err)
+  local acp_provider = Config.acp_providers[Config.provider] or {}
+  local mcp_servers = acp_provider.mcp_servers or {}
+  acp_client:create_session(project_root, mcp_servers, function(session_id_, err)
     if err then
       opts.on_stop({ reason = "error", error = err })
       return


### PR DESCRIPTION
Allow `acp_providers` to specify an `mcp_servers` array that gets passed to `create_session`. This enables agents to connect to HTTP MCP servers configured by the client.

## Example with goose

When using ACP providers, users can now configure MCP servers in their setup:

```lua
require("avante").setup({
  provider = "goose",
  acp_providers = {
    ["goose"] = {
      mcp_servers = {
        { type = "http", name = "kiwi", url = "https://mcp.kiwi.com", headers = {} },
      },
    },
  },
})
```

<img width="1268" height="812" alt="Screenshot 2025-12-23 at 9 20 36 AM" src="https://github.com/user-attachments/assets/8aab1b5f-71fb-43b0-a45e-cc484f2aa0e7" />

Note: goose support is pending https://github.com/block/goose/pull/6230