### PR TITLE
fix: enhance CI builds, dynamic fork artifact downloads, and Windows paths

### DIFF
--- a/.github/workflows/luarocks.yml
+++ b/.github/workflows/luarocks.yml
@@ -12,6 +12,7 @@ on:
 
 jobs:
   luarocks-upload:
+    if: github.repository == 'yetone/avante.nvim'
     runs-on: ubuntu-24.04
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -2,7 +2,7 @@ name: Release
 
 on:
   push:
-    tags: [v\d+\.\d+\.\d+]
+    tags: ['v*']
 
 permissions:
   contents: write

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -64,7 +64,7 @@ jobs:
             rust_target: x86_64-unknown-linux-gnu
             docker_platform: linux/amd64
             container: quay.io/pypa/manylinux2014_x86_64 # for glibc 2.17
-          - os: macos-13
+          - os: macos-latest
             os_name: darwin
             arch: x86_64
             rust_target: x86_64-apple-darwin
@@ -95,7 +95,7 @@ jobs:
       - name: Build all crates
         if: ${{ matrix.config.container == null }}
         run: |
-          cargo build --release --features ${{ matrix.feature }}
+          cargo build --release --features ${{ matrix.feature }} --target ${{ matrix.config.rust_target }}
 
       - name: Build all crates with glibc 2.17 # for glibc 2.17
         if: ${{ matrix.config.container != null }}
@@ -116,13 +116,15 @@ jobs:
           mkdir -p results
           if [ "${{ matrix.config.os_name }}" == "darwin" ]; then
             EXT="dylib"
+            TARGET_DIR="target/${{ matrix.config.rust_target }}/release"
           else
             EXT="so"
+            TARGET_DIR="target/release"
           fi
-          cp target/release/libavante_templates.$EXT results/avante_templates.$EXT
-          cp target/release/libavante_tokenizers.$EXT results/avante_tokenizers.$EXT
-          cp target/release/libavante_repo_map.$EXT results/avante_repo_map.$EXT
-          cp target/release/libavante_html2md.$EXT results/avante_html2md.$EXT
+          cp $TARGET_DIR/libavante_templates.$EXT results/avante_templates.$EXT
+          cp $TARGET_DIR/libavante_tokenizers.$EXT results/avante_tokenizers.$EXT
+          cp $TARGET_DIR/libavante_repo_map.$EXT results/avante_repo_map.$EXT
+          cp $TARGET_DIR/libavante_html2md.$EXT results/avante_html2md.$EXT
 
           cd results
           tar zcvf avante_lib-${{ matrix.config.os_name }}-${{ matrix.config.arch }}-${{ matrix.feature }}.tar.gz *.${EXT}
@@ -133,10 +135,11 @@ jobs:
         run: |
           New-Item -ItemType Directory -Force -Path results
 
-          Copy-Item -Path "target\release\avante_templates.dll" -Destination "results\avante_templates.dll"
-          Copy-Item -Path "target\release\avante_tokenizers.dll" -Destination "results\avante_tokenizers.dll"
-          Copy-Item -Path "target\release\avante_repo_map.dll" -Destination "results\avante_repo_map.dll"
-          Copy-Item -Path "target\release\avante_html2md.dll" -Destination "results\avante_html2md.dll"
+          $TargetDir = "target\${{ matrix.config.rust_target }}\release"
+          Copy-Item -Path "$TargetDir\avante_templates.dll" -Destination "results\avante_templates.dll"
+          Copy-Item -Path "$TargetDir\avante_tokenizers.dll" -Destination "results\avante_tokenizers.dll"
+          Copy-Item -Path "$TargetDir\avante_repo_map.dll" -Destination "results\avante_repo_map.dll"
+          Copy-Item -Path "$TargetDir\avante_html2md.dll" -Destination "results\avante_html2md.dll"
 
           Set-Location -Path results
 

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -114,7 +114,11 @@ jobs:
         shell: bash
         run: |
           mkdir -p results
-          EXT="so"
+          if [ "${{ matrix.config.os_name }}" == "darwin" ]; then
+            EXT="dylib"
+          else
+            EXT="so"
+          fi
           cp target/release/libavante_templates.$EXT results/avante_templates.$EXT
           cp target/release/libavante_tokenizers.$EXT results/avante_tokenizers.$EXT
           cp target/release/libavante_repo_map.$EXT results/avante_repo_map.$EXT

