### PR TITLE
Support loading ACP sessions if agent can

### DIFF
--- a/lua/avante/llm.lua
+++ b/lua/avante/llm.lua
@@ -1320,8 +1320,7 @@ function M._stream_acp(opts)
       if not session_id then
         M._create_acp_session_and_continue(opts, acp_client)
       else
-        if opts.just_connect_acp_client then return end
-        M._continue_stream_acp(opts, acp_client, session_id)
+        M._load_acp_session_and_continue(opts, acp_client, session_id)
       end
     end)
     return
@@ -1352,6 +1351,23 @@ function M._create_acp_session_and_continue(opts, acp_client)
 
     if opts.just_connect_acp_client then return end
     M._continue_stream_acp(opts, acp_client, session_id_)
+  end)
+end
+
+---@param opts AvanteLLMStreamOptions
+---@param acp_client avante.acp.ACPClient
+---@param session_id string
+function M._load_acp_session_and_continue(opts, acp_client, session_id)
+  local project_root = Utils.root.get()
+  acp_client:load_session(session_id, project_root, {}, function(_, err)
+    if err then
+      -- Failed to load session, create a new one. It happens after switching acp providers
+      M._create_acp_session_and_continue(opts, acp_client)
+      return
+    end
+
+    if opts.just_connect_acp_client then return end
+    M._continue_stream_acp(opts, acp_client, session_id)
   end)
 end
 


### PR DESCRIPTION
Issues described in issue https://github.com/yetone/avante.nvim/issues/2879

Now previous ACP sessions is not loaded. When session_id is not `nil`, only `initialize` is executed before "session/prompt" request. As a result, follow up queries will always fail when using Opencode ACP.