### PR TITLE
codex: dont mandate npx

### DIFF
--- a/README.md
+++ b/README.md
@@ -1255,8 +1255,8 @@ ACP providers are configured in the `acp_providers` section of your configuratio
       },
     },
     ["claude-code"] = {
-      command = "npx",
-      args = { "@zed-industries/claude-code-acp" },
+      command = "claude-agent-acp",
+      args = { },
       env = {
         NODE_NO_WARNINGS = "1",
         ANTHROPIC_API_KEY = os.getenv("ANTHROPIC_API_KEY"),

--- a/README.md
+++ b/README.md
@@ -1267,8 +1267,8 @@ ACP providers are configured in the `acp_providers` section of your configuratio
       args = { "acp" },
     },
     ["codex"] = {
-      command = "npx",
-      args = { "@zed-industries/codex-acp" },
+      command = "codex-acp",
+      args = {},
       env = {
         NODE_NO_WARNINGS = "1",
         OPENAI_API_KEY = os.getenv("OPENAI_API_KEY"),

--- a/lua/avante/config.lua
+++ b/lua/avante/config.lua
@@ -271,8 +271,8 @@ M._defaults = {
       args = { "acp" },
     },
     ["codex"] = {
-      command = "npx",
-      args = { "-y", "-g", "@zed-industries/codex-acp" },
+      command = "codex-acp",
+      args = {},
       env = {
         NODE_NO_WARNINGS = "1",
         HOME = os.getenv("HOME"),

--- a/lua/avante/config.lua
+++ b/lua/avante/config.lua
@@ -256,8 +256,8 @@ M._defaults = {
       auth_method = "gemini-api-key",
     },
     ["claude-code"] = {
-      command = "npx",
-      args = { "-y", "-g", "@zed-industries/claude-code-acp" },
+      command = "claude-agent-acp",
+      args = {},
       env = {
         NODE_NO_WARNINGS = "1",
         ANTHROPIC_API_KEY = os.getenv("ANTHROPIC_API_KEY"),


### PR DESCRIPTION
I have 'codex-acp' in PATH and yet 'codex' acp provider failed because it tries to start it with npx but I dont have npx. The default should be to look in PATH rather than invoke an indirection that has certainly some cost.

One can restore the previous command via 

```
require'avante'.setup{
    acp_providers = {
     ["codex"] = {
       command = "npx",
       args = { "-y", "-g", "@zed-industries/codex-acp" },
    }
}
```

NB: here is a similar PR for nvim-lspconfig https://github.com/neovim/nvim-lspconfig/pull/4233