### PR TITLE
fix: remove unconditional last line removal in user request block parsing

### DIFF
--- a/lua/avante/sidebar.lua
+++ b/lua/avante/sidebar.lua
@@ -752,7 +752,6 @@ function Sidebar:get_current_user_request_block(position)
     end
   end
   if start_line == nil then return nil end
-  content_lines = vim.list_slice(content_lines, 1, #content_lines - 1)
   local content = table.concat(content_lines, "\n")
   return {
     start_line = current_resp_start_line + start_line - 1,


### PR DESCRIPTION
The pattern ^>\s+(.+)$ already filters out empty lines by requiring at least one character after the prefix. Unconditionally removing the last collected line assumed a trailing empty line always exists, which breaks retry functionality when the content structure differs.

Removing this line makes the parser robust across all scenarios without making assumptions about trailing formatting artifacts.