### PR TITLE
fix acp listing

### DIFF
--- a/lua/avante/diff.lua
+++ b/lua/avante/diff.lua
@@ -23,7 +23,7 @@ local M = {}
 -- Types
 -----------------------------------------------------------------------------//
 
----@alias ConflictSide "'ours'"|"'theirs'"|"'all_theirs'"|"'both'"|"'cursor'"|"'base'"|"'none'"
+---@alias ConflictSide "ours"|"theirs"|"all_theirs"|"both"|"cursor"|"base"|"none"
 
 --- @class AvanteConflictHighlights
 --- @field current string

--- a/lua/avante/utils/init.lua
+++ b/lua/avante/utils/init.lua
@@ -177,8 +177,6 @@ function M.shell_run_async(input_cmd, shell_cmd, on_complete, cwd, timeout)
   end
 end
 
----@see https://github.com/LazyVim/LazyVim/blob/main/lua/lazyvim/util/toggle.lua
----
 ---@alias _ToggleSet fun(state: boolean): nil
 ---@alias _ToggleGet fun(): boolean
 ---
@@ -189,6 +187,8 @@ end
 ---
 ---@class ToggleBind.wrap: ToggleBind
 ---@operator call:boolean
+---
+---@see https://github.com/LazyVim/LazyVim/blob/main/lua/lazyvim/util/toggle.lua
 
 ---@param toggle ToggleBind
 function M.toggle_wrap(toggle)


### PR DESCRIPTION
SwitchInputProvider doesn't list ACP providers.

Marking this as draft because I would like to add a test. Probably after 
https://github.com/yetone/avante.nvim/pull/3031  gets merged