### PR TITLE
feat: Add kiro as known ACP provider (#2953)

### DIFF
--- a/README.md
+++ b/README.md
@@ -1227,6 +1227,14 @@ To use ACP-compatible agents with Avante.nvim, you need to configure an ACP prov
 }
 ```
 
+#### Kiro CLI with ACP
+```lua
+{
+  provider = "kiro-cli",
+  -- other configuration options...
+}
+```
+
 ### ACP Configuration
 
 ACP providers are configured in the `acp_providers` section of your configuration:

--- a/lua/avante/config.lua
+++ b/lua/avante/config.lua
@@ -287,6 +287,10 @@ M._defaults = {
       command = "kimi",
       args = { "--acp" },
     },
+    ["kiro-cli"] = {
+      command = "kiro-cli",
+      args = { "acp" },
+    },
   },
   ---To add support for custom provider, follow the format below
   ---See https://github.com/yetone/avante.nvim/wiki#custom-providers for more details


### PR DESCRIPTION
Adding kiro-cli as a known ACP provider.  
Most features will work out of the box, though kiro does implement some custom notifications that Avante doesn't handle yet.