### PR TITLE
ci: add job to release to luarocks.org

### DIFF
--- a/.github/workflows/luarocks.yml
+++ b/.github/workflows/luarocks.yml
@@ -1,0 +1,38 @@
+name: Push to luarocks.org
+
+on:
+  push:
+    tags:
+      - '*'
+  release:
+    types:
+      - created
+  pull_request:
+  workflow_dispatch:
+
+jobs:
+  luarocks-upload:
+    runs-on: ubuntu-24.04
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0 # Required to count the commits
+      - name: Get Version
+        run: echo "LUAROCKS_VERSION=$(git describe --abbrev=0 --tags)" >> $GITHUB_ENV
+      - name: LuaRocks Upload
+        uses: nvim-neorocks/luarocks-tag-release@v7
+        env:
+          LUAROCKS_API_KEY: ${{ secrets.LUAROCKS_API_KEY }}
+        with:
+          version: ${{ env.LUAROCKS_VERSION }}
+          dependencies: |
+            lua == 5.1
+            luarocks >= 3.11.1, < 4.0.0
+            plenary.nvim
+            nui.nvim
+          labels: |
+            neovim
+            ai
+            llm
+          detailed_description: |
+            **avante.nvim** is a Neovim plugin designed to emulate the behaviour of the [Cursor](https://www.cursor.com) AI IDE. It provides users with AI-driven code suggestions and the ability to apply these recommendations directly to their source files with minimal effort.

--- a/README.md
+++ b/README.md
@@ -233,6 +233,18 @@ For building binary if you wish to build from source, then `cargo` is required. 
 
 <details>
 
+  <summary><a href="https://github.com/lumen-oss/rocks.nvim">rocks.nvim</a></summary>
+
+Run `:Rocks install avante.nvim` then add to your init.lua:
+
+```lua
+require('avante').setup()
+```
+
+</details>
+
+<details>
+
   <summary>vim-plug</summary>
 
 ```vim


### PR DESCRIPTION
The current upload version https://luarocks.org/modules/neorocks/avante.nvim
is from a third party https://github.com/lumen-oss/nurr that I help with.

Avante is a big enough project that it should be in control of its luarocks release IMO.

I've taken the liberty to mention how to install avante with rocks.nvim.

For the release workflow to work, someone with a Luarocks account will have to add their API key to this repo's secrets.

![](https://user-images.githubusercontent.com/12857160/211071297-afb129be-7a8f-4662-b282-9d52bb0286de.png)


NB: this is a new submission of https://github.com/yetone/avante.nvim/pull/2946 . While I can understand autoclosing issues, I find autoclosing PRs which usually are higher effort contributions than tickets really hostile. Especially after 15 days.