### PR TITLE
refactor: rewrite mappings with <Plug>

### DIFF
--- a/lua/avante/init.lua
+++ b/lua/avante/init.lua
@@ -154,12 +154,7 @@ function H.keymaps()
   end, { noremap = true, silent = true })
 
   if Config.behaviour.auto_set_keymaps then
-    Utils.safe_keymap_set(
-      { "n", "v" },
-      Config.mappings.ask,
-      "<Plug>(AvanteAsk)",
-      { desc = "avante: ask" }
-    )
+    Utils.safe_keymap_set({ "n", "v" }, Config.mappings.ask, "<Plug>(AvanteAsk)", { desc = "avante: ask" })
     Utils.safe_keymap_set(
       { "n", "v" },
       Config.mappings.zen_mode,
@@ -172,30 +167,10 @@ function H.keymaps()
       "<Plug>(AvanteAskNew)",
       { desc = "avante: create new ask" }
     )
-    Utils.safe_keymap_set(
-      "v",
-      Config.mappings.edit,
-      "<Plug>(AvanteEdit)",
-      { desc = "avante: edit" }
-    )
-    Utils.safe_keymap_set(
-      "n",
-      Config.mappings.stop,
-      "<Plug>(AvanteStop)",
-      { desc = "avante: stop" }
-    )
-    Utils.safe_keymap_set(
-      "n",
-      Config.mappings.refresh,
-      "<Plug>(AvanteRefresh)",
-      { desc = "avante: refresh" }
-    )
-    Utils.safe_keymap_set(
-      "n",
-      Config.mappings.focus,
-      "<Plug>(AvanteFocus)",
-      { desc = "avante: focus" }
-    )
+    Utils.safe_keymap_set("v", Config.mappings.edit, "<Plug>(AvanteEdit)", { desc = "avante: edit" })
+    Utils.safe_keymap_set("n", Config.mappings.stop, "<Plug>(AvanteStop)", { desc = "avante: stop" })
+    Utils.safe_keymap_set("n", Config.mappings.refresh, "<Plug>(AvanteRefresh)", { desc = "avante: refresh" })
+    Utils.safe_keymap_set("n", Config.mappings.focus, "<Plug>(AvanteFocus)", { desc = "avante: focus" })
 
     Utils.safe_keymap_set("n", Config.mappings.toggle.default, "<Plug>(AvanteToggle)", { desc = "avante: toggle" })
     Utils.safe_keymap_set(

--- a/lua/avante/init.lua
+++ b/lua/avante/init.lua
@@ -100,7 +100,11 @@ function H.keymaps()
     function() require("avante.api").ask({ ask = false }) end,
     { noremap = true }
   )
+  vim.keymap.set({ "n", "v" }, "<Plug>(AvanteZenMode)", function() require("avante.api").zen_mode() end, {
+    noremap = true,
+  })
   vim.keymap.set("v", "<Plug>(AvanteEdit)", function() require("avante.api").edit() end, { noremap = true })
+  vim.keymap.set("n", "<Plug>(AvanteStop)", function() require("avante.api").stop() end, { noremap = true })
   vim.keymap.set("n", "<Plug>(AvanteRefresh)", function() require("avante.api").refresh() end, { noremap = true })
   vim.keymap.set("n", "<Plug>(AvanteFocus)", function() require("avante.api").focus() end, { noremap = true })
   vim.keymap.set("n", "<Plug>(AvanteBuild)", function() require("avante.api").build() end, { noremap = true })
@@ -117,77 +121,102 @@ function H.keymaps()
   vim.keymap.set("n", "<Plug>(AvanteConflictNextConflict)", function() Diff.find_next("ours") end)
   vim.keymap.set("n", "<Plug>(AvanteConflictPrevConflict)", function() Diff.find_prev("ours") end)
   vim.keymap.set("n", "<Plug>(AvanteSelectModel)", function() require("avante.api").select_model() end)
+  vim.keymap.set("n", "<Plug>(AvanteSelectHistory)", function() require("avante.api").select_history() end)
   vim.keymap.set("n", "<Plug>(AvanteSelectACPModel)", function() require("avante.api").select_acp_model() end, {
     noremap = true,
   })
   vim.keymap.set("n", "<Plug>(AvanteSelectACPMode)", function() require("avante.api").select_acp_mode() end, {
     noremap = true,
   })
