### PR TITLE
fix(claude): correct typo in ANTHROPIC_API_KEY environment variable name

### DIFF
--- a/lua/avante/providers/claude.lua
+++ b/lua/avante/providers/claude.lua
@@ -150,7 +150,7 @@ function M.setup()
   local auth_type = P[Config.provider].auth_type
 
   if auth_type == "api" then
-    M.api_key_name = "ANTRHOPIC_API_KEY"
+    M.api_key_name = "ANTHROPIC_API_KEY"
     require("avante.tokenizers").setup(M.tokenizer_id)
     vim.g.avante_login = true
     M._is_setup = true


### PR DESCRIPTION
Quick fix for a typo in the Claude provider where the environment variable name was misspelled as `ANTRHOPIC_API_KEY` instead of `ANTHROPIC_API_KEY` (reordering the 'H')

For anyone finding this before it's merged: you can also work around the issue by explicitly stating the API key name:
```
...
    providers = {
      claude = {
        endpoint = "https://api.anthropic.com",
        api_key_name = "ANTHROPIC_API_KEY",
        model = "claude-opus-4-5-20251101",
        timeout = 30000, -- Timeout in milliseconds
        extra_request_body = {
          temperature = 0.75,
          max_tokens = 20480,
        },
      },
```