### PR TITLE
fix: avoid "Content is not an image" warning with CJK IME input

### DIFF
--- a/plugin/avante.lua
+++ b/plugin/avante.lua
@@ -24,7 +24,10 @@ if Config.support_paste_image() then
     ---@param lines string[]
     ---@param phase -1|1|2|3
     return function(lines, phase)
-      require("img-clip.util").verbose = false
+      -- NOTE: require("img-clip.util").verbose = false does NOT silence warnings
+      -- because img-clip's warn() reads config.get_opt("verbose"), not util.verbose.
+      -- Suppress via api_opts which has highest priority in img-clip's config lookup.
+      require("img-clip.config").api_opts = { default = { verbose = false } }
 
       local bufnr = vim.api.nvim_get_current_buf()
       local filetype = vim.api.nvim_get_option_value("filetype", { buf = bufnr })
@@ -32,6 +35,16 @@ if Config.support_paste_image() then
 
       ---@type string
       local line = lines[1]
+
+      -- Only attempt image paste if the line looks like an image path/URL,
+      -- or if the clipboard actually contains an image. This avoids the
+      -- "Content is not an image" warning when Chinese IME commits text via
+      -- vim.paste (which is not a real paste from clipboard).
+      local img_clip_util = require("img-clip.util")
+      local img_clip_clipboard = require("img-clip.clipboard")
+      local is_image_candidate = (line and (img_clip_util.is_image_url(line) or img_clip_util.is_image_path(line)))
+        or img_clip_clipboard.content_is_image()
+      if not is_image_candidate then return overridden(lines, phase) end
 
       local ok = Clipboard.paste_image(line)
       if not ok then return overridden(lines, phase) end


### PR DESCRIPTION
## Problem

When `img-clip.nvim` is installed, avante overrides `vim.paste` to support image pasting in `AvanteInput` buffers. However, **CJK (Chinese/Japanese/Korean) input methods** commit candidate text through `vim.paste` rather than inserting characters one by one. This causes every IME keystroke to trigger `img-clip`'s `paste_image()`, which emits:

```
Content is not an image.
```

This warning appears on every character typed with a CJK IME (e.g. Chinese Pinyin), but not in English mode.

## Root Cause — Two Bugs

**Bug 1: Ineffective verbose silencing**

The existing code sets `require("img-clip.util").verbose = false`, but this does **nothing**. `img-clip`'s `warn()` function reads `config.get_opt("verbose")`, not `util.verbose`:

```lua
-- img-clip/util.lua
M.warn = function(msg)
  if config.get_opt("verbose") then  -- reads config, not M.verbose!
    vim.notify(msg, vim.log.levels.WARN, { title = "img-clip" })
  end
end
```

**Bug 2: Unconditional paste_image() call**

`paste_image()` is called for all content pasted into `AvanteInput` buffers — including IME-committed text. When the text is not an image path/URL, `img-clip` emits the warning.

## Fix

**Fix 1:** Suppress via `api_opts` (highest priority in img-clip's config lookup) instead of the no-op `util.verbose`:

```lua
require("img-clip.config").api_opts = { default = { verbose = false } }
```

**Fix 2:** Pre-check whether the content is actually an image candidate before calling `paste_image()`:
- Check if `line` is an image URL (`is_image_url`) or image file path (`is_image_path`)
- Or check if the system clipboard actually contains an image (`content_is_image`)

If none are true, fall through directly to the original `vim.paste` handler.

## Test

- Open avante with a CJK IME active
- Type Chinese/Japanese/Korean characters in the input area
- **Before:** warning `Content is not an image.` appears on every IME commit
- **After:** no warning; text input works normally; image paste still works when clipboard contains an actual image