### PR TITLE
feat: add logging to file

### DIFF
--- a/lua/avante/config.lua
+++ b/lua/avante/config.lua
@@ -28,6 +28,7 @@ M.instructions_file = "avante.md"
 ---@class avante.Config
 M._defaults = {
   debug = false,
+  log_level = vim.log.levels.WARN,
   ---@alias avante.Mode "agentic" | "legacy"
   ---@type avante.Mode
   mode = "agentic",
@@ -1080,6 +1081,10 @@ function M.setup(opts)
   for k, v in pairs(M._options.providers) do
     M._options.providers[k] = type(v) == "function" and v() or v
   end
+
+  vim.g.avante = {
+    log_level = merged.log_level,
+  }
 end
 
 ---@param opts table<string, any>

--- a/lua/avante/init.lua
+++ b/lua/avante/init.lua
@@ -508,6 +508,7 @@ function M.setup(opts)
   ---PERF: we can still allow running require("avante").setup() multiple times to override config if users wish to
   ---but most of the other functionality will only be called once from lazy.nvim
   Config.setup(opts)
+  require("avante.utils.log").set_level(vim.g.avante.log_level)
 
   if M.did_setup then return end
 

--- a/lua/avante/utils/init.lua
+++ b/lua/avante/utils/init.lua
@@ -2,6 +2,7 @@ local api = vim.api
 local fn = vim.fn
 local lsp = vim.lsp
 
+local log = require("avante.utils.log")
 local LRUCache = require("avante.utils.lru_cache")
 local diff2search_replace = require("avante.utils.diff2search_replace")
 
@@ -420,6 +421,7 @@ end
 function M.error(msg, opts)
   opts = opts or {}
   opts.level = vim.log.levels.ERROR
+  log.error(msg)
   M.notify(msg, opts)
 end
 
@@ -428,6 +430,7 @@ end
 function M.info(msg, opts)
   opts = opts or {}
   opts.level = vim.log.levels.INFO
+  log.info(msg)
   M.notify(msg, opts)
 end
 
@@ -436,12 +439,11 @@ end
 function M.warn(msg, opts)
   opts = opts or {}
   opts.level = vim.log.levels.WARN
+  log.warn(msg)
   M.notify(msg, opts)
 end
 
 function M.debug(...)
-  if not require("avante.config").debug then return end
-
   local args = { ... }
   if #args == 0 then return end
 
@@ -462,6 +464,10 @@ function M.debug(...)
       table.insert(formated_args, vim.inspect(arg))
     end
   end
+
+  log.debug(formated_args)
+  -- print only on debug (todo: spellfix format(t)ed_args)
+  if not require("avante.config").debug then return end
   print(unpack(formated_args))
 end
 

--- a/lua/avante/utils/log.lua
+++ b/lua/avante/utils/log.lua
@@ -1,0 +1,111 @@
+local log = {}
+
+-- NOTE: These functions are initialised as empty for type checking purposes
+-- and implemented later.
+
+-- ---@type fun(any)
+-- function log.trace(_) end
+-- ---@type fun(any)
+-- function log.debug(_) end
+-- ---@type fun(any)
+-- function log.info(_) end
+-- ---@type fun(any)
+-- function log.warn(_) end
+-- ---@type fun(any)
+-- function log.error(_) end
+
+local LARGE = 1e9
+
+local log_date_format = "%F %H:%M:%S"
+
+local function format_log(arg) return vim.inspect(arg) end
+
+---Get the avante.nvim log file path.
+---@package
+---@return string filepath
+function log.get_logfile() return vim.fs.joinpath(vim.fn.stdpath("cache"), "avante.log") end
+
+---Open the avante.nvim log file.
+---@package
+function log.open_logfile() vim.cmd.e(log.get_logfile()) end
+
+local logfile, openerr
+---@private
+---Opens log file. Returns true if file is open, false on error
+---@return boolean
+local function open_logfile()
+  -- Try to open file only once
+  if logfile then return true end
+  if openerr then return false end
+
+  logfile, openerr = io.open(log.get_logfile(), "w+")
+  if not logfile then
+    local err_msg = string.format("Failed to open avante.nvim log file: %s", openerr)
+    vim.notify(err_msg, vim.log.levels.ERROR)
+    return false
+  end
+
+  local log_info = vim.uv.fs_stat(log.get_logfile())
+  if log_info and log_info.size > LARGE then
+    local warn_msg =
+      string.format("avante.nvim log is large (%d MB): %s", log_info.size / (1000 * 1000), log.get_logfile())
+    vim.notify(warn_msg, vim.log.levels.WARN)
+  end
+
+  -- Start message for logging
+  logfile:write(string.format("[START][%s] avante.nvim logging initiated\n", os.date(log_date_format)))
+  return true
+end
+
+local log_levels = vim.deepcopy(vim.log.levels)
+for levelstr, levelnr in pairs(log_levels) do
+  log_levels[levelnr] = levelstr
+end
+
+---Set the log level
+---@param level (string|integer) The log level
+---@see vim.log.levels
+---@usage `log.set_level(vim.log.levels.DEBUG)`
+function log.set_level(level)
+  if type(level) == "string" then
+    log.level = assert(log_levels[string.upper(level)], string.format("avante.nvim: Invalid log level: %q", level))
+  else
+    assert(log_levels[level], string.format("avante.nvim: Invalid log level: %d", level))
+    log.level = level
+  end
+end
+
+for level, levelnr in pairs(vim.log.levels) do
+  log[level:lower()] = function(...)
+    if log.level == vim.log.levels.OFF or not open_logfile() then return false end
+    local argc = select("#", ...)
+    if levelnr < log.level then return false end
+    if argc == 0 then return true end
+    local info = debug.getinfo(2, "Sl")
+    local fileinfo = string.format("%s:%s", info.short_src, info.currentline)
+    local _, millis = vim.uv.gettimeofday()
+    local parts = {
+      table.concat(
+        { level, "|", os.date(log_date_format) .. "." .. tostring(millis):sub(1, 3), "|", fileinfo, "|" },
+        " "
+      ),
+    }
+    for i = 1, argc do
+      local arg = select(i, ...)
+      if arg == nil then
+        table.insert(parts, "<nil>")
+      elseif type(arg) == "string" then
+        table.insert(parts, arg)
+      else
+        table.insert(parts, format_log(arg))
+      end
+    end
+    logfile:write(table.concat(parts, " "), "\n")
+    logfile:flush()
+  end
+end
+
+--- NOTE: We can't use rocks.config here, as that would lead to a cyclic module dependency
+log.set_level(vim.tbl_get(vim.g, "avante", "log_level") or vim.log.levels.WARN)
+
+return log


### PR DESCRIPTION
avante is a complex program, especially as lua doesn't enforce strong typing. As I work on it, I find myself adding log statements to understand what's going on. 
The current backend for logs is not practical as it's intrusive, generates a popup everytime, and it doesn't distinguish between userfacing and dev-related logs, as error/warn just rely on vim.notify.

This introduces a cheap logger as I cant find any I am really confident with on luarocks.org and I dont want to add a dependency I am not confident about.