### PR TITLE
fix: avante.llm_tools.helpers.is_ignored error

### DIFF
--- a/lua/avante/llm_tools/helpers.lua
+++ b/lua/avante/llm_tools/helpers.lua
@@ -129,9 +129,7 @@ end
 ---@return boolean
 function M.is_ignored(abs_path)
   local project_root = Utils.get_project_root()
-  local exit_code = vim
-    .system({ "git", "-C", vim.fn.shellescape(project_root), "check-ignore", vim.fn.shellescape(abs_path) }, { text = true })
-    :wait().code
+  local exit_code = vim.system({ "git", "-C", project_root, "check-ignore", abs_path }, { text = true }):wait().code
 
   -- If command failed or git is not available or not a git repository, fall back to old method
   if exit_code ~= 0 and exit_code ~= 1 then return old_is_ignored(abs_path) end


### PR DESCRIPTION
vim.fn.shellescape() will reture such as : '~/workspace/avante.nvim', single quotes are redundant.