### PR TITLE
Avoid error triggered by inputing Chinese characters if img pasting not set up

### DIFF
--- a/plugin/avante.lua
+++ b/plugin/avante.lua
@@ -32,6 +32,9 @@ if Config.support_paste_image() then
 
       ---@type string
       local line = lines[1]
+      -- NOTE: Inputing Chinese characters triggers paste events, which results in error if evn not setup for image pasting
+      -- Valid image data is usually long. So use length to filter out invalid image data
+      if not line or vim.fn.strlen(line) < 32 then return overridden(lines, phase) end
 
       local ok = Clipboard.paste_image(line)
       if not ok then return overridden(lines, phase) end


### PR DESCRIPTION
This is a work around to avoid https://github.com/yetone/avante.nvim/issues/2887. 

In my working env, I don't setup img-clip. So it raise errors when I input Chinese characters, because that triggers past event. I have set `behaviour.support_paste_from_clipboard` to false. But it seems not working.

Since the content in pasted event triggered by Chinese character is usually very short (It's triggered when using Pinyin to input several characters), but valid image data is usually long. So use the length to avoid the errors.