### PR TITLE
fix: clean up duplicate entry in avante.txt

### DIFF
--- a/doc/avante.txt
+++ b/doc/avante.txt
@@ -776,8 +776,6 @@ avante sidebar                                                  *avante-sidebar*
  `r`             Confirm response
  `i`             Confirm input
 
-avante.Sidebar                                                  *avante.Sidebar*
-
 
 avante.CodeState                                              *avante.CodeState*
 


### PR DESCRIPTION
Removed duplicate `avante.Sidebar` entry which caused docs to fail on Lazy Update. This entry I'm proposing to remove duplicates line 792. 