### PR TITLE
fix: improve item action prompt and UI flow for Avante History

### DIFF
--- a/lua/avante/ui/selector/providers/native.lua
+++ b/lua/avante/ui/selector/providers/native.lua
@@ -21,31 +21,22 @@ function M.show(selector)
 
     -- If on_delete_item callback is provided, prompt for action
     if type(selector.on_delete_item) == "function" then
-      vim.ui.input(
-        { prompt = "Action for '" .. item.title .. "': (o)pen, (d)elete, (c)ancel?", default = "" },
-        function(input)
-          if not input then -- User cancelled input
-            selector.on_select(nil) -- Treat as cancellation of selection
-            return
-          end
-          local choice = input:lower()
-          if choice == "d" or choice == "delete" then
-            selector.on_delete_item(item.id)
-            -- The native provider handles the UI flow; we just need to refresh.
-            selector.on_open() -- Re-open the selector to refresh the list
-          elseif choice == "" or choice == "o" or choice == "open" then
-            selector.on_select({ item.id })
-          elseif choice == "c" or choice == "cancel" then
-            if type(selector.on_open) == "function" then
-              selector.on_open()
-            else
-              selector.on_select(nil) -- Fallback if on_open is not defined
-            end
-          else -- c or any other input, treat as cancel
-            selector.on_select(nil) -- Fallback if on_open is not defined
-          end
+      vim.ui.select({ "Open", "Delete", "Cancel" }, {
+        prompt = "Action for '" .. item.title .. "':",
+      }, function(choice)
+        if choice == "Open" then
+          selector.on_select({ item.id })
+          return
+        elseif choice == "Delete" then
+          selector.on_delete_item(item.id)
         end
-      )
+
+        if type(selector.on_open) == "function" then
+          selector.on_open() -- Re-open the selector to refresh the list
+        else
+          selector.on_select(nil) -- Fallback if on_open is not defined
+        end
+      end)
     else
       -- Default behavior: directly select the item
       selector.on_select({ item.id })


### PR DESCRIPTION
When selecting an action for an item in Avante History, the prompt is often truncated due to its length.
As a result, the available options — (o)pen, (d)elete, and (c)ancel — which appear at the end of the prompt, are not visible to the user.

<img width="1002" height="110" alt="image" src="https://github.com/user-attachments/assets/597e37f2-1618-45b2-9fae-ec94776fba4d" />


This commit switched from a text input prompt to a select menu for item actions in the native selector provider. This change enhances usability by providing clear options for "Open", "Delete", and "Cancel", reducing ambiguity and user error.

<img width="1642" height="256" alt="image" src="https://github.com/user-attachments/assets/e4a7253f-3d7d-4a4b-b3fe-4af5fc4dd0c9" />
