### PR TITLE
fix: fix Claude Max (OAuth) authentication flow

### DIFF
--- a/lua/avante/providers/claude.lua
+++ b/lua/avante/providers/claude.lua
@@ -41,6 +41,7 @@ M.role_map = {
 }
 
 M._is_setup = false
+M._authenticating = false
 M._refresh_timer = nil
 
 -- Token validation helper
@@ -185,10 +186,13 @@ function M.setup()
     setup_token_management()
     M._is_setup = true
   else
-    M.authenticate()
     setup_token_management()
-    -- Note: M._is_setup is NOT set to true here because authenticate() is async
-    -- and may fail. The flag indicates setup was attempted, not that it succeeded.
+    vim.schedule(function()
+      Utils.info(
+        "Claude: not authenticated. Run :AvanteAuth to sign in.",
+        { title = "Avante" }
+      )
+    end)
   end
 end
 
@@ -699,8 +703,12 @@ function M.on_error(result)
 end
 
 function M.authenticate()
+  if M._authenticating then return end
+  M._authenticating = true
+
   local verifier, verifier_err = pkce.generate_verifier()
   if not verifier then
+    M._authenticating = false
     vim.schedule(
       function()
         vim.notify("Failed to generate PKCE verifier: " .. (verifier_err or "Unknown error"), vim.log.levels.ERROR)
@@ -711,6 +719,7 @@ function M.authenticate()
 
   local challenge, challenge_err = pkce.generate_challenge(verifier)
   if not challenge then
+    M._authenticating = false
     vim.schedule(
       function()
         vim.notify("Failed to generate PKCE challenge: " .. (challenge_err or "Unknown error"), vim.log.levels.ERROR)
@@ -721,6 +730,7 @@ function M.authenticate()
 
   local state, state_err = pkce.generate_verifier()
   if not state then
+    M._authenticating = false
     vim.schedule(
       function() vim.notify("Failed to generate PKCE state: " .. (state_err or "Unknown error"), vim.log.levels.ERROR) end
     )
@@ -763,6 +773,7 @@ function M.authenticate()
       })
 
       if response.status >= 400 then
+        M._authenticating = false
         vim.schedule(
           function() vim.notify(string.format("HTTP %d: %s", response.status, response.body), vim.log.levels.ERROR) end
         )
@@ -775,9 +786,11 @@ function M.authenticate()
         vim.schedule(function() vim.notify("✓ Authentication successful!", vim.log.levels.INFO) end)
         M._is_setup = true
       else
+        M._authenticating = false
         vim.schedule(function() vim.notify("Failed to decode JSON", vim.log.levels.ERROR) end)
       end
     else
+      M._authenticating = false
       vim.schedule(function() vim.notify("Failed to parse code, authentication failed!", vim.log.levels.ERROR) end)
     end
   end
@@ -871,6 +884,8 @@ function M.store_tokens(tokens)
 
   vim.schedule(function()
     local data_path = vim.fn.stdpath("data") .. "/avante/claude-auth.json"
+
+    vim.fn.mkdir(vim.fn.fnamemodify(data_path, ":h"), "p")
 
     -- Safely encode JSON
     local ok, json_str = pcall(vim.json.encode, json)

--- a/lua/avante/ui/input/providers/native.lua
+++ b/lua/avante/ui/input/providers/native.lua
@@ -17,7 +17,7 @@ function M.show(input)
     )
   end
 
-  vim.ui.select(opts, input.on_submit)
+  vim.ui.input(opts, input.on_submit)
 end
 
 return M

--- a/plugin/avante.lua
+++ b/plugin/avante.lua
@@ -193,3 +193,4 @@ cmd("ACPModels", function() require("avante.api").select_acp_model() end, { desc
 cmd("ACPModes", function() require("avante.api").select_acp_mode() end, { desc = "avante: switch ACP mode" })
 cmd("History", function() require("avante.api").select_history() end, { desc = "avante: show histories" })
 cmd("Stop", function() require("avante.api").stop() end, { desc = "avante: stop current AI request" })
+cmd("Auth", function() require("avante.providers.claude").authenticate() end, { desc = "avante: authenticate with Claude" })


### PR DESCRIPTION
- Fix native input provider calling vim.ui.select instead of vim.ui.input, which caused a crash when the auth dialog opened
- Guard authenticate() with _authenticating flag to prevent multiple concurrent calls when setup() is invoked more than once
- Create stdpath("data")/avante/ directory before writing the token file, so tokens are actually persisted across sessions
- Stop auto-calling authenticate() on startup when no token exists; show a one-time notice to run :AvanteAuth instead, preventing repeated rate limit hits on the OAuth token endpoint
- Add :AvanteAuth command for on-demand authentication