### PR TITLE
fix: request failure on deepseek

### DIFF
--- a/lua/avante/providers/openai.lua
+++ b/lua/avante/providers/openai.lua
@@ -239,10 +239,10 @@ function M:parse_messages(opts)
               if last_message and last_message.role == self.role_map["assistant"] and last_message.tool_calls then
                 last_message.tool_calls = vim.list_extend(last_message.tool_calls, tool_calls)
 
-                if pending_reasoning_content then
-                  last_message.reasoning_content = pending_reasoning_content
+                
+                  last_message.reasoning_content = pending_reasoning_content or ""
                   pending_reasoning_content = nil
-                end
+                
 
                 if not last_message.content then last_message.content = "" end
               else
@@ -251,10 +251,10 @@ function M:parse_messages(opts)
                   tool_calls = tool_calls,
                   content = "",
                 }
-                if pending_reasoning_content then
-                  tool_call_message.reasoning_content = pending_reasoning_content
+                
+                  tool_call_message.reasoning_content = pending_reasoning_content or ""
                   pending_reasoning_content = nil
-                end
+                
                 table.insert(messages, tool_call_message)
               end
             end

--- a/lua/avante/providers/openai.lua
+++ b/lua/avante/providers/openai.lua
@@ -239,10 +239,8 @@ function M:parse_messages(opts)
               if last_message and last_message.role == self.role_map["assistant"] and last_message.tool_calls then
                 last_message.tool_calls = vim.list_extend(last_message.tool_calls, tool_calls)
 
-                
-                  last_message.reasoning_content = pending_reasoning_content or ""
-                  pending_reasoning_content = nil
-                
+                last_message.reasoning_content = pending_reasoning_content or ""
+                pending_reasoning_content = nil
 
                 if not last_message.content then last_message.content = "" end
               else
@@ -251,10 +249,10 @@ function M:parse_messages(opts)
                   tool_calls = tool_calls,
                   content = "",
                 }
-                
-                  tool_call_message.reasoning_content = pending_reasoning_content or ""
-                  pending_reasoning_content = nil
-                
+
+                tool_call_message.reasoning_content = pending_reasoning_content or ""
+                pending_reasoning_content = nil
+
                 table.insert(messages, tool_call_message)
               end
             end


### PR DESCRIPTION
Fix #3030 
Setting these two reasoning_content to empty strings fixes the issue on DeepSeek and should not cause errors for other OpenAI‑compatible APIs.