### PR TITLE
fix: cannot switch to/back from ACP provider

### DIFF
--- a/lua/avante/providers/init.lua
+++ b/lua/avante/providers/init.lua
@@ -230,9 +230,8 @@ end
 function M.refresh(provider_name)
   require("avante.config").override({ provider = provider_name })
 
-  if Config.acp_providers[provider_name] then
-    Config.provider = provider_name
-  else
+  Config.provider = provider_name
+  if Config.acp_providers[provider_name] == nil then
     ---@type AvanteProviderFunctor | AvanteBedrockProviderFunctor
     local p = M[Config.provider]
     E.setup({ provider = p, refresh = true })

--- a/plugin/avante.lua
+++ b/plugin/avante.lua
@@ -125,7 +125,7 @@ cmd("Refresh", function() require("avante.api").refresh() end, { desc = "avante:
 cmd("Focus", function() require("avante.api").focus() end, { desc = "avante: switch focus windows" })
 cmd("SwitchProvider", function(_opts)
   local providers = vim.tbl_keys(Config.providers)
-  vim.tbl_extend("force", providers, Config.acp_providers)
+  vim.list_extend(providers, vim.tbl_keys(Config.acp_providers))
   vim.ui.select(providers, { prompt = "Provider> " }, function(choice, idx)
     if idx ~= nil then require("avante.api").switch_provider(vim.trim(choice)) end
   end)


### PR DESCRIPTION
This fixes two issues of `AvanteSwitchProvider`,

1. ACP providers are listed but cannot be switched.
2. Cannot switch back to non-ACP provider if current one is ACP.