### PR TITLE
feat: support configuration via global vim.g.avante

### DIFF
--- a/README.md
+++ b/README.md
@@ -436,6 +436,32 @@ require('avante').setup({
 
 _See [config.lua#L9](./lua/avante/config.lua) for the full config_
 
+You can pass options directly to `setup()`:
+
+```lua
+require("avante").setup({
+  provider = "claude",
+  behaviour = {
+    auto_suggestions = false,
+  },
+})
+```
+
+Alternatively, define the same options in `vim.g.avante` before calling `setup()`:
+
+```lua
+vim.g.avante = {
+  provider = "claude",
+  behaviour = {
+    auto_suggestions = false,
+  },
+}
+
+require("avante").setup()
+```
+
+If both are used, options passed to `setup()` override values from `vim.g.avante`.
+
 <details>
 <summary>Default configuration</summary>
 

--- a/lua/avante/config.lua
+++ b/lua/avante/config.lua
@@ -921,7 +921,13 @@ function M.setup(opts)
   opts = opts or {} -- Ensure `opts` is defined with a default table
   vim.validate("opts", opts, "table", true)
 
-  opts = opts or {}
+  local global_opts = {}
+  if vim.g.avante ~= nil then
+    vim.validate("vim.g.avante", vim.g.avante, "table", true)
+    global_opts = vim.deepcopy(vim.g.avante, true)
+  end
+
+  opts = vim.tbl_deep_extend("force", global_opts, opts or {})
 
   local migration_url = "https://github.com/yetone/avante.nvim/wiki/Provider-configuration-migration-guide"
 
@@ -1074,9 +1080,9 @@ function M.setup(opts)
     M._options.providers[k] = type(v) == "function" and v() or v
   end
 
-  vim.g.avante = {
+  vim.g.avante = vim.tbl_deep_extend("force", vim.g.avante or {}, {
     log_level = merged.log_level,
-  }
+  })
 end
 
 ---@param opts table<string, any>

--- a/tests/config_spec.lua
+++ b/tests/config_spec.lua
@@ -1,0 +1,48 @@
+describe("config", function()
+  local Config
+  local previous_avante
+
+  before_each(function()
+    previous_avante = vim.g.avante
+    package.loaded["avante.config"] = nil
+    Config = require("avante.config")
+  end)
+
+  after_each(function()
+    vim.g.avante = previous_avante
+    package.loaded["avante.config"] = nil
+  end)
+
+  it("loads setup options from vim.g.avante", function()
+    vim.g.avante = {
+      provider = "openai",
+      behaviour = {
+        auto_suggestions = true,
+      },
+    }
+
+    Config.setup({})
+
+    assert.are.same("openai", Config.provider)
+    assert.is_true(Config.behaviour.auto_suggestions)
+  end)
+
+  it("lets explicit setup options override vim.g.avante", function()
+    vim.g.avante = {
+      provider = "openai",
+      behaviour = {
+        auto_suggestions = true,
+      },
+    }
+
+    Config.setup({
+      provider = "claude",
+      behaviour = {
+        auto_suggestions = false,
+      },
+    })
+
+    assert.are.same("claude", Config.provider)
+    assert.is_false(Config.behaviour.auto_suggestions)
+  end)
+end)


### PR DESCRIPTION
Endgame is to remove setup but right now it's not doable because there is some processing needed to customize/provider setup mappings.

Goal is to refactor config such that we can configure exclusively via vim.g.avante see https://github.com/yetone/avante.nvim/issues/3065