### PR TITLE
feat(log): use standard neovim log folder

### DIFF
--- a/lua/avante/utils/log.lua
+++ b/lua/avante/utils/log.lua
@@ -23,7 +23,7 @@ local function format_log(arg) return vim.inspect(arg) end
 ---Get the avante.nvim log file path.
 ---@package
 ---@return string filepath
-function log.get_logfile() return vim.fs.joinpath(vim.fn.stdpath("cache"), "avante.log") end
+function log.get_logfile() return vim.fs.joinpath(vim.fn.stdpath("log"), "avante.log") end
 
 ---Open the avante.nvim log file.
 ---@package


### PR DESCRIPTION
so one can use the `:log` avante command without needing to special case stuff.