### PR TITLE
chore: renamed vim.g.avante -> vim.g.avante_loaded

### DIFF
--- a/plugin/avante.lua
+++ b/plugin/avante.lua
@@ -8,9 +8,9 @@ if vim.fn.has("nvim-0.10") == 0 then
   vim.cmd([[quit]])
 end
 
-if vim.g.avante ~= nil then return end
+if vim.g.avante_loaded ~= nil then return end
 
-vim.g.avante = 1
+vim.g.avante_loaded = 1
 
 --- NOTE: We will override vim.paste if img-clip.nvim is available to work with avante.nvim internal logic paste
 local Clipboard = require("avante.clipboard")


### PR DESCRIPTION
vim.g.avante is used as a way to check if the config is loaded but I want to use vim.g.avante to store config instead of the setup() debacle.

See https://mrcjkb.dev/posts/2023-08-22-setup.html as to why setup is bad.