### PR TITLE
chore: deprecate require'avante_lib'.load()

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -114,11 +114,7 @@ jobs:
         shell: bash
         run: |
           mkdir -p results
-          if [ "${{ matrix.config.os_name }}" == "linux" ]; then
-            EXT="so"
-          else
-            EXT="dylib"
-          fi
+          EXT="so"
           cp target/release/libavante_templates.$EXT results/avante_templates.$EXT
           cp target/release/libavante_tokenizers.$EXT results/avante_tokenizers.$EXT
           cp target/release/libavante_repo_map.$EXT results/avante_repo_map.$EXT

--- a/Makefile
+++ b/Makefile
@@ -13,7 +13,7 @@ endif
 
 LUA_VERSIONS := luajit lua51
 
-BUILD_DIR := build
+BUILD_DIR := lua
 BUILD_FROM_SOURCE ?= false
 TARGET_LIBRARY ?= all
 
@@ -68,7 +68,7 @@ $(BUILD_DIR):
 	@mkdir -p $(BUILD_DIR)
 
 clean:
-	@rm -rf $(BUILD_DIR)
+	@rm -rf $(BUILD_DIR)/*.$(EXT)
 
 luacheck:
 	@luacheck `find \( -path './target' -prune \) -o -name "*.lua" -print` --codes

--- a/Makefile
+++ b/Makefile
@@ -6,7 +6,8 @@ ifeq ($(UNAME), Linux)
 	EXT := so
 else ifeq ($(UNAME), Darwin)
 	OS := macOS
-	EXT := dylib
+	# looks interchangeable with "dylib", but nvim will find .so automatically in rtp
+	EXT := so
 else
 	$(error Unsupported operating system: $(UNAME))
 endif

--- a/README.md
+++ b/README.md
@@ -353,7 +353,6 @@ programs.neovim = {
       plugin = pkgs.vimPlugins.avante-nvim;
       type = "lua";
       config = ''
-              require("avante_lib").load()
               require("avante").setup()
       '' # or builtins.readFile ./plugins/avante.lua;
     }

--- a/README_zh.md
+++ b/README_zh.md
@@ -221,7 +221,6 @@ programs.neovim = {
       plugin = pkgs.vimPlugins.avante-nvim;
       type = "lua";
       config = ''
-              require("avante_lib").load()
               require("avante").setup()
       '' # 或 builtins.readFile ./plugins/avante.lua;
     }

--- a/build.sh
+++ b/build.sh
@@ -8,7 +8,7 @@ REPO_NAME="avante.nvim"
 SCRIPT_DIR="$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" &>/dev/null && pwd)"
 
 # Set the target directory to clone the artifact
-TARGET_DIR="${SCRIPT_DIR}/build"
+TARGET_DIR="${SCRIPT_DIR}/lua"
 
 # Get the artifact download URL based on the platform and Lua version
 case "$(uname -s)" in
@@ -79,10 +79,10 @@ fi
 
 fetch_remote_tags
 latest_tag="$(git describe --tags --abbrev=0 || true)" # will be empty in clone repos
-built_tag="$(cat build/.tag 2>/dev/null || true)"
+built_tag="$(cat "${TARGET_DIR}/.tag" 2>/dev/null || true)"
 
 save_tag() {
-  echo "$latest_tag" > build/.tag
+  echo "$latest_tag" > "${TARGET_DIR}/.tag"
 }
 
 if [[ "$latest_tag" = "$built_tag" && -n "$latest_tag" ]]; then
@@ -107,6 +107,6 @@ else
   echo "No latest tag found. Building from source."
   cargo build --release --features=$LUA_VERSION
   for f in target/release/lib*.$LIB_EXT; do
-    cp "$f" "build/$(echo $f | sed 's#.*/lib##')"
+    cp "$f" "${TARGET_DIR}/$(echo $f | sed 's#.*/lib##')"
   done
 fi

--- a/build.sh
+++ b/build.sh
@@ -4,6 +4,7 @@ set -e
 
 REPO_OWNER="yetone"
 REPO_NAME="avante.nvim"
+REPO_REMOTE="${1:-origin}"
 
 SCRIPT_DIR="$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" &>/dev/null && pwd)"
 
@@ -66,7 +67,7 @@ test_gh_auth() {
 }
 
 fetch_remote_tags() {
-  git ls-remote --tags origin | cut -f2 | sed 's|refs/tags/||' | while read tag; do
+  git ls-remote --tags "$REPO_REMOTE" | cut -f2 | sed 's|refs/tags/||' | while read tag; do
     if ! git rev-parse "$tag" >/dev/null 2>&1; then
       git fetch origin "refs/tags/$tag:refs/tags/$tag"
     fi

--- a/build.sh
+++ b/build.sh
@@ -18,7 +18,7 @@ Linux*)
   ;;
 Darwin*)
   PLATFORM="darwin"
-  LIB_EXT="dylib"
+  LIB_EXT="so"
   ;;
 CYGWIN* | MINGW* | MSYS*)
   PLATFORM="windows"

--- a/lua/avante/init.lua
+++ b/lua/avante/init.lua
@@ -55,37 +55,6 @@ end
 
 local H = {}
 
-function H.load_path()
-  local ok, LazyConfig = pcall(require, "lazy.core.config")
-
-  if ok then
-    Utils.debug("LazyConfig loaded")
-    local name = "avante.nvim"
-    local function load_path() require("avante_lib").load() end
-
-    if LazyConfig.plugins[name] and LazyConfig.plugins[name]._.loaded then
-      vim.schedule(load_path)
-    else
-      api.nvim_create_autocmd("User", {
-        pattern = "LazyLoad",
-        callback = function(event)
-          if event.data == name then
-            load_path()
-            return true
-          end
-        end,
-      })
-    end
-
-    api.nvim_create_autocmd("User", {
-      pattern = "VeryLazy",
-      callback = load_path,
-    })
-  else
-    require("avante_lib").load()
-  end
-end
-
 function H.keymaps()
   vim.keymap.set({ "n", "v" }, "<Plug>(AvanteAsk)", function() require("avante.api").ask() end, { noremap = true })
   vim.keymap.set(
@@ -503,8 +472,6 @@ function M.setup(opts)
   require("avante.utils.log").set_level(vim.g.avante.log_level)
 
   if M.did_setup then return end
-
-  H.load_path()
 
   require("avante.html2md").setup()
   require("avante.repo_map").setup()

--- a/lua/avante_lib.lua
+++ b/lua/avante_lib.lua
@@ -1,20 +1,8 @@
 local M = {}
 
-local function get_library_path()
-  local os_name = require("avante.utils").get_os_name()
-  local ext = os_name == "linux" and "so" or (os_name == "darwin" and "dylib" or "dll")
-  local dirname = string.sub(debug.getinfo(1).source, 2, #"/avante_lib.lua" * -1)
-  return dirname .. ("../build/?.%s"):format(ext)
-end
-
----@type fun(s: string): string
-local function trim_semicolon(s) return s:sub(-1) == ";" and s:sub(1, -2) or s end
-
+--- @deprecated You do not need to call this function anymore
 function M.load()
-  local library_path = get_library_path()
-  if not string.find(package.cpath, library_path, 1, true) then
-    package.cpath = trim_semicolon(package.cpath) .. ";" .. library_path
-  end
+  -- noop
 end
 
 return M


### PR DESCRIPTION
mark it as deprecated to avoid breaking user configs but it is now a noop (does nothing). Updated README to reflect changes in #2324

reenactment of https://github.com/yetone/avante.nvim/pull/2354 that I intend to finish