### PR TITLE
fix: kimi acp doesn't work any more

### DIFF
--- a/lua/avante/config.lua
+++ b/lua/avante/config.lua
@@ -285,7 +285,7 @@ M._defaults = {
     },
     ["kimi-cli"] = {
       command = "kimi",
-      args = { "--acp" },
+      args = { "acp" },
     },
   },
   ---To add support for custom provider, follow the format below


### PR DESCRIPTION
fix https://github.com/yetone/avante.nvim/issues/3002. 
<img width="1322" height="443" alt="image" src="https://github.com/user-attachments/assets/f258c538-42b0-4b7d-80e4-34d2580bf31b" />


new kimi versions has deprecated "kimi --acp" and will use "kimi acp"