--- a/Build.ps1
+++ b/Build.ps1
@@ -69,8 +69,16 @@ function Download-Prebuilt($feature, $tag) {
         gh release download $latestTag --repo "$REPO_OWNER/$REPO_NAME" --pattern "*$ARTIFACT_NAME_PATTERN*" --output $TempFile --clobber
     } else {
       # Get the artifact download URL
-      $RELEASE = Invoke-RestMethod -Uri "https://api.github.com/repos/$REPO_OWNER/$REPO_NAME/releases/tags/$tag"
-      $ARTIFACT_URL = $RELEASE.assets | Where-Object { $_.name -like "*$ARTIFACT_NAME_PATTERN*" } | Select-Object -ExpandProperty browser_download_url
+          $RELEASE = Invoke-RestMethod -Uri "https://api.github.com/repos/$REPO_OWNER/$REPO_NAME/releases/tags/$tag"
+          $ARTIFACT_URL = $RELEASE.assets | Where-Object { $_.name -like "*$ARTIFACT_NAME_PATTERN*" } | Select-Object -ExpandProperty browser_download_url
+
+      # Defensive validation
+      if ([string]::IsNullOrWhiteSpace($ARTIFACT_URL)) {
+          Write-Error "Prebuilt binary matching '$ARTIFACT_NAME_PATTERN' not found for release tag '$tag'."
+          Write-Host "The required binary is not available. Please build from source using:" -ForegroundColor Yellow
+          Write-Host "powershell -ExecutionPolicy Bypass -File Build.ps1 -BuildFromSource true" -ForegroundColor Yellow
+          exit 1
+      }
 
       # Download and extract the artifact
       Invoke-WebRequest -Uri $ARTIFACT_URL -OutFile $TempFile

--- a/Build.ps1
+++ b/Build.ps1
@@ -9,8 +9,14 @@ $ErrorActionPreference = "Stop"
 $ProgressPreference = "SilentlyContinue"
 
 $BuildDir = "build"
-$REPO_OWNER = "yetone"
-$REPO_NAME = "avante.nvim"
+$remoteUrl = git config --get remote.origin.url 2>$null
+if ($remoteUrl -match "github\.com[:/]([^/]+)/([^/]+?)(?:\.git)?$") {
+    $REPO_OWNER = $matches[1]
+    $REPO_NAME = $matches[2]
+} else {
+    $REPO_OWNER = "yetone"
+    $REPO_NAME = "avante.nvim"
+}
 
 function Build-FromSource($feature) {
     if (-not (Test-Path $BuildDir)) {

--- a/build.sh
+++ b/build.sh
@@ -2,9 +2,17 @@
 
 set -e
 
-REPO_OWNER="yetone"
-REPO_NAME="avante.nvim"
 REPO_REMOTE="${1:-origin}"
+remote_url=$(git config --get remote.${REPO_REMOTE}.url 2>/dev/null || true)
+if [[ "$remote_url" == *"github.com"* ]]; then
+  tmp="${remote_url#*github.com[:/]}"
+  tmp="${tmp%.git}"
+  REPO_OWNER="${tmp%/*}"
+  REPO_NAME="${tmp#*/}"
+else
+  REPO_OWNER="yetone"
+  REPO_NAME="avante.nvim"
+fi
 
 SCRIPT_DIR="$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" &>/dev/null && pwd)"
 

--- a/lua/avante/path.lua
+++ b/lua/avante/path.lua
@@ -299,7 +299,8 @@ function Prompt.get_templates_dir(project_root)
     directory = Path:new(vim.fs.normalize(win_path))
   end
   local cache_prompt_dir = Path:new(P.cache_path):joinpath(directory)
-  if not cache_prompt_dir:exists() then cache_prompt_dir:mkdir({ parents = true }) end
+  local cache_dir_str = tostring(cache_prompt_dir):gsub("\\", "/")
+  if vim.fn.isdirectory(cache_dir_str) == 0 then vim.fn.mkdir(cache_dir_str, "p") end
 
   local function find_rules(dir)
     if not dir then return end

--- a/lua/avante/path.lua
+++ b/lua/avante/path.lua
@@ -451,6 +451,11 @@ P.repo_map = RepoMap
 ---@return AvanteTemplates|nil
 function P._init_templates_lib()
   if _templates_lib ~= nil then return _templates_lib end
+
+  local build_dir = vim.fn.fnamemodify(debug.getinfo(1, "S").source:sub(2), ":h:h:h") .. "/build"
+  local ext = vim.fn.has("win32") == 1 and "dll" or "so"
+  package.cpath = package.cpath .. ";" .. build_dir .. "/?." .. ext
+
   local ok, module = pcall(require, "avante_templates")
   ---@cast module AvanteTemplates
   ---@cast ok boolean


### PR DESCRIPTION
This PR introduces several crucial fixes to improve the CI/CD pipeline, support fork builds, and fix native Windows bugs.

### CI & Releases (`release.yaml`)
- Fixed macOS cross-compilation builds by migrating to `macos-latest` (M1/ARM).
- Fixed `.dylib` extension mismatch for macOS binaries.
- Disabled Luarocks upload on forks to prevent Action failures when `LUAROCKS_API_KEY` is missing.
- Simplified the release action trigger.

### Build Scripts (`Build.ps1` & `build.sh`)
- Removed hardcoded `yetone/avante.nvim` repository owner. The build scripts now dynamically resolve the repository owner and name via `git config --get remote.origin.url`. This allows users running from forks to download their own release artifacts properly without falling back to source compilation.

### Core Path Fixes (`lua/avante/path.lua`)
- Fixed a bug where `mkdir` would fail on Windows due to mixed slashes (`/` and `\`) when creating the cache directory. Forced path normalization to forward slashes before calling `vim.fn.mkdir`.
- Dynamically added the `build/` directory to `package.cpath` before requiring `avante_templates`. This ensures Neovim can instantly load the DLLs/SOs even if the package manager (`lazy.nvim`) hasn't updated the search path yet in the current session.

Tested successfully on both Windows and Linux!

To make testing easier, you can also try replacing "yetone/avante.nvim" with "RobsonMobarack/avante.nvim" to get it directly from my repository.