### PR TITLE
feat: hide statusline in avante's windows

### DIFF
--- a/ftplugin/AvanteInput.lua
+++ b/ftplugin/AvanteInput.lua
@@ -1,1 +1,1 @@
-vim.wo.statusline=''
+vim.wo.statusline = ""

--- a/ftplugin/AvanteInput.lua
+++ b/ftplugin/AvanteInput.lua
@@ -1,0 +1,1 @@
+vim.wo.statusline=''


### PR DESCRIPTION
it takes too much space to display 0 information of interest.

This can be overriden by restoring the value of statusline in after/ftplugin/AvanteInput.lua