### PR TITLE
Use `kind` instead of `optionId` when checking ACP tool permissions

### DIFF
--- a/lua/avante/llm_tools/helpers.lua
+++ b/lua/avante/llm_tools/helpers.lua
@@ -75,13 +75,13 @@ function M.confirm(message, callback, confirm_opts, session_ctx, tool_name)
   end
 
   if Config.behaviour.confirmation_ui_style == "inline_buttons" then
-    M.confirm_inline(function(option_id)
-      if option_id == "allow" or option_id == "allow_once" or option_id == "allow_always" then
-        if option_id == "allow_always" and session_ctx then session_ctx.always_yes = true end
+    M.confirm_inline(function(kind)
+      if kind == "allow" or kind == "allow_once" or kind == "allow_always" then
+        if kind == "allow_always" and session_ctx then session_ctx.always_yes = true end
 
         callback(true)
       else
-        callback(false, option_id)
+        callback(false, kind)
       end
     end, confirm_opts or {})
     return

--- a/lua/avante/ui/acp_confirm_adapter.lua
+++ b/lua/avante/ui/acp_confirm_adapter.lua
@@ -49,7 +49,7 @@ function M.generate_buttons_for_acp_options(options)
       if item.kind == "reject_once" or item.kind == "reject_always" then hl = Highlights.BUTTON_DANGER_HOVER end
       ---@type avante.ui.ACPConfirmAdapter.ButtonOption
       local button = {
-        id = item.optionId,
+        id = item.kind,
         name = item.name,
         icon = icon,
         hl = hl,


### PR DESCRIPTION
# Summary

Fixes an issue with the codex-acp tool. Codex uses a different value for `optionId` and `kind`. Existing code checked if the `optionId` was one of the `kind` values which it would never be and therefore all tool calls would be rejected. This only occurs when `auto_approve_tool_permissions` is set to `false`.

# Cause

Codex returned the following messages when ACP was used. 

```js
{
  "jsonrpc": "2.0",
  "id": 1,
  "method": "session/request_permission",
  "params": {
    "options": [
      { "optionId": "approved", "name": "Yes", "kind": "allow_once" },
      { "optionId": "abort", "name": "No, provide feedback", "kind": "reject_once" }
    ],
    // Other params
  }
}
```

The important thing here is that `optionId != kind`. In `/llm_tools/helpers.lua` a check was done whether the option id was `allow`, `allow_once`, etc. in order to determine if the user approved the action or not.

This check would always fail when codex was used because `approved` isn't in this list. Resulting in the tool call being rejected no matter the selected option.

# The fix

Using `kind` solves the issue of arbitrary values for the `optionId`. The `optionId` is still used for the ACP communication, in `/llm.lua:1223` it looks at a map of the options containing the correct ids to determine what to send.

> Looking at the docs the `optionId` is just a text value that could be anything. https://agentclientprotocol.com/protocol/tool-calls#param-option-id

# Sidenotes

- First PR on this repo so if anything is wrong or missing let me know
- Tested only with codex (don't have a claude code subscription so I can only assume that would still work)
- Probably fixes https://github.com/yetone/avante.nvim/issues/2836
    - Looking at this issue the used config also has `auto_approve_tool_permissions=false`
