### PR TITLE
fix: Adjust unset operation for api key name to after check for type

### DIFF
--- a/lua/avante/providers/claude.lua
+++ b/lua/avante/providers/claude.lua
@@ -31,7 +31,7 @@ local claude_code_spoof_prompt = "You are Claude Code, Anthropic's official CLI 
 ---@field claude_token ClaudeAuthToken?
 M.state = nil
 
-M.api_key_name = ""
+M.api_key_name = "ANTHROPIC_API_KEY"
 M.support_prompt_caching = true
 
 M.tokenizer_id = "gpt-4o"
@@ -150,12 +150,12 @@ function M.setup()
   local auth_type = P[Config.provider].auth_type
 
   if auth_type == "api" then
-    M.api_key_name = "ANTRHOPIC_API_KEY"
     require("avante.tokenizers").setup(M.tokenizer_id)
-    vim.g.avante_login = true
     M._is_setup = true
     return
   end
+
+  M.api_key_name = ""
 
   if not M.state then M.state = {
     claude_token = nil,


### PR DESCRIPTION
Fixes issue where api_key_name wasn't set for claude as it needed to be unset for the max subscription auth. Closes #2918, #2921

## Testing
Ran a query with an api key and the max auth key and got back the expected erorrs (my API account has no balance, but the correct key was used)
<img width="3840" height="2400" alt="image" src="https://github.com/user-attachments/assets/35dee611-7052-4e32-b5f6-a5b23b391b59" />
