### PR TITLE
fix: allow specify edit provider

### DIFF
--- a/lua/avante/config.lua
+++ b/lua/avante/config.lua
@@ -39,6 +39,7 @@ M._defaults = {
   -- Of course, you can reduce the request frequency by increasing `suggestion.debounce`.
   auto_suggestions_provider = nil,
   memory_summary_provider = nil,
+  edit_provider = nil,
   ---@alias Tokenizer "tiktoken" | "hf"
   ---@type Tokenizer
   -- Used for counting tokens and encoding text.

--- a/lua/avante/llm.lua
+++ b/lua/avante/llm.lua
@@ -1749,10 +1749,17 @@ function M._stream(opts)
   -- Reset the cancellation flag at the start of a new request
   if LLMToolHelpers then LLMToolHelpers.is_cancelled = false end
 
-  local acp_provider = Config.acp_providers[Config.provider]
-  if acp_provider then return M._stream_acp(opts) end
+  local provider_name = opts.mode == "editing" and Config.edit_provider or Config.provider
+  local acp_provider = Config.acp_providers[provider_name]
+  if acp_provider then
+    if opts.mode == "editing" then
+      Utils.error("Editing is not supported with ACP, specify a separate `edit_provider` in your config")
+      return
+    end
+    return M._stream_acp(opts)
+  end
 
-  local provider = opts.provider or Providers[Config.provider]
+  local provider = opts.provider or Providers[provider_name]
   opts.session_ctx = opts.session_ctx or {}
 
   if not opts.session_ctx.on_messages_add then opts.session_ctx.on_messages_add = opts.on_messages_add end


### PR DESCRIPTION
Allow specifying a provider specifically for `:AvanteEdit`. This is necessary when using an ACP provider because ACP isn't supported in edit mode, and doesn't quite make sense either. Thus, we also explicitly notify the user if they're trying to use edit with an ACP.
