### PR TITLE
fix(config): match versioned gpt codex models

### DIFF
--- a/lua/avante/config.lua
+++ b/lua/avante/config.lua
@@ -8,7 +8,7 @@ local Utils = require("avante.utils")
 
 local function copilot_use_response_api(opts)
   local model = opts and opts.model
-  return type(model) == "string" and model:match("gpt%-5%-codex") ~= nil
+  return type(model) == "string" and model:match("gpt%-%d+%.?%d*%-codex") ~= nil
 end
 
 ---@class avante.file_selector.IParams


### PR DESCRIPTION
Copilot_use_response_api() previously only recognized the exact model id "gpt-5-codex". New Codex model ids like gpt-5.1-codex / gpt-5.2-codex / gpt-5.3-codex (and future versioned variants) would fail the check and be routed as non-Codex, causing the wrong API path to be selected. Fix by widening the pattern to accept gpt-<major>[.<minor>]-codex.