### PR TITLE
fix: Check if provider is in acp_providers to avoid nil

### DIFF
--- a/lua/avante/sidebar.lua
+++ b/lua/avante/sidebar.lua
@@ -1003,7 +1003,17 @@ function Sidebar:render_header(winid, bufnr, header_text, hl, reverse_hl, opts)
 
   local model_name = nil
   if opts.include_model and Config.windows.sidebar_header.include_model then
-    model_name = Config.provider .. " | " .. Config.providers[Config.provider].model
+    local provider_name = Config.provider
+    if Config.acp_providers[provider_name] then
+      model_name = provider_name
+    else
+      local provider_config = Config.providers[provider_name]
+      if provider_config and provider_config.model then
+        model_name = provider_name .. " | " .. provider_config.model
+      else
+        model_name = provider_name
+      end
+    end
   end
 
   if Config.windows.sidebar_header.rounded then


### PR DESCRIPTION
ACP provider configs don't have the same fields as non-ACP ones, so the provider field and model was nil, but this PR should guard against that. Fixes #2995 

Before: 
<img width="2543" height="1336" alt="before_fix_toggle_call" src="https://github.com/user-attachments/assets/9ef0ff4c-01da-486f-b959-02eb13269e5d" />

After:
<img width="2547" height="1347" alt="after_fix_toggle_call" src="https://github.com/user-attachments/assets/f2b8c961-6806-4c4c-aabf-b901a19387c1" />

