### PR TITLE
tests: dont presume of ag/rg paths

### DIFF
--- a/lua/avante/llm_tools/init.lua
+++ b/lua/avante/llm_tools/init.lua
@@ -568,7 +568,7 @@ function M.python(input, opts)
         return
       end
       if vim.fn.executable("docker") == 0 then
-        on_complete(nil, "Python tool is not available to execute any code")
+        on_complete(nil, "Python tool via docker is not available to execute any code")
         return
       end
 

--- a/tests/llm_tools_spec.lua
+++ b/tests/llm_tools_spec.lua
@@ -144,7 +144,7 @@ describe("llm_tools", function()
     it("should search using ripgrep when available", function()
       -- Mock exepath to return rg path
       vim.fn.exepath = function(cmd)
-        if cmd == "rg" then return "/usr/bin/rg" end
+        if cmd == "rg" then return original_exepath("rg") end
         return ""
       end
 
@@ -193,7 +193,7 @@ describe("llm_tools", function()
     it("should search using ag when rg is not available", function()
       -- Mock exepath to return ag path
       vim.fn.exepath = function(cmd)
-        if cmd == "ag" then return "/usr/bin/ag" end
+        if cmd == "ag" then return original_exepath("ag") end
         return ""
       end
 
@@ -212,7 +212,7 @@ describe("llm_tools", function()
     it("should search using grep when rg and ag are not available", function()
       -- Mock exepath to return grep path
       vim.fn.exepath = function(cmd)
-        if cmd == "grep" then return "/usr/bin/grep" end
+        if cmd == "grep" then return original_exepath("grep") end
         return ""
       end
 

--- a/tests/llm_tools_spec.lua
+++ b/tests/llm_tools_spec.lua
@@ -9,8 +9,8 @@ local glob = require("avante.llm_tools.glob")
 local view = require("avante.llm_tools.view")
 local bash = require("avante.llm_tools.bash")
 
-LlmToolHelpers.confirm = function(msg, cb) return cb(true) end
-LlmToolHelpers.already_in_context = function(path) return false end
+LlmToolHelpers.confirm = function(_msg, cb) return cb(true) end
+LlmToolHelpers.already_in_context = function(_path) return false end
 
 describe("llm_tools", function()
   local test_dir = "/tmp/test_llm_tools"


### PR DESCRIPTION
I wanted to add a test with my fix for AvanteSwitchProviders not listing ACP providers so I tried to run it locally and the hardcoded paths towards rg/ag/grep are a problem