+  vim.keymap.set("n", "<Plug>(AvanteShowRepoMap)", function() require("avante.repo_map").show() end, {
+    noremap = true,
+    silent = true,
+  })
+  vim.keymap.set("n", "<Plug>(AvanteAddAllBuffers)", function() require("avante.api").add_buffer_files() end, {
+    noremap = true,
+  })
+
+  vim.keymap.set("i", "<Plug>(AvanteSuggestionAccept)", function()
+    local _, _, sg = M.get()
+    sg:accept()
+  end, { noremap = true, silent = true })
+  vim.keymap.set("i", "<Plug>(AvanteSuggestionDismiss)", function()
+    local _, _, sg = M.get()
+    if sg:is_visible() then sg:dismiss() end
+  end, { noremap = true, silent = true })
+  vim.keymap.set("i", "<Plug>(AvanteSuggestionNext)", function()
+    local _, _, sg = M.get()
+    sg:next()
+  end, { noremap = true, silent = true })
+  vim.keymap.set("i", "<Plug>(AvanteSuggestionPrev)", function()
+    local _, _, sg = M.get()
+    sg:prev()
+  end, { noremap = true, silent = true })
 
   if Config.behaviour.auto_set_keymaps then
     Utils.safe_keymap_set(
       { "n", "v" },
       Config.mappings.ask,
-      function() require("avante.api").ask() end,
+      "<Plug>(AvanteAsk)",
       { desc = "avante: ask" }
     )
     Utils.safe_keymap_set(
       { "n", "v" },
       Config.mappings.zen_mode,
-      function() require("avante.api").zen_mode() end,
+      "<Plug>(AvanteZenMode)",
       { desc = "avante: toggle Zen Mode" }
     )
     Utils.safe_keymap_set(
       { "n", "v" },
       Config.mappings.new_ask,
-      function() require("avante.api").ask({ new_chat = true }) end,
+      "<Plug>(AvanteAskNew)",
       { desc = "avante: create new ask" }
     )
     Utils.safe_keymap_set(
       "v",
       Config.mappings.edit,
-      function() require("avante.api").edit() end,
+      "<Plug>(AvanteEdit)",
       { desc = "avante: edit" }
     )
     Utils.safe_keymap_set(
       "n",
       Config.mappings.stop,
-      function() require("avante.api").stop() end,
+      "<Plug>(AvanteStop)",
       { desc = "avante: stop" }
     )
     Utils.safe_keymap_set(
       "n",
       Config.mappings.refresh,
-      function() require("avante.api").refresh() end,
+      "<Plug>(AvanteRefresh)",
       { desc = "avante: refresh" }
     )
     Utils.safe_keymap_set(
       "n",
       Config.mappings.focus,
-      function() require("avante.api").focus() end,
+      "<Plug>(AvanteFocus)",
       { desc = "avante: focus" }
     )
 
-    Utils.safe_keymap_set("n", Config.mappings.toggle.default, function() M.toggle() end, { desc = "avante: toggle" })
+    Utils.safe_keymap_set("n", Config.mappings.toggle.default, "<Plug>(AvanteToggle)", { desc = "avante: toggle" })
     Utils.safe_keymap_set(
       "n",
       Config.mappings.toggle.debug,
-      function() M.toggle.debug() end,
+      "<Plug>(AvanteToggleDebug)",
       { desc = "avante: toggle debug" }
     )
     Utils.safe_keymap_set(
       "n",
       Config.mappings.toggle.selection,
-      function() M.toggle.hint() end,
+      "<Plug>(AvanteToggleSelection)",
       { desc = "avante: toggle selection" }
     )
     Utils.safe_keymap_set(
       "n",
       Config.mappings.toggle.suggestion,
-      function() M.toggle.suggestion() end,
+      "<Plug>(AvanteToggleSuggestion)",
       { desc = "avante: toggle suggestion" }
     )
-    Utils.safe_keymap_set("n", Config.mappings.toggle.repomap, function() require("avante.repo_map").show() end, {
+    Utils.safe_keymap_set("n", Config.mappings.toggle.repomap, "<Plug>(AvanteShowRepoMap)", {
       desc = "avante: display repo map",
       noremap = true,
       silent = true,
@@ -195,68 +224,56 @@ function H.keymaps()
     Utils.safe_keymap_set(
       "n",
       Config.mappings.select_model,
-      function() require("avante.api").select_model() end,
+      "<Plug>(AvanteSelectModel)",
       { desc = "avante: select model" }
     )
     Utils.safe_keymap_set(
       "n",
       Config.mappings.select_history,
-      function() require("avante.api").select_history() end,
+      "<Plug>(AvanteSelectHistory)",
       { desc = "avante: select history" }
     )
     Utils.safe_keymap_set(
       "n",
       Config.mappings.select_acp_model,
-      function() require("avante.api").select_acp_model() end,
+      "<Plug>(AvanteSelectACPModel)",
       { desc = "avante: select ACP model" }
     )
     Utils.safe_keymap_set(
       "n",
       Config.mappings.select_acp_mode,
-      function() require("avante.api").select_acp_mode() end,
+      "<Plug>(AvanteSelectACPMode)",
       { desc = "avante: select ACP mode" }
     )
 
     Utils.safe_keymap_set(
       "n",
       Config.mappings.files.add_all_buffers,
-      function() require("avante.api").add_buffer_files() end,
+      "<Plug>(AvanteAddAllBuffers)",
       { desc = "avante: add all open buffers" }
     )
   end
 
   if Config.behaviour.auto_suggestions then
-    Utils.safe_keymap_set("i", Config.mappings.suggestion.accept, function()
-      local _, _, sg = M.get()
-      sg:accept()
-    end, {
+    Utils.safe_keymap_set("i", Config.mappings.suggestion.accept, "<Plug>(AvanteSuggestionAccept)", {
       desc = "avante: accept suggestion",
       noremap = true,
       silent = true,
     })
 
-    Utils.safe_keymap_set("i", Config.mappings.suggestion.dismiss, function()
-      local _, _, sg = M.get()
-      if sg:is_visible() then sg:dismiss() end
-    end, {
+    Utils.safe_keymap_set("i", Config.mappings.suggestion.dismiss, "<Plug>(AvanteSuggestionDismiss)", {
       desc = "avante: dismiss suggestion",
       noremap = true,
       silent = true,
     })
 
-    Utils.safe_keymap_set("i", Config.mappings.suggestion.next, function()
-      local _, _, sg = M.get()
-      sg:next()
-    end, {
+    Utils.safe_keymap_set("i", Config.mappings.suggestion.next, "<Plug>(AvanteSuggestionNext)", {
       desc = "avante: next suggestion",
       noremap = true,
       silent = true,
     })
 
-    Utils.safe_keymap_set("i", Config.mappings.suggestion.prev, function()
-      local _, _, sg = M.get()
-      sg:prev()
-    end, {
+    Utils.safe_keymap_set("i", Config.mappings.suggestion.prev, "<Plug>(AvanteSuggestionPrev)", {
       desc = "avante: previous suggestion",
       noremap = true,
       silent = true,

--- a/lua/avante/sidebar.lua
+++ b/lua/avante/sidebar.lua
@@ -1596,16 +1596,28 @@ end
 ---@param container NuiSplit
 function Sidebar:setup_window_navigation(container)
   local buf = api.nvim_win_get_buf(container.winid)
+  vim.keymap.set(
+    { "n", "i" },
+    "<Plug>(AvanteSidebarSwitchWindow)",
+    function() self:switch_window_focus("next") end,
+    { buffer = buf, noremap = true, silent = true, nowait = true }
+  )
+  vim.keymap.set(
+    { "n", "i" },
+    "<Plug>(AvanteSidebarReverseSwitchWindow)",
+    function() self:switch_window_focus("previous") end,
+    { buffer = buf, noremap = true, silent = true, nowait = true }
+  )
   Utils.safe_keymap_set(
     { "n", "i" },
     Config.mappings.sidebar.switch_windows,
-    function() self:switch_window_focus("next") end,
+    "<Plug>(AvanteSidebarSwitchWindow)",
     { buffer = buf, noremap = true, silent = true, nowait = true }
   )
   Utils.safe_keymap_set(
     { "n", "i" },
     Config.mappings.sidebar.reverse_switch_windows,
-    function() self:switch_window_focus("previous") end,
+    "<Plug>(AvanteSidebarReverseSwitchWindow)",
     { buffer = buf, noremap = true, silent = true, nowait = true }
   )
 end


### PR DESCRIPTION
to keep a single source of truths for mappings

Might be controversial reading https://github.com/yetone/avante.nvim/wiki#keymaps-and-api-i-guess but this looks like the vim way ?!