### PR TITLE
fix: always update Config.provider on provider switch (#2956)

### DIFF
--- a/lua/avante/providers/init.lua
+++ b/lua/avante/providers/init.lua
@@ -229,15 +229,14 @@ end
 ---@param provider_name avante.ProviderName
 function M.refresh(provider_name)
   require("avante.config").override({ provider = provider_name })
+  Config.provider = provider_name
 
-  if Config.acp_providers[provider_name] then
-    Config.provider = provider_name
-  else
+  if not Config.acp_providers[provider_name] then
     ---@type AvanteProviderFunctor | AvanteBedrockProviderFunctor
     local p = M[Config.provider]
     E.setup({ provider = p, refresh = true })
   end
-  Utils.info("Switch to provider: " .. provider_name, { once = true, title = "Avante" })
+  Utils.info("Switch to provider: " .. provider_name, { title = "Avante" })
 end
 
 ---@param opts AvanteProvider | AvanteSupportedProvider | AvanteAnthropicProvider | AvanteProviderFunctor | AvanteBedrockProviderFunctor


### PR DESCRIPTION
Ensure Config.provider is updated on every provider switch, regardless of provider type. This prevents stale direct property values from shadowing the metatable, which previously caused `:AvanteSwitchProvider` to fail after toggling between ACP and built-in providers multiple times.

This commit also removes `once = true` from `Utils.info` calls to ensure the switch message is always displayed, even when switching to the same provider multiple times. This prevents user confusion when switching providers repeatedly, as the message would otherwise be suppressed if already shown.

Fixes #2956 