### PR TITLE
fix: map <esc> to close in normal mode instead of insert mode

### DIFF
--- a/lua/avante/ui/selector/providers/telescope.lua
+++ b/lua/avante/ui/selector/providers/telescope.lua
@@ -60,7 +60,7 @@ function M.show(selector)
           end,
         }),
         attach_mappings = function(prompt_bufnr, map)
-          map("i", "<esc>", require("telescope.actions").close)
+          map("n", "<esc>", require("telescope.actions").close)
           map("i", "<c-del>", function()
             local picker = action_state.get_current_picker(prompt_bufnr)
 


### PR DESCRIPTION
Fixes https://github.com/yetone/avante.nvim/issues/2948

Using telescope as the file_selector provider makes pressing Escape once close the picker. This is counter-intuitive based on the default telescope behavior.

Normally you would enter normal mode, enabling navigating the list with j and k - the default vim navigation keys. Then you would press Escape again to close it.