### PR TITLE
Add client info into avante for allow ACP whitelist in auggie

### DIFF
--- a/lua/avante/libs/acp_client.lua
+++ b/lua/avante/libs/acp_client.lua
@@ -230,7 +230,6 @@ ACPClient.ERROR_CODES = {
 ---@field max_reconnect_attempts? number Maximum reconnection attempts
 ---@field heartbeat_interval? number Heartbeat interval in milliseconds
 ---@field auth_method? string Authentication method
----@field client_info? avante.acp.ClientInfo Client information (name and version)
 ---@field handlers? ACPHandlers
 ---@field on_state_change? fun(new_state: ACPConnectionState, old_state: ACPConnectionState)
 
@@ -242,7 +241,7 @@ function ACPClient:new(config)
   local client = setmetatable({
     id_counter = 0,
     protocol_version = 1,
-    client_info = config.client_info or {
+    client_info = {
       name = "avante.nvim",
       version = "0.0.1",
     },


### PR DESCRIPTION
## Summary

Add client identification (`clientInfo`) to the ACP (Agent Communication Protocol) initialize request to enable proper client whitelisting by ACP agents.

## Problem

When Avante connects to ACP agents like `auggie`, the agent needs to identify and whitelist the connecting client. Currently, Avante only sends `protocolVersion` and `clientCapabilities` during the ACP initialization handshake, but is missing the `clientInfo` field that contains the client's name and version.

This causes issues with ACP agents that require client identification for whitelisting purposes. For example, auggie logs show it expects a user-agent string:

```
'ACPSessionManager': Using session user-agent: augment.cli/0.15.0-prerelease.4 (commit 7a31a643)/acp
```

Without `clientInfo`, ACP agents cannot properly identify Avante clients, potentially blocking or limiting functionality.

## Solution

This PR adds `clientInfo` support to the ACP client implementation with sensible defaults.

### Changes Made

1. **Added `ClientInfo` type definition** with `name` and `version` fields
2. **Updated `ACPClient` class** to include `client_info` field
3. **Updated `ACPClient:new()`** to initialize `client_info` with defaults:
   - Default name: `"avante.nvim"`
   - Default version: `"0.0.1"`
4. **Modified `initialize` request** to include `clientInfo` in the parameters sent to ACP agents
5. **Fixed nil-safety** for the `config` parameter in `ACPClient:new()`

### ACP Initialize Request (Before)

```json
{
  "jsonrpc": "2.0",
  "id": 1,
  "method": "initialize",
  "params": {
    "protocolVersion": 1,
    "clientCapabilities": {
      "fs": {
        "readTextFile": true,
        "writeTextFile": true
      }
    }
  }
}
```

### ACP Initialize Request (After)

```json
{
  "jsonrpc": "2.0",
  "id": 1,
  "method": "initialize",
  "params": {
    "protocolVersion": 1,
    "clientInfo": {
      "name": "avante.nvim",
      "version": "0.0.1"
    },
    "clientCapabilities": {
      "fs": {
        "readTextFile": true,
        "writeTextFile": true
      }
    }
  }
}
```

## Testing

Tested with auggie ACP client to verify:
- ✅ `clientInfo` is properly sent in the initialize request
- ✅ ACP agents can identify and whitelist Avante clients
- ✅ Default values work correctly
- ✅ Nil-safety for config parameter works as expected

Used local config to test this out
```
  {
    dir = "/Users/justinxu/avante.nvim",
    name = "avante.nvim",
    event = "VeryLazy",
    lazy = false,
    version = false,
    opts = {
      -- add any opts here
    },
    build = "make",
    dependencies = {
      "nvim-treesitter/nvim-treesitter",
      "stevearc/dressing.nvim",
      "nvim-lua/plenary.nvim",
      "MunifTanjim/nui.nvim",
      "nvim-tree/nvim-web-devicons",
    },
  },

```

Before:
<img width="441" height="631" alt="image" src="https://github.com/user-attachments/assets/1450b24d-dcf1-445f-b98e-ac1374708d40" />

After:
<img width="449" height="549" alt="image" src="https://github.com/user-attachments/assets/393de054-76df-4379-af81-72ef8f0da9f4" />


## Impact

This change enables Avante to work properly with ACP agents that require client identification for whitelisting, such as auggie and other ACP-compliant agents. It follows the ACP protocol specification (similar to LSP) which requires clients to identify themselves during initialization.

## Related

- Fixes issues with auggie ACP client whitelisting
- Aligns with ACP protocol specification for client identification