### PR TITLE
Improve environment variable handling for ACP agents

### DIFF
--- a/README.md
+++ b/README.md
@@ -1267,6 +1267,13 @@ ACP providers are configured in the `acp_providers` section of your configuratio
 }
 ```
 
+### Environment Variables Handling
+
+When spawning an ACP agent, `avante.nvim` handles environment variables as follows:
+
+1.  **Inheritance**: The agent inherits all environment variables from the current Neovim process.
+2.  **Overrides**: Environment variables defined in the `env` table of the ACP provider configuration will override inherited values. Setting a variable to `vim.NIL` will remove it from the environment.
+
 ### Prerequisites
 
 Before using ACP agents, ensure you have the required tools installed:

--- a/tests/libs/acp_client_env_spec.lua
+++ b/tests/libs/acp_client_env_spec.lua
@@ -1,0 +1,174 @@
+local ACPClient = require("avante.libs.acp_client")
+local stub = require("luassert.stub")
+
+describe("ACPClient Environment Handling", function()
+  local schedule_stub
+  local environ_stub
+  local spawn_stub
+  local uv = vim.uv or vim.loop
+
+  before_each(function()
+    schedule_stub = stub(vim, "schedule")
+    schedule_stub.invokes(function(fn) fn() end)
+
+    environ_stub = stub(vim.fn, "environ")
+    spawn_stub = stub(uv, "spawn")
+  end)
+
+  after_each(function()
+    schedule_stub:revert()
+    environ_stub:revert()
+    spawn_stub:revert()
+  end)
+
+  it("should inherit all environment variables when no overrides are provided", function()
+    -- Mock environment
+    environ_stub.returns({
+      USER = "testuser",
+      HOME = "/home/testuser",
+      PATH = "/usr/bin:/bin"
+    })
+
+    -- Mock successful spawn
+    spawn_stub.returns({}, 1234)
+
+    local config = {
+      transport_type = "stdio",
+      command = "test-agent",
+      args = {},
+      env = nil -- No overrides
+    }
+
+    local client = ACPClient:new(config)
+    client:connect(function() end)
+
+    assert.stub(spawn_stub).was_called(1)
+    local call_args = spawn_stub.calls[1].refs
+    local options = call_args[2]
+    local env_list = options.env
+
+    -- Verify env list contains all inherited variables
+    local env_map = {}
+    for _, item in ipairs(env_list) do
+      local k, v = item:match("([^=]+)=(.*)")
+      env_map[k] = v
+    end
+
+    assert.equals("testuser", env_map["USER"])
+    assert.equals("/home/testuser", env_map["HOME"])
+    assert.equals("/usr/bin:/bin", env_map["PATH"])
+  end)
+
+  it("should override existing environment variables", function()
+    -- Mock environment
+    environ_stub.returns({
+      USER = "testuser",
+      HOME = "/home/testuser",
+      PATH = "/usr/bin:/bin"
+    })
+
+    -- Mock successful spawn
+    spawn_stub.returns({}, 1234)
+
+    local config = {
+      transport_type = "stdio",
+      command = "test-agent",
+      args = {},
+      env = {
+        HOME = "/home/override"
+      }
+    }
+
+    local client = ACPClient:new(config)
+    client:connect(function() end)
+
+    assert.stub(spawn_stub).was_called(1)
+    local call_args = spawn_stub.calls[1].refs
+    local options = call_args[2]
+    local env_list = options.env
+
+    local env_map = {}
+    for _, item in ipairs(env_list) do
+      local k, v = item:match("([^=]+)=(.*)")
+      env_map[k] = v
+    end
+
+    assert.equals("testuser", env_map["USER"]) -- Inherited
+    assert.equals("/home/override", env_map["HOME"]) -- Overridden
+    assert.equals("/usr/bin:/bin", env_map["PATH"]) -- Inherited
+  end)
+
+  it("should add new environment variables", function()
+    -- Mock environment
+    environ_stub.returns({
+      USER = "testuser",
+    })
+
+    -- Mock successful spawn
+    spawn_stub.returns({}, 1234)
+
+    local config = {
+      transport_type = "stdio",
+      command = "test-agent",
+      args = {},
+      env = {
+        NEW_VAR = "new_value"
+      }
+    }
+
+    local client = ACPClient:new(config)
+    client:connect(function() end)
+
+    assert.stub(spawn_stub).was_called(1)
+    local call_args = spawn_stub.calls[1].refs
+    local options = call_args[2]
+    local env_list = options.env
+
+    local env_map = {}
+    for _, item in ipairs(env_list) do
+      local k, v = item:match("([^=]+)=(.*)")
+      env_map[k] = v
+    end
+
+    assert.equals("testuser", env_map["USER"])
+    assert.equals("new_value", env_map["NEW_VAR"])
+  end)
+
+  it("should delete inherited environment variables when overridden with nil", function()
+    -- Mock environment
+    environ_stub.returns({
+      USER = "testuser",
+      HOME = "/home/testuser",
+      TO_BE_REMOVED = "remove_me"
+    })
+
+    -- Mock successful spawn
+    spawn_stub.returns({}, 1234)
+
+    local config = {
+      transport_type = "stdio",
+      command = "test-agent",
+      args = {},
+      env = {
+        TO_BE_REMOVED = vim.NIL
+      }
+    }
+
+    local client = ACPClient:new(config)
+    client:connect(function() end)
+
+    assert.stub(spawn_stub).was_called(1)
+    local call_args = spawn_stub.calls[1].refs
+    local options = call_args[2]
+    local env_list = options.env
+
+    local env_map = {}
+    for _, item in ipairs(env_list) do
+      local k, v = item:match("([^=]+)=(.*)")
+      env_map[k] = v
+    end
+
+    assert.equals("testuser", env_map["USER"])
+    assert.is_nil(env_map["TO_BE_REMOVED"])
+  end)
+end)


### PR DESCRIPTION
* Pass through all environment variables by default
* Allow environment variables to be overridden or entirely removed

This fixes the default behavior when using gemini-cli in ACP mode when using the oauth-personal authentication mode.  Without this fix, the ACP session silently fails on startup.  I found that gemini-cli requires the `HOME` environment variable to be set, but the current behavior of avante is to strip away all environment variables except `PATH`.

I couldn't find any documented justification for the current behavior.  Given that people typically run gemini-cli without scrubbing away their environment variables, I couldn't see a real security argument for stripping the environment down either.