### PR TITLE
fix: Prevent duplicate instruction appending in generate_prompts

### DIFF
--- a/lua/avante/llm.lua
+++ b/lua/avante/llm.lua
@@ -262,11 +262,14 @@ function M.generate_prompts(opts)
   local project_root = Utils.root.get()
   local instruction_file_path = PPath:new(project_root, project_instruction_file)
 
-  if instruction_file_path:exists() then
+  if instruction_file_path:exists() and not opts._instructions_loaded then
     local lines = Utils.read_file_from_buf_or_disk(instruction_file_path:absolute())
     local instruction_content = lines and table.concat(lines, "\n") or ""
 
-    if instruction_content then opts.instructions = (opts.instructions or "") .. "\n" .. instruction_content end
+    if instruction_content then 
+      opts.instructions = (opts.instructions or "") .. "\n" .. instruction_content 
+    end
+    opts._instructions_loaded = true
   end
 
   local mode = opts.mode or Config.mode
@@ -438,8 +441,9 @@ function M.generate_prompts(opts)
     :filter(function(msg) return type(msg.content) ~= "string" or msg.content ~= "" end)
     :totable()
 
-  if opts.instructions ~= nil and opts.instructions ~= "" then
+  if opts.instructions ~= nil and opts.instructions ~= "" and not opts._instructions_added_to_messages then
     messages = vim.list_extend(messages, { { role = "user", content = opts.instructions } })
+    opts._instructions_added_to_messages = true
   end
 
   opts.session_ctx = opts.session_ctx or {}

--- a/tests/llm_spec.lua
+++ b/tests/llm_spec.lua
@@ -151,4 +151,47 @@ describe("generate_prompts", function()
     assert.are.same(#result.tools, 1)
     assert.are.same(result.tools[1].name, "test_tool")
   end)
+
+  it("should not duplicate instruction file content when called multiple times with same opts", function()
+    local opts = {}
+    llm.generate_prompts(opts)
+    local first_instructions = opts.instructions
+    
+    -- Call again with the same opts object
+    llm.generate_prompts(opts)
+    local second_instructions = opts.instructions
+    
+    -- Instructions should be the same, not duplicated
+    assert.are.same(first_instructions, second_instructions)
+    -- Verify that mock content is present (more flexible than hardcoded exact match)
+    assert.truthy(string.find(opts.instructions, "Mock Instructions"))
+  end)
+
+  it("should not duplicate instructions in messages when called multiple times with same opts", function()
+    local opts = {
+      instructions = "Test instructions"
+    }
+    
+    -- First call
+    local result1 = llm.generate_prompts(opts)
+    local instruction_message_count1 = 0
+    for _, msg in ipairs(result1.session_ctx.messages) do
+      if msg.role == "user" and msg.content == "Test instructions" then
+        instruction_message_count1 = instruction_message_count1 + 1
+      end
+    end
+    
+    -- Second call with same opts
+    local result2 = llm.generate_prompts(opts)
+    local instruction_message_count2 = 0
+    for _, msg in ipairs(result2.session_ctx.messages) do
+      if msg.role == "user" and msg.content == "Test instructions" then
+        instruction_message_count2 = instruction_message_count2 + 1
+      end
+    end
+    
+    -- Should have instructions message only once in both calls
+    assert.are.same(1, instruction_message_count1)
+    assert.are.same(1, instruction_message_count2)
+  end)
 end)


### PR DESCRIPTION
The `generate_prompts` function appended instructions multiple times when called repeatedly with the same `opts` object, causing duplicate content in both the instruction string and messages array.

Resolves https://github.com/yetone/avante.nvim/issues/2907

## Changes

- **Instruction file loading** (lines 265-273): Added `opts._instructions_loaded` guard flag to prevent re-reading and re-appending file content. Flag set after file processing regardless of content to avoid redundant I/O.

- **Message array insertion** (lines 444-447): Added `opts._instructions_added_to_messages` guard flag to prevent duplicate instruction messages.

## Example

```lua
local opts = { instructions = "Initial" }

-- Without guards (old behavior):
generate_prompts(opts)  -- instructions: "Initial\nFile content"
generate_prompts(opts)  -- instructions: "Initial\nFile content\nFile content" ❌

-- With guards (new behavior):
generate_prompts(opts)  -- instructions: "Initial\nFile content"
generate_prompts(opts)  -- instructions: "Initial\nFile content" ✓
```

## Tests

Added two test cases validating no duplication occurs across multiple `generate_prompts` calls with the same `opts` object.

<!-- START COPILOT ORIGINAL PROMPT -->

Copilot PR from my fork: https://github.com/ccope/avante.nvim/pull/1

<details>

<summary>Original prompt</summary>

> ## Problem
> 
> The `generate_prompts` function in `lua/avante/llm.lua` has two issues where instructions can be appended multiple times if the function is called repeatedly with the same `opts` object:
> 
> 1. **Lines 265-270**: Instructions from the project instruction file are appended to `opts.instructions` without checking if they've already been added
> 2. **Lines 441-443**: The instructions are added to the messages array without checking if they've already been added
> 
> This causes duplicate content when `generate_prompts` is called multiple times with the same options.
> 
> ## Solution
> 
> Add guard flags to prevent duplicate appending:
> 
> 1. Add `opts._instructions_loaded` flag to track if the instruction file content has been loaded
> 2. Add `opts._instructions_added_to_messages` flag to track if instructions have been added to the messages array
> 
> ## Changes Required
> 
> In `lua/avante/llm.lua`, modify the `M.generate_prompts` function:
> 
> **Around line 265-270**, change:
> ```lua
> if instruction_file_path:exists() then
>   local lines = Utils.read_file_from_buf_or_disk(instruction_file_path:absolute())
>   local instruction_content = lines and table.concat(lines, "\n") or ""
> 
>   if instruction_content then opts.instructions = (opts.instructions or "") .. "\n" .. instruction_content end
> end
> ```
> 
> To:
> ```lua
> if instruction_file_path:exists() and not opts._instructions_loaded then
>   local lines = Utils.read_file_from_buf_or_disk(instruction_file_path:absolute())
>   local instruction_content = lines and table.concat(lines, "\n") or ""
> 
>   if instruction_content then 
>     opts.instructions = (opts.instructions or "") .. "\n" .. instruction_content 
>     opts._instructions_loaded = true
>   end
> end
> ```
> 
> **Around line 441-443**, change:
> ```lua
> if opts.instructions ~= nil and opts.instructions ~= "" then
>   messages = vim.list_extend(messages, { { role = "user", content = opts.instructions } })
> end
> ```
> 
> To:
> ```lua
> if opts.instructions ~= nil and opts.instructions ~= "" and not opts._instructions_added_to_messages then
>   messages = vim.list_extend(messages, { { role = "user", content = opts.instructions } })
>   opts._instructions_added_to_messages = true
> end
> ```
> 
> ## Expected Outcome
> 
> After these changes, the `generate_prompts` function can be safely called multiple times with the same `opts` object without duplicating instruction content.
> 


</details>



<!-- START COPILOT CODING AGENT SUFFIX -->

*This pull request was created from Copilot chat.*
>