### PR TITLE
feat: log failed command

### DIFF
--- a/lua/avante/libs/acp_client.lua
+++ b/lua/avante/libs/acp_client.lua
@@ -417,7 +417,7 @@ function ACPClient:_create_stdio_transport()
 
     if not handle then
       self:_set_state("error")
-      error("Failed to spawn ACP agent process ["..table.concat({self.config.command, unpack(args)}, " ").."]")
+      error("Failed to spawn ACP agent process [" .. table.concat({ self.config.command, unpack(args) }, " ") .. "]")
     end
 
     transport_self.process = handle

--- a/lua/avante/libs/acp_client.lua
+++ b/lua/avante/libs/acp_client.lua
@@ -417,7 +417,7 @@ function ACPClient:_create_stdio_transport()
 
     if not handle then
       self:_set_state("error")
-      error("Failed to spawn ACP agent process")
+      error("Failed to spawn ACP agent process ["..table.concat({self.config.command, unpack(args)}, " ").."]")
     end
 
     transport_self.process = handle


### PR DESCRIPTION
npx was not available so I was greeted with `Failed to spawn ACP agent process` without much details. 
Ideally we would show stderr but that needs to read from the libuv pipe which is a tad more involving so this will do for now.