### PR TITLE
fix: correctly merge acp_providers in SwitchProvider (#2958)

### DIFF
--- a/plugin/avante.lua
+++ b/plugin/avante.lua
@@ -125,7 +125,8 @@ cmd("Refresh", function() require("avante.api").refresh() end, { desc = "avante:
 cmd("Focus", function() require("avante.api").focus() end, { desc = "avante: switch focus windows" })
 cmd("SwitchProvider", function(_opts)
   local providers = vim.tbl_keys(Config.providers)
-  vim.tbl_extend("force", providers, Config.acp_providers)
+  local acp_providers = vim.tbl_keys(Config.acp_providers)
+  vim.list_extend(providers, acp_providers)
   vim.ui.select(providers, { prompt = "Provider> " }, function(choice, idx)
     if idx ~= nil then require("avante.api").switch_provider(vim.trim(choice)) end
   end)


### PR DESCRIPTION
This commit resolves two issues in the AvanteSwitchProvider command that prevented the ACP providers from appearing in the switch provider menu.

- The `vim.tbl_extend` function does not modify the table in place, but instead returns a new table. The previous implementation did not assign the result, so the providers list was not updated.
- The selection list should be built from the keys of the merged `acp_providers`, rather than from the original `acp_providers` table.

Fixes #2958