### PR TITLE
Change codex acp provider command to automatically install & run

### DIFF
--- a/README.md
+++ b/README.md
@@ -1239,7 +1239,8 @@ ACP providers are configured in the `acp_providers` section of your configuratio
       args = { "acp" },
     },
     ["codex"] = {
-      command = "codex-acp",
+      command = "npx",
+      args = { "@zed-industries/codex-acp" },
       env = {
         NODE_NO_WARNINGS = "1",
         OPENAI_API_KEY = os.getenv("OPENAI_API_KEY"),

--- a/lua/avante/config.lua
+++ b/lua/avante/config.lua
@@ -268,7 +268,8 @@ M._defaults = {
       args = { "acp" },
     },
     ["codex"] = {
-      command = "codex-acp",
+      command = "npx",
+      args = { "-y", "@zed-industries/codex-acp" },
       env = {
         NODE_NO_WARNINGS = "1",
         HOME = os.getenv("HOME"),


### PR DESCRIPTION
Motivation of this PR can be found here https://github.com/yetone/avante.nvim/issues/2888#issuecomment-3693046942.

I'm afraid someone else may not konw he should first manually install `@zed-industries/codex-acp` before start codex-acp. This PR is to make it run with `npx` like what it does for claude-code-acp