### PR TITLE
fix: revert vim.text.diff to vim.diff for Neovim 0.10 compatibility

### DIFF
--- a/.github/workflows/lua.yaml
+++ b/.github/workflows/lua.yaml
@@ -69,7 +69,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        nvim_version: [ stable ]
+        nvim_version: [ v0.11.0 ]
         luals_version: [ 3.13.6 ]
     steps:
       - uses: actions/checkout@v6

--- a/lua/avante/history/render.lua
+++ b/lua/avante/history/render.lua
@@ -135,7 +135,7 @@ function M.get_diff_lines(old_str, new_str, decoration, truncate)
   local old_lines = vim.split(old_str, "\n")
   local new_lines = vim.split(new_str, "\n")
   ---@diagnostic disable-next-line: assign-type-mismatch, missing-fields
-  local patch = vim.text.diff(old_str, new_str, { ---@type integer[][]
+  local patch = vim.diff(old_str, new_str, { ---@type integer[][]
     algorithm = "histogram",
     result_type = "indices",
     ctxlen = vim.o.scrolloff,

--- a/lua/avante/llm_tools/replace_in_file.lua
+++ b/lua/avante/llm_tools/replace_in_file.lua
@@ -253,7 +253,7 @@ Please make sure the diff is formatted correctly, and that the SEARCH/REPLACE bl
       local patch
       if Config.behaviour.minimize_diff then
         ---@diagnostic disable-next-line: assign-type-mismatch, missing-fields
-        patch = vim.text.diff(old_string, new_string, { ---@type integer[][]
+        patch = vim.diff(old_string, new_string, { ---@type integer[][]
           algorithm = "histogram",
           result_type = "indices",
           ctxlen = vim.o.scrolloff,

--- a/lua/avante/sidebar.lua
+++ b/lua/avante/sidebar.lua
@@ -816,7 +816,7 @@ local function minimize_snippet(original_lines, snippet)
   local snippet_content = snippet.content
   local snippet_lines = vim.split(snippet_content, "\n")
   ---@diagnostic disable-next-line: assign-type-mismatch
-  local patch = vim.text.diff( ---@type integer[][]
+  local patch = vim.diff( ---@type integer[][]
     original_snippet_content,
     snippet_content,
     ---@diagnostic disable-next-line: missing-fields

--- a/lua/avante/suggestion.lua
+++ b/lua/avante/suggestion.lua
@@ -305,7 +305,7 @@ function Suggestion:show()
         virt_text_win_col = #current_lines[start_row]
         lines[1] = string.sub(lines[1], #current_lines[start_row] + 1)
       else
-        local patch = vim.text.diff(
+        local patch = vim.diff(
           current_lines[start_row],
           lines[1],
           ---@diagnostic disable-next-line: missing-fields

--- a/lua/avante/utils/init.lua
+++ b/lua/avante/utils/init.lua
@@ -1807,7 +1807,7 @@ function M.get_unified_diff(text1, text2, opts)
   opts.result_type = "unified"
   opts.ctxlen = opts.ctxlen or 3
 
-  return vim.text.diff(text1, text2, opts)
+  return vim.diff(text1, text2, opts)
 end
 
 function M.is_floating_window(win_id)


### PR DESCRIPTION
see https://github.com/yetone/avante.nvim/pull/3043