### PR TITLE
@teto fix: native input  provider

### DIFF
--- a/lua/avante/ui/input/providers/native.lua
+++ b/lua/avante/ui/input/providers/native.lua
@@ -1,5 +1,6 @@
 local M = {}
 
+---Let user enter freeform value
 ---@param input avante.ui.Input
 function M.show(input)
   local opts = {
@@ -17,7 +18,7 @@ function M.show(input)
     )
   end
 
-  vim.ui.select(opts, input.on_submit)
+  vim.ui.input(opts, input.on_submit)
 end
 
 return M

--- a/tests/ui/input_spec.lua
+++ b/tests/ui/input_spec.lua
@@ -3,13 +3,9 @@ local Input = require("avante.ui.input")
 describe("Input", function()
   local original_input
 
-  before_each(function()
-    original_input = vim.ui.input
-  end)
+  before_each(function() original_input = vim.ui.input end)
 
-  after_each(function()
-    vim.ui.input = original_input
-  end)
+  after_each(function() vim.ui.input = original_input end)
 
   it("uses vim.ui.input for the native provider", function()
     local captured_opts

--- a/tests/ui/input_spec.lua
+++ b/tests/ui/input_spec.lua
@@ -1,0 +1,44 @@
+local Input = require("avante.ui.input")
+
+describe("Input", function()
+  local original_input
+
+  before_each(function()
+    original_input = vim.ui.input
+  end)
+
+  after_each(function()
+    vim.ui.input = original_input
+  end)
+
+  it("uses vim.ui.input for the native provider", function()
+    local captured_opts
+    local captured_on_submit
+    local submitted
+
+    vim.ui.input = function(opts, on_submit)
+      captured_opts = opts
+      captured_on_submit = on_submit
+    end
+
+    local input = Input:new({
+      provider = "native",
+      title = "Model name",
+      default = "claude",
+      completion = "file",
+      on_submit = function(result) submitted = result end,
+    })
+
+    input:open()
+
+    assert.are.same({
+      prompt = "Model name",
+      default = "claude",
+      completion = "file",
+    }, captured_opts)
+    assert.is_function(captured_on_submit)
+
+    captured_on_submit("openai")
+    assert.are.same("openai", submitted)
+  end)
+end)


### PR DESCRIPTION
It was changed wrongly in 9b72d16426400fba244f525adf6cd5e4ecc26c70. Added a codex-generated test.