### PR TITLE
Provider compatability, utf-8 safety, concurrent session isolation

### DIFF
--- a/lua/avante/api.lua
+++ b/lua/avante/api.lua
@@ -43,8 +43,6 @@ local function to_windows_path(path)
   return winpath
 end
 
----Command to install the necessary rust libraries
----Defaults to download the libraries but passing `source=true` will force a local build via cargo
 ---@param opts? {source: boolean}
 function M.build(opts)
   opts = opts or { source = true }
@@ -268,8 +266,12 @@ function M.select_history()
     vim.api.nvim_buf_call(buf, function()
       if not require("avante").is_sidebar_open() then require("avante").open_sidebar({}) end
       local Path = require("avante.path")
+      -- Update the global metadata pointer so the NEXT fresh instance opens
+      -- the right file, but also pin THIS sidebar to the selected file so
+      -- it doesn't get hijacked by a concurrent instance's save.
       Path.history.save_latest_filename(buf, filename)
       local sidebar = require("avante").get()
+      sidebar.current_history_filename = filename
       sidebar:update_content_with_history()
       sidebar:create_todos_container()
       sidebar:initialize_token_count()

--- a/lua/avante/history/message.lua
+++ b/lua/avante/history/message.lua
@@ -17,6 +17,7 @@ M.__index = M
 ---@field is_user_submission? boolean
 ---@field just_for_display? boolean
 ---@field visible? boolean
+---@field from_instance? string -- instance_name of the sending chat (cross-instance message)
 ---
 ---@param role "user" | "assistant"
 ---@param content AvanteLLMMessageContentItem

--- a/lua/avante/init.lua
+++ b/lua/avante/init.lua
@@ -148,6 +148,9 @@ local M = {
   current = { sidebar = nil, selection = nil, suggestion = nil },
   ---@type table<string, any> Global ACP client registry for cleanup on exit
   acp_clients = {},
+  --- instance_name → Sidebar: cross-instance messaging registry
+  ---@type table<string, avante.Sidebar>
+  instance_registry = {},
 }
 
 M.did_setup = false
@@ -423,7 +426,13 @@ function H.autocmds()
       local tab = tonumber(ev.file)
       local s = M.sidebars[tab]
       local sl = M.selections[tab]
-      if s then s:reset() end
+      if s then
+        -- Remove this sidebar from the cross-instance registry before reset.
+        if s.chat_history and s.chat_history.instance_name then
+          M.instance_registry[s.chat_history.instance_name] = nil
+        end
+        s:reset()
+      end
       if sl then sl:delete_autocmds() end
       if tab ~= nil then M.sidebars[tab] = nil end
     end,

--- a/lua/avante/llm.lua
+++ b/lua/avante/llm.lua
@@ -29,9 +29,28 @@ local group = api.nvim_create_augroup("avante_llm", { clear = true })
 ---@param prev_memory string | nil
 ---@param history_messages avante.HistoryMessage[]
 ---@param cb fun(memory: avante.ChatMemory | nil): nil
-function M.summarize_memory(prev_memory, history_messages, cb)
-  local system_prompt =
-    [[You are an expert coding assistant. Your goal is to generate a concise, structured summary of the conversation below that captures all essential information needed to continue development after context replacement. Include tasks performed, code areas modified or reviewed, key decisions or assumptions, test results or errors, and outstanding tasks or next steps.]]
+---@param prev_memory string | nil
+---@param history_messages avante.HistoryMessage[]
+---@param cb fun(memory: avante.ChatMemory | nil): nil
+---@param mode? "compact" | "simplify"  -- "compact" (default): readable structured summary; "simplify": ultra-terse bullet points
+function M.summarize_memory(prev_memory, history_messages, cb, mode)
+  local system_prompt
+  local user_prompt_suffix
+  if mode == "simplify" then
+    system_prompt = [[You are an expert software engineering assistant.
+Your task is to create the most compact possible summary of a coding conversation.
+Be EXTREMELY concise. Include only what an engineer MUST know to continue the work:
+- Current state of the code (what was built, changed, or fixed)
+- Exact errors or blockers still unresolved
+- The precise next step(s) remaining
+- Any critical decisions, constraints, or gotchas
+Omit all explanations, rationale, and conversational filler. Output dense, terse bullet points.]]
+    user_prompt_suffix = "\n\nProvide the minimal engineering-context summary. Use terse bullet points only."
+  else
+    system_prompt = [[You are an expert coding assistant. Your goal is to generate a concise, structured summary of the conversation below that captures all essential information needed to continue development after context replacement. Include tasks performed, code areas modified or reviewed, key decisions or assumptions, test results or errors, and outstanding tasks or next steps.]]
+    user_prompt_suffix = "\n\nPlease summarize this conversation, covering:\n1. Tasks performed and outcomes\n2. Code files, modules, or functions modified or examined\n3. Important decisions or assumptions made\n4. Errors encountered and test or build results\n5. Remaining tasks, open questions, or next steps\nProvide the summary in a clear, concise format."
+  end
+
   if #history_messages == 0 then
     cb(nil)
     return
@@ -55,9 +74,7 @@ function M.summarize_memory(prev_memory, history_messages, cb)
     :map(function(msg) return msg.message.role .. ": " .. HistoryRender.message_to_text(msg, history_messages) end)
     :totable()
   local conversation_text = table.concat(conversation_items, "\n")
-  local user_prompt = "Here is the conversation so far:\n"
-    .. conversation_text
-    .. "\n\nPlease summarize this conversation, covering:\n1. Tasks performed and outcomes\n2. Code files, modules, or functions modified or examined\n3. Important decisions or assumptions made\n4. Errors encountered and test or build results\n5. Remaining tasks, open questions, or next steps\nProvide the summary in a clear, concise format."
+  local user_prompt = "Here is the conversation so far:\n" .. conversation_text .. user_prompt_suffix
   if prev_memory then user_prompt = user_prompt .. "\n\nThe previous summary is:\n\n" .. prev_memory end
   local messages = {
     {
@@ -92,6 +109,89 @@ function M.summarize_memory(prev_memory, history_messages, cb)
             last_message_uuid = latest_message_uuid,
           }
           cb(memory)
+        else
+          cb(nil)
+        end
+      end,
+    },
+  })
+end
+
+--- Alias for `summarize_memory` with mode="simplify".
+--- Kept as a separate entry-point so call-sites remain explicit.
+---@param prev_memory string | nil
+---@param history_messages avante.HistoryMessage[]
+---@param cb fun(memory: avante.ChatMemory | nil): nil
+function M.simplify_history(prev_memory, history_messages, cb)
+  M.summarize_memory(prev_memory, history_messages, cb, "simplify")
+end
+
+--- Draft a message to send to another Avante chat instance.
+--- The LLM uses the current conversation history as context and composes a
+--- self-contained message that captures the user's intent so that the
+--- receiving instance has all the information it needs.
+---@param history_messages avante.HistoryMessage[]  current chat's history
+---@param user_intent string                        what the user wants to communicate
+---@param sender_name string                        instance name of the sending chat
+---@param target_name string                        instance name of the receiving chat
+---@param cb fun(drafted_message: string | nil): nil
+function M.draft_inter_instance_message(history_messages, user_intent, sender_name, target_name, cb)
+  local system_prompt = string.format(
+    [[You are the AI assistant for the coding chat session "%s".
+You are composing a message to send to another AI assistant session named "%s".
+Both sessions are running concurrently inside the same editor on the same codebase.
+
+Given the conversation history below and the user's stated intent, draft a clear,
+self-contained message for the receiving session.  The message must:
+- Include all context the receiving session needs (it cannot see our history)
+- Be concise but complete — the receiver will act on it directly
+- Sound like a peer-to-peer handoff, not a forwarded chat log
+
+Output ONLY the message body — no preamble, no "Here is the message:", no quotes.]],
+    sender_name,
+    target_name
+  )
+
+  local conversation_items = vim
+    .iter(history_messages)
+    :filter(function(msg) return not msg.is_dummy and not msg.just_for_display end)
+    :map(function(msg) return msg.message.role .. ": " .. HistoryRender.message_to_text(msg, history_messages) end)
+    :totable()
+  local conversation_text = table.concat(conversation_items, "\n")
+
+  local user_prompt = "Current conversation history:\n"
+    .. conversation_text
+    .. "\n\nUser's intent for the message to send:\n"
+    .. user_intent
+    .. "\n\nDraft the message to send to ["
+    .. target_name
+    .. "]:"
+
+  local messages = { { role = "user", content = user_prompt } }
+  local response_content = ""
+  local provider = Providers.get_memory_summary_provider()
+
+  M.curl({
+    provider = provider,
+    prompt_opts = {
+      system_prompt = system_prompt,
+      messages = messages,
+    },
+    handler_opts = {
+      on_start = function(_) end,
+      on_chunk = function(chunk)
+        if not chunk then return end
+        response_content = response_content .. chunk
+      end,
+      on_stop = function(stop_opts)
+        if stop_opts.error ~= nil then
+          Utils.error(string.format("draft_inter_instance_message failed: %s", vim.inspect(stop_opts.error)))
+          cb(nil)
+          return
+        end
+        if stop_opts.reason == "complete" then
+          response_content = Utils.trim_think_content(response_content)
+          cb(response_content ~= "" and response_content or nil)
         else
           cb(nil)
         end
@@ -510,6 +610,35 @@ local parse_headers = function(headers_file)
   return headers
 end
 
+--- Recursively sanitize a value so it can be safely JSON-encoded.
+--- Removes UTF-8 surrogate code points (U+D800–U+DFFF) from all strings, replacing each
+--- 3-byte surrogate sequence with the Unicode replacement character U+FFFD.
+--- `vim.json.encode` (backed by cjson) rejects strings containing surrogate bytes with
+--- "surrogates not allowed", which can happen when file content, clipboard data, or
+--- terminal output contains lone surrogate pairs encoded in modified UTF-8 (CESU-8).
+---@param value any
+---@return any
+local function sanitize_for_json(value)
+  local t = type(value)
+  if t == "string" then
+    -- UTF-8 surrogates occupy 3 bytes: 0xED [0xA0-0xBF] [0x80-0xBF]
+    -- Replace with U+FFFD (0xEF 0xBF 0xBD) to preserve string length parity.
+    return (value:gsub("\xED[\xA0-\xBF][\x80-\xBF]", "\xEF\xBF\xBD"))
+  elseif t == "table" then
+    -- Preserve vim.empty_dict() marker so cjson encodes as {} not []
+    if vim.tbl_isempty(value) and not vim.islist(value) then return vim.empty_dict() end
+    local out = {}
+    for k, v in pairs(value) do
+      out[sanitize_for_json(k)] = sanitize_for_json(v)
+    end
+    -- Preserve array vs. hash-table metatable so cjson encodes them correctly.
+    if vim.islist(value) then return vim.list_slice(out, 1) end
+    return out
+  else
+    return value
+  end
+end
+
 ---@param opts avante.CurlOpts
 function M.curl(opts)
   local provider = opts.provider
@@ -592,8 +721,16 @@ function M.curl(opts)
       raw = spec.rawArgs,
     }
   else
-    -- For regular JSON requests, encode as JSON and write to file
-    local json_content = vim.json.encode(spec.body)
+    -- For regular JSON requests, encode as JSON and write to file.
+    -- sanitize_for_json strips invalid UTF-8 surrogates that cause cjson to reject the body.
+    local ok, json_content = pcall(vim.json.encode, sanitize_for_json(spec.body))
+    if not ok then
+      Utils.error("Failed to encode request body: " .. tostring(json_content), { title = "Avante" })
+      if handler_opts.on_stop then
+        handler_opts.on_stop({ reason = "error", error = { message = "Failed to encode request body: " .. tostring(json_content) } })
+      end
+      return
+    end
     fn.writefile(vim.split(json_content, "\n"), curl_body_file)
     curl_options = {
       headers = spec.headers,
@@ -776,16 +913,6 @@ function M.curl(opts)
   })
 
   return active_job
-end
-
-local retry_timer = nil
-local abort_retry_timer = false
-local function stop_retry_timer()
-  if retry_timer then
-    retry_timer:stop()
-    pcall(function() retry_timer:close() end)
-    retry_timer = nil
-  end
 end
 
 -- Intelligently truncate chat history for session recovery to avoid token limits
@@ -1253,10 +1380,9 @@ function M._stream_acp(opts)
             end
             return
           end
-          ---@type string[]
-          local file_lines = lines or {}
-          if line ~= nil and limit ~= nil then file_lines = vim.list_slice(file_lines, line, line + limit) end
-          local content = table.concat(file_lines, "\n")
+          lines = lines or {}
+          if line ~= nil and limit ~= nil then lines = vim.list_slice(lines, line, line + limit) end
+          local content = table.concat(lines, "\n")
           if
             last_tool_call_message
             and last_tool_call_message.acp_tool_call
@@ -1751,8 +1877,25 @@ end
 
 ---@param opts AvanteLLMStreamOptions
 function M._stream(opts)
-  -- Reset the cancellation flag at the start of a new request
+  -- Initialise the per-session cancellation flag.  Using session_ctx isolates each
+  -- avante instance so that cancelling one stream does not affect concurrent streams
+  -- running in other sidebar instances.
+  opts.session_ctx = opts.session_ctx or {}
+  opts.session_ctx.is_cancelled = false
+  -- Keep the legacy global in sync for any code that still reads it directly.
   if LLMToolHelpers then LLMToolHelpers.is_cancelled = false end
+
+  -- Per-stream retry-timer state. Using per-stream locals instead of module-level
+  -- variables prevents multiple avante instances from clobbering each other's timers.
+  local retry_timer = nil
+  local stream_cancelled = false
+  local function stop_retry_timer()
+    if retry_timer then
+      retry_timer:stop()
+      pcall(function() retry_timer:close() end)
+      retry_timer = nil
+    end
+  end
 
   local acp_provider = Config.acp_providers[Config.provider]
   if acp_provider then return M._stream_acp(opts) end
@@ -1911,7 +2054,13 @@ function M._stream(opts)
         })
         if result ~= nil or error ~= nil then return handle_tool_result(result, error) end
       end
-      if stop_opts.reason == "cancelled" then dispatch_cancel_message() end
+      if stop_opts.reason == "cancelled" then
+        stream_cancelled = true -- signal any running retry countdown to stop
+        -- Per-session flag: lets process_tool_use polling detect the cancel
+        -- without touching other instances' session_ctx.
+        opts.session_ctx.is_cancelled = true
+        dispatch_cancel_message()
+      end
       local history_messages = opts.get_history_messages and opts.get_history_messages({ all = true }) or {}
       local pending_tools, pending_tool_use_messages = History.get_pending_tools(history_messages)
       if stop_opts.reason == "complete" and Config.mode == "agentic" then
@@ -1993,10 +2142,12 @@ function M._stream(opts)
         Utils.info("Rate limit reached. Retrying in " .. retry_count .. " seconds", { title = "Avante" })
 
         local function countdown()
-          if abort_retry_timer then
+          -- stream_cancelled is set to true when on_stop fires with reason "cancelled"
+          -- (triggered by the CANCEL_PATTERN autocmd from cancel_inflight_request).
+          -- dispatch_cancel_message() is already called at that point; here we just stop.
+          if stream_cancelled then
             Utils.info("Retry aborted due to user requested cancellation.")
             stop_retry_timer()
-            dispatch_cancel_message()
             return
           end
 
@@ -2168,7 +2319,6 @@ function M.stream(opts)
 
   opts.mode = opts.mode or Config.mode
 
-  abort_retry_timer = false
   if Config.dual_boost.enabled and valid_dual_boost_modes[opts.mode] then
     M._dual_boost_stream(
       opts,
@@ -2181,13 +2331,15 @@ function M.stream(opts)
 end
 
 function M.cancel_inflight_request()
-  if LLMToolHelpers.is_cancelled ~= nil then LLMToolHelpers.is_cancelled = true end
+  -- Close any open confirmation popup immediately.
   if LLMToolHelpers.confirm_popup ~= nil then
     LLMToolHelpers.confirm_popup:cancel()
     LLMToolHelpers.confirm_popup = nil
   end
-  abort_retry_timer = true
-
+  -- Fire the CANCEL_PATTERN autocmd.  Each active _stream() invocation has registered
+  -- a once-handler that (a) shuts down the curl job and (b) calls on_stop({reason="cancelled"}),
+  -- which in turn sets session_ctx.is_cancelled=true so tool-execution polling stops,
+  -- and stream_cancelled=true so any running rate-limit retry countdown stops.
   api.nvim_exec_autocmds("User", { pattern = M.CANCEL_PATTERN })
 end
 

--- a/lua/avante/llm_tools/grep.lua
+++ b/lua/avante/llm_tools/grep.lua
@@ -8,7 +8,8 @@ local M = setmetatable({}, Base)
 
 M.name = "grep"
 
-M.description = "Search for a keyword in a directory using grep in current project scope"
+M.description =
+  "Search for a pattern in files using ripgrep, returning matching lines with surrounding context. Use this to find code, definitions, and usages across the project."
 
 ---@type AvanteLLMToolParam
 M.param = {
@@ -21,8 +22,15 @@ M.param = {
     },
     {
       name = "query",
-      description = "Query to search for",
+      description = "Query to search for (supports regex)",
       type = "string",
+    },
+    {
+      name = "context_lines",
+      description = "Number of lines to show above and below each match (default 3)",
+      type = "integer",
+      default = 3,
+      optional = true,
     },
     {
       name = "case_sensitive",
@@ -47,6 +55,7 @@ M.param = {
   usage = {
     path = "Relative path to the project directory",
     query = "Query to search for",
+    context_lines = "Number of context lines above and below each match (default 3)",
     case_sensitive = "Whether to search case sensitively",
     include_pattern = "Glob pattern to include files",
     exclude_pattern = "Glob pattern to exclude files",
@@ -56,19 +65,19 @@ M.param = {
 ---@type AvanteLLMToolReturn[]
 M.returns = {
   {
-    name = "files",
-    description = "List of files that match the keyword",
+    name = "results",
+    description = "Search results with file paths, line numbers, and matching content with context",
     type = "string",
   },
   {
     name = "error",
-    description = "Error message if the directory was not searched successfully",
+    description = "Error message if the search failed",
     type = "string",
     optional = true,
   },
 }
 
----@type AvanteLLMToolFunc<{ path: string, query: string, case_sensitive?: boolean, include_pattern?: string, exclude_pattern?: string }>
+---@type AvanteLLMToolFunc<{ path: string, query: string, context_lines?: integer, case_sensitive?: boolean, include_pattern?: string, exclude_pattern?: string }>
 function M.func(input, opts)
   local on_log = opts.on_log
 
@@ -76,17 +85,23 @@ function M.func(input, opts)
   if not Helpers.has_permission_to_access(abs_path) then return "", "No permission to access path: " .. abs_path end
   if not Path:new(abs_path):exists() then return "", "No such file or directory: " .. abs_path end
 
-  ---check if any search cmd is available
+  local context_lines = input.context_lines or 3
+
+  -- Prefer ripgrep (rg), fall back to other tools
   local search_cmd = vim.fn.exepath("rg")
   if search_cmd == "" then search_cmd = vim.fn.exepath("ag") end
-  if search_cmd == "" then search_cmd = vim.fn.exepath("ack") end
   if search_cmd == "" then search_cmd = vim.fn.exepath("grep") end
-  if search_cmd == "" then return "", "No search command found" end
+  if search_cmd == "" then return "", "No search command found (rg, ag, or grep required)" end
 
-  ---execute the search command
   local cmd = {}
   if search_cmd:find("rg") then
-    cmd = { search_cmd, "--files-with-matches", "--hidden" }
+    -- ripgrep: return content with line numbers and context
+    cmd = { search_cmd, "-n", "--hidden", "--no-heading" }
+    -- Add context lines
+    if context_lines > 0 then
+      table.insert(cmd, "-C")
+      table.insert(cmd, tostring(context_lines))
+    end
     if input.case_sensitive then
       table.insert(cmd, "--case-sensitive")
     else
@@ -100,10 +115,17 @@ function M.func(input, opts)
       table.insert(cmd, "--glob")
       table.insert(cmd, "!" .. input.exclude_pattern)
     end
+    -- Limit output to avoid overwhelming context
+    table.insert(cmd, "--max-count")
+    table.insert(cmd, "50")
     table.insert(cmd, input.query)
     table.insert(cmd, abs_path)
   elseif search_cmd:find("ag") then
     cmd = { search_cmd, "--nocolor", "--nogroup", "--hidden" }
+    if context_lines > 0 then
+      table.insert(cmd, "-C")
+      table.insert(cmd, tostring(context_lines))
+    end
     if input.case_sensitive then table.insert(cmd, "--case-sensitive") end
     if input.include_pattern then
       table.insert(cmd, "--ignore")
@@ -115,19 +137,12 @@ function M.func(input, opts)
     end
     table.insert(cmd, input.query)
     table.insert(cmd, abs_path)
-  elseif search_cmd:find("ack") then
-    cmd = { search_cmd, "--nocolor", "--nogroup", "--hidden" }
-    if input.case_sensitive then table.insert(cmd, "--smart-case") end
-    if input.exclude_pattern then
-      table.insert(cmd, "--ignore-dir")
-      table.insert(cmd, input.exclude_pattern)
-    end
-    table.insert(cmd, input.query)
-    table.insert(cmd, abs_path)
   elseif search_cmd:find("grep") then
-    local files =
-      vim.system({ "git", "-C", abs_path, "ls-files", "-co", "--exclude-standard" }, { text = true }):wait().stdout
-    cmd = { "grep", "-rH" }
+    cmd = { "grep", "-rnH" }
+    if context_lines > 0 then
+      table.insert(cmd, "-C")
+      table.insert(cmd, tostring(context_lines))
+    end
     if not input.case_sensitive then table.insert(cmd, "-i") end
     if input.include_pattern then
       table.insert(cmd, "--include")
@@ -138,21 +153,23 @@ function M.func(input, opts)
       table.insert(cmd, input.exclude_pattern)
     end
     table.insert(cmd, input.query)
-    if files ~= "" then
-      for _, path in ipairs(vim.split(files, "\n")) do
-        if not path:match("^%s*$") then table.insert(cmd, vim.fs.joinpath(abs_path, path)) end
-      end
-    else
-      table.insert(cmd, abs_path)
-    end
+    table.insert(cmd, abs_path)
   end
 
   Utils.debug("cmd", table.concat(cmd, " "))
   if on_log then on_log("Running command: " .. table.concat(cmd, " ")) end
-  local result = vim.system(cmd, { text = true }):wait().stdout or ""
-  local filepaths = vim.split(result, "\n")
+  local result = vim.system(cmd, { text = true }):wait()
+  local output = result.stdout or ""
 
-  return vim.json.encode(filepaths), nil
+  -- Truncate if too large (avoid blowing up context)
+  local max_output_size = 50000
+  if #output > max_output_size then
+    output = output:sub(1, max_output_size) .. "\n\n...[output truncated, " .. #output .. " total bytes]"
+  end
+
+  if output == "" then return vim.json.encode({ matches = {}, total = 0 }), nil end
+
+  return output, nil
 end
 
 return M

--- a/lua/avante/llm_tools/helpers.lua
+++ b/lua/avante/llm_tools/helpers.lua
@@ -7,14 +7,33 @@ local M = {}
 
 M.CANCEL_TOKEN = "__CANCELLED__"
 
--- Track cancellation state
+-- Track cancellation state (legacy global — prefer session_ctx.is_cancelled for new code).
+-- This flag is kept for backward compatibility with external callers but is no longer the
+-- primary cancellation signal; per-stream session_ctx._cancel_state is used instead.
 M.is_cancelled = false
 ---@type avante.ui.Confirm
 M.confirm_popup = nil
 
+--- Check whether the current execution has been cancelled.
+--- Prefers per-stream session_ctx (set via session_ctx.is_cancelled) over the legacy global.
+---@param session_ctx? table
+---@return boolean
+function M.check_cancelled(session_ctx)
+  if session_ctx then return session_ctx.is_cancelled == true end
+  return M.is_cancelled
+end
+
+--- Clear the cancellation flag for a session without touching the global.
+---@param session_ctx? table
+function M.reset_cancelled(session_ctx)
+  if session_ctx then session_ctx.is_cancelled = false end
+  -- Intentionally does NOT reset M.is_cancelled — the global is only reset at stream start.
+end
+
 ---@param rel_path string
 ---@return string
 function M.get_abs_path(rel_path)
+  if not rel_path then error("get_abs_path: path argument is nil", 2) end
   local project_root = Utils.get_project_root()
   local p = Utils.is_absolute_path(rel_path) and rel_path or vim.fs.normalize(vim.fs.joinpath(project_root, rel_path))
   if p:sub(-2) == "/." then p = p:sub(1, -3) end

--- a/lua/avante/llm_tools/init.lua
+++ b/lua/avante/llm_tools/init.lua
@@ -105,6 +105,7 @@ function M.str_replace_based_edit_tool(input, opts)
   if not input.command then return false, "command not provided" end
   if on_log then on_log("command: " .. input.command) end
   if not on_complete then return false, "on_complete not provided" end
+  if not input.path then return false, "path not provided" end
   local abs_path = Helpers.get_abs_path(input.path)
   if not Helpers.has_permission_to_access(abs_path) then return false, "No permission to access path: " .. abs_path end
   if input.command == "view" then
@@ -1331,8 +1332,12 @@ M.run_python = M.python
 function M.process_tool_use(tools, tool_use, opts)
   local on_log = opts.on_log
   local on_complete = opts.on_complete
+  -- session_ctx carries the per-stream cancellation state (session_ctx.is_cancelled).
+  -- Helpers.check_cancelled() prefers session_ctx over the legacy global flag so that
+  -- cancelling one avante instance does not accidentally abort tool execution in another.
+  local session_ctx = opts.session_ctx or {}
   -- Check if execution is already cancelled
-  if Helpers.is_cancelled then
+  if Helpers.check_cancelled(session_ctx) then
     Utils.debug("Tool execution cancelled before starting: " .. tool_use.name)
     if on_complete then
       on_complete(nil, Helpers.CANCEL_TOKEN)
@@ -1365,13 +1370,13 @@ function M.process_tool_use(tools, tool_use, opts)
         100,
         100,
         vim.schedule_wrap(function()
-          if Helpers.is_cancelled then
+          if Helpers.check_cancelled(session_ctx) then
             Utils.debug("Tool execution cancelled during execution: " .. tool_use.name)
             if cancel_timer and not cancel_timer:is_closing() then
               cancel_timer:stop()
               cancel_timer:close()
             end
-            Helpers.is_cancelled = false
+            Helpers.reset_cancelled(session_ctx)
             on_complete(nil, Helpers.CANCEL_TOKEN)
           end
         end)
@@ -1389,7 +1394,7 @@ function M.process_tool_use(tools, tool_use, opts)
     end
 
     -- Check for cancellation one more time before processing result
-    if Helpers.is_cancelled then
+    if Helpers.check_cancelled(session_ctx) then
       if on_log then on_log(tool_use.id, tool_use.name, "cancelled during result handling", "failed") end
       return nil, Helpers.CANCEL_TOKEN
     end
@@ -1408,11 +1413,16 @@ function M.process_tool_use(tools, tool_use, opts)
     return result_str, err
   end
 
-  local result, err = func(input_json, {
-    session_ctx = opts.session_ctx or {},
+  -- Wrap the tool call in pcall so that any unhandled error is converted into a
+  -- proper tool_result error instead of crashing the stream callback.  Without
+  -- this, a crash would leave an orphaned tool_use message in history with no
+  -- matching tool_result, causing every subsequent API request to fail with an
+  -- "ids were found without tool_result blocks" error.
+  local ok, result, err = pcall(func, input_json, {
+    session_ctx = session_ctx,
     on_log = function(log)
       -- Check for cancellation during logging
-      if Helpers.is_cancelled then return end
+      if Helpers.check_cancelled(session_ctx) then return end
       if on_log then on_log(tool_use.id, tool_use.name, log, "running") end
     end,
     set_store = function(key, value)
@@ -1420,8 +1430,8 @@ function M.process_tool_use(tools, tool_use, opts)
     end,
     on_complete = function(result, err)
       -- Check for cancellation before completing
-      if Helpers.is_cancelled then
-        Helpers.is_cancelled = false
+      if Helpers.check_cancelled(session_ctx) then
+        Helpers.reset_cancelled(session_ctx)
         if on_complete then on_complete(nil, Helpers.CANCEL_TOKEN) end
         return
       end
@@ -1436,6 +1446,23 @@ function M.process_tool_use(tools, tool_use, opts)
     streaming = opts.streaming,
     tool_use_id = opts.tool_use_id,
   })
+
+  if not ok then
+    -- func threw an unhandled error; stop the cancel timer and surface the error
+    -- as a normal tool failure so the caller can record a tool_result and keep
+    -- the message history consistent.
+    local error_msg = tostring(result) -- pcall puts the error in the first return slot
+    if cancel_timer and not cancel_timer:is_closing() then
+      cancel_timer:stop()
+      cancel_timer:close()
+    end
+    if on_log then on_log(tool_use.id, tool_use.name, "Unexpected error: " .. error_msg, "failed") end
+    if on_complete then
+      on_complete(nil, "Unexpected error: " .. error_msg)
+      return
+    end
+    return nil, "Unexpected error: " .. error_msg
+  end
 
   -- Result and error being nil means that the tool was executed asynchronously
   if result == nil and err == nil and on_complete then return end

--- a/lua/avante/path.lua
+++ b/lua/avante/path.lua
@@ -3,6 +3,7 @@ local Utils = require("avante.utils")
 local Path = require("plenary.path")
 local Scan = require("plenary.scandir")
 local Config = require("avante.config")
+local Names = require("avante.utils.names")
 
 ---@class avante.Path
 ---@field history_path string
@@ -128,6 +129,7 @@ end
 ---@param bufnr integer
 function History.new(bufnr)
   local filepath = History.get_latest_filepath(bufnr, true)
+  local instance_name = Names.generate()
   ---@type avante.ChatHistory
   local history = {
     title = "untitled",
@@ -136,6 +138,8 @@ function History.new(bufnr)
     messages = {},
     todos = {},
     filename = filepath_to_filename(filepath),
+    instance_id = Utils.uuid(),
+    instance_name = instance_name,
   }
   return history
 end
@@ -157,6 +161,14 @@ function History.from_file(filepath)
         if not vim.islist(history.todos) then history.todos = {} end
         ---@cast history avante.ChatHistory
         history.filename = filepath_to_filename(filepath)
+        -- Backfill instance_id / instance_name for histories created before this feature.
+        if not history.instance_id or history.instance_id == "" then history.instance_id = Utils.uuid() end
+        if not history.instance_name or history.instance_name == "" then
+          history.instance_name = Names.generate()
+        else
+          -- Register the persisted name so the collision table stays accurate.
+          Names.register(history.instance_name)
+        end
         return history
       end
     end
@@ -173,12 +185,43 @@ function History.load(bufnr, filename)
   return History.from_file(history_filepath) or History.new(bufnr)
 end
 
+--- Recursively strip UTF-8 surrogate code points (CESU-8: 0xED [0xA0-0xBF] [0x80-0xBF])
+--- from all string values in `value`, replacing each 3-byte sequence with U+FFFD.
+--- This prevents cjson from rejecting the JSON with "surrogates not allowed" when
+--- file content or tool results contain characters encoded in modified UTF-8.
+---@param value any
+---@return any
+local function deep_sanitize_utf8(value)
+  local t = type(value)
+  if t == "string" then
+    return (value:gsub("\xED[\xA0-\xBF][\x80-\xBF]", "\xEF\xBF\xBD"))
+  elseif t == "table" then
+    local out = {}
+    for k, v in pairs(value) do
+      out[deep_sanitize_utf8(k)] = deep_sanitize_utf8(v)
+    end
+    if vim.islist(value) then return vim.list_slice(out, 1) end
+    return out
+  else
+    return value
+  end
+end
+
 -- Saves the chat history for the given buffer.
 ---@param bufnr integer
 ---@param history avante.ChatHistory
 function History.save(bufnr, history)
   local history_filepath = History.get_filepath(bufnr, history.filename)
-  history_filepath:write(vim.json.encode(history), "w")
+  -- Sanitize surrogate code points before encoding so that history files
+  -- remain valid UTF-8 JSON even when tool results or file contents contain
+  -- CESU-8 / modified-UTF-8 surrogate bytes.
+  local ok, json_content = pcall(vim.json.encode, deep_sanitize_utf8(history))
+  if not ok then
+    -- Fallback: encode without sanitization (better to save something than nothing)
+    ok, json_content = pcall(vim.json.encode, history)
+    if not ok then return end
+  end
+  history_filepath:write(json_content, "w")
   History.save_latest_filename(bufnr, history.filename)
 end
 
@@ -295,8 +338,7 @@ function Prompt.get_templates_dir(project_root)
   -- get root directory of given bufnr
   local directory = Path:new(project_root)
   if Utils.get_os_name() == "windows" then
-    local win_path = vim.fs.abspath(tostring(directory)):gsub("^%a:", ""):gsub("^[/\\]+", "")
-    directory = Path:new(vim.fs.normalize(win_path))
+    directory = Path:new(vim.fs.abspath(tostring(directory)):gsub("^%a:", ""))
   end
   local cache_prompt_dir = Path:new(P.cache_path):joinpath(directory)
   if not cache_prompt_dir:exists() then cache_prompt_dir:mkdir({ parents = true }) end

--- a/lua/avante/providers/claude.lua
+++ b/lua/avante/providers/claude.lua
@@ -235,6 +235,19 @@ function M:get_rate_limit_sleep_time(headers)
   return Utils.datetime_diff(tostring(now), tostring(reset_dt))
 end
 
+-- Models that do not support the temperature parameter.
+-- Claude 4+ generation models (new naming: claude-{tier}-{version}) deprecate temperature entirely.
+local function is_temperature_unsupported(model)
+  if not model then return false end
+  -- Claude 4+ models use new naming convention: claude-{tier}-{major}[-{minor}]-{date}
+  -- e.g. claude-opus-4-20250514, claude-sonnet-4-5-20250929, claude-sonnet-4-20250514
+  -- Also handles bedrock/vertex prefixed names like us.anthropic.claude-opus-4-*
+  if model:match("claude%-opus%-[4-9]") then return true end
+  if model:match("claude%-sonnet%-[4-9]") then return true end
+  if model:match("claude%-haiku%-[4-9]") then return true end
+  return false
+end
+
 -- Prefix for tool names when using OAuth to avoid Anthropic's tool name validation
 local OAUTH_TOOL_PREFIX = "av_"
 
@@ -252,7 +265,11 @@ function M:transform_tool(tool, use_prefix)
   local input_schema_properties, required = Utils.llm_tool_param_fields_to_json_schema(tool.param.fields)
   local tool_name = tool.name
   if use_prefix then tool_name = OAUTH_TOOL_PREFIX .. tool.name end
-  return {
+  -- Ensure properties is always a JSON object (not array) even when empty
+  if not input_schema_properties or vim.tbl_isempty(input_schema_properties) then
+    input_schema_properties = vim.empty_dict()
+  end
+  local tool_def = {
     name = tool_name,
     description = tool.get_description and tool.get_description() or tool.description,
     input_schema = {
@@ -261,6 +278,9 @@ function M:transform_tool(tool, use_prefix)
       required = required,
     },
   }
+  -- OAuth/claude-code beta requires discriminated tool type
+  if use_prefix then tool_def.type = "custom" end
+  return tool_def
 end
 
 function M:is_disable_stream() return false end
@@ -660,18 +680,23 @@ function M:parse_curl_args(prompt_opts)
   local api_path = "/v1/messages"
   if provider_conf.auth_type == "max" then api_path = "/v1/messages?beta=true" end
 
+  local body = vim.tbl_deep_extend("force", {
+    model = provider_conf.model,
+    system = system,
+    messages = messages,
+    tools = tools,
+    stream = true,
+  }, request_body)
+
+  -- Strip temperature for models that don't support it (e.g. Opus 4 with always-on thinking)
+  if is_temperature_unsupported(provider_conf.model) then body.temperature = nil end
+
   return {
     url = Utils.url_join(provider_conf.endpoint, api_path),
     proxy = provider_conf.proxy,
     insecure = provider_conf.allow_insecure,
     headers = Utils.tbl_override(headers, self.extra_headers),
-    body = vim.tbl_deep_extend("force", {
-      model = provider_conf.model,
-      system = system,
-      messages = messages,
-      tools = tools,
-      stream = true,
-    }, request_body),
+    body = body,
   }
 end
 
@@ -692,7 +717,8 @@ function M.on_error(result)
   if error_type == "insufficient_quota" then
     error_msg = "You don't have any credits or have exceeded your quota. Please check your plan and billing details."
   elseif error_type == "invalid_request_error" and error_msg:match("temperature") then
-    error_msg = "Invalid temperature value. Please ensure it's between 0 and 1."
+    error_msg = error_msg
+      .. " Try removing 'temperature' from your provider's extra_request_body config."
   end
 
   Utils.error(error_msg, { once = true, title = "Avante" })
@@ -930,6 +956,7 @@ function M.cleanup_claude()
   if M._file_watcher then
     ---@diagnostic disable-next-line: param-type-mismatch
     M._file_watcher:stop()
+    pcall(function() M._file_watcher:close() end)
     M._file_watcher = nil
   end
 end

--- a/lua/avante/providers/openai.lua
+++ b/lua/avante/providers/openai.lua
@@ -24,6 +24,10 @@ function M:is_disable_stream() return false end
 ---@return AvanteOpenAITool
 function M:transform_tool(tool)
   local input_schema_properties, required = Utils.llm_tool_param_fields_to_json_schema(tool.param.fields)
+  -- Ensure properties is always a JSON object (not array) even when empty
+  if not input_schema_properties or vim.tbl_isempty(input_schema_properties) then
+    input_schema_properties = vim.empty_dict()
+  end
   ---@type AvanteOpenAIToolFunctionParameters
   local parameters = {
     type = "object",

--- a/lua/avante/providers/vertex_claude.lua
+++ b/lua/avante/providers/vertex_claude.lua
@@ -64,6 +64,12 @@ function M:parse_curl_args(prompt_opts)
     tools = tools,
   })
 
+  -- Strip temperature for models that don't support it (e.g. Claude 4+ with always-on thinking)
+  local model = provider_conf.model or ""
+  if model:match("claude%-opus%-[4-9]") or model:match("claude%-sonnet%-[4-9]") or model:match("claude%-haiku%-[4-9]") then
+    request_body.temperature = nil
+  end
+
   return {
     url = url,
     headers = Utils.tbl_override({

--- a/lua/avante/sidebar.lua
+++ b/lua/avante/sidebar.lua
@@ -124,6 +124,8 @@ local SIDEBAR_CONTAINERS = {
 ---@field containers { result?: NuiSplit, todos?: NuiSplit, selected_code?: NuiSplit, selected_files?: NuiSplit, input?: NuiSplit }
 ---@field file_selector FileSelector
 ---@field chat_history avante.ChatHistory | nil
+---@field current_history_filename string | nil Tracks which history file this sidebar is using; prevents concurrent instances from hijacking each other's session via the shared metadata.json pointer.
+---@field _chat_history_mtime integer | nil Disk mtime (seconds) of the history file at the last load/save; used to detect concurrent writes from other Avante instances.
 ---@field current_state avante.GenerateState | nil
 ---@field state_timer table | nil
 ---@field state_spinner_chars string[]
@@ -170,6 +172,13 @@ function Sidebar:new(id)
     file_selector = FileSelector:new(id),
     is_generating = false,
     chat_history = nil,
+    -- Tracks which history file THIS sidebar instance is using so that two
+    -- Avante instances open on the same project do not steal each other's
+    -- session when one of them saves or creates a new chat.
+    current_history_filename = nil,
+    -- mtime (seconds) of the history file as it was when last loaded or saved
+    -- by THIS instance. Used to detect concurrent writes from other instances.
+    _chat_history_mtime = nil,
     current_state = nil,
     state_timer = nil,
     state_spinner_chars = Config.windows.spinner.generating,
@@ -229,6 +238,12 @@ function Sidebar:reset()
   self.current_tool_use_extmark_id = nil
   self.win_size_store = {}
   self.is_in_full_view = false
+  -- Clear the pinned history filename so that initialize() → reload_chat_history()
+  -- reads from metadata.json for whatever project/buffer is opened next.
+  -- The per-session isolation guarantee (two tabs on the same project not
+  -- stealing each other's history) is preserved because each tab has its own
+  -- Sidebar instance and reset() is never called on another tab's sidebar.
+  self.current_history_filename = nil
 end
 
 ---@class SidebarOpenOptions: AskOptions
@@ -1120,7 +1135,9 @@ end
 
 function Sidebar:render_result()
   if not Utils.is_valid_container(self.containers.result) then return end
+  local instance_name = self.chat_history and self.chat_history.instance_name
   local header_text = Utils.icon("󰭻 ") .. "Avante"
+  if instance_name then header_text = header_text .. " [" .. instance_name .. "]" end
   self:render_header(
     self.containers.result.winid,
     self.containers.result.bufnr,
@@ -2014,6 +2031,18 @@ function Sidebar:_get_message_lines(ctx, message, messages, ignore_record_prefix
     return res
   end
   if message.message.role == "user" then
+    -- Cross-instance messages are rendered with a special "← From <name>" header
+    -- instead of the standard "> " user prefix.
+    if message.from_instance then
+      local from_label = "← From [" .. message.from_instance .. "]"
+      local res = { Line:new({ { from_label } }) }
+      for _, line_ in ipairs(lines) do
+        local sections = { { "> " } }
+        sections = vim.list_extend(sections, line_.sections)
+        table.insert(res, Line:new(sections))
+      end
+      return res
+    end
     local res = {}
     for _, line_ in ipairs(lines) do
       local sections = { { "> " } }
@@ -2350,8 +2379,127 @@ function Sidebar:compact_history_messages(args, cb)
   end)
 end
 
+--- /simplify command: run all history messages through the model with an
+--- aggressive prompt that distils only the information an engineer needs to
+--- continue the work.  The result replaces the chat memory so that old
+--- messages are hidden from subsequent API calls.
+function Sidebar:simplify_history_messages(args, cb)
+  local history_memory = self.chat_history.memory
+  local messages = History.get_history_messages(self.chat_history)
+  self.current_state = "compacting"
+  self:render_state()
+  self:update_content(
+    "simplifying history …",
+    { focus = false, scroll = true, callback = function() self:focus_input() end }
+  )
+  Llm.simplify_history(history_memory and history_memory.content, messages, function(memory)
+    if memory then
+      self.chat_history.memory = memory
+      Path.history.save(self.code.bufnr, self.chat_history)
+    end
+    self:update_content(
+      "simplified!",
+      { focus = false, scroll = true, callback = function() self:focus_input() end }
+    )
+    self.current_state = "compacted"
+    self:clear_state()
+    if cb then cb(args) end
+  end)
+end
+
+--- /send <instance_name> <intent> command: ask the current conversation's model
+--- to draft a message for another active Avante instance based on the user's
+--- intent and the current conversation context, then deliver that drafted
+--- message to the target instance.  The message appears in the receiver's chat
+--- with a "← From [name]" header, but is stored as a plain user message so
+--- the API receives valid turn order.
+---@param args string   e.g. "swift-fox tell them about the auth bug we found"
+---@param cb? fun(args: string): nil
+function Sidebar:send_message_to_instance(args, cb)
+  local target_name, user_intent = args:match("^(%S+)%s+(.*)")
+  if not target_name or not user_intent or user_intent == "" then
+    self:update_content(
+      "Usage: /send <instance-name> <message intent>\n"
+        .. "The current chat will draft the message based on conversation context.",
+      { focus = false, scroll = false, callback = function() self:focus_input() end }
+    )
+    if cb then cb(args) end
+    return
+  end
+
+  local Avante = require("avante")
+  local target_sidebar = Avante.instance_registry[target_name]
+  if not target_sidebar then
+    self:update_content(
+      "Instance not found: " .. target_name .. "\nAvailable: " .. table.concat(
+        vim.tbl_keys(Avante.instance_registry),
+        ", "
+      ),
+      { focus = false, scroll = false, callback = function() self:focus_input() end }
+    )
+    if cb then cb(args) end
+    return
+  end
+
+  local sender_name = self.chat_history and self.chat_history.instance_name or "unknown"
+  local history_messages = History.get_history_messages(self.chat_history)
+
+  -- Show drafting status in the current instance.
+  self.current_state = "generating"
+  self:render_state()
+  self:update_content(
+    "drafting message to [" .. target_name .. "] …",
+    { focus = false, scroll = false, callback = function() self:focus_input() end }
+  )
+
+  -- Ask the current conversation's model to draft the message.
+  Llm.draft_inter_instance_message(history_messages, user_intent, sender_name, target_name, function(drafted)
+    self.current_state = nil
+    self:clear_state()
+
+    if not drafted or drafted == "" then
+      self:update_content(
+        "Failed to draft message to [" .. target_name .. "]",
+        { focus = false, scroll = false, callback = function() self:focus_input() end }
+      )
+      if cb then cb(args) end
+      return
+    end
+
+    -- Inject the LLM-drafted message into the target sidebar as a user message
+    -- tagged with `from_instance` so the renderer shows the special header.
+    local injected = History.Message:new("user", drafted, {
+      from_instance = sender_name,
+      is_user_submission = false,
+      visible = true,
+    })
+    target_sidebar:add_history_messages({ injected })
+    target_sidebar:save_history()
+    -- Force the target sidebar to re-render so the new message is visible.
+    if Utils.is_valid_container(target_sidebar.containers.result, true) then
+      pcall(function() target_sidebar:update_content_with_history() end)
+    end
+
+    self:update_content(
+      "Message sent to [" .. target_name .. "]",
+      { focus = false, scroll = false, callback = function() self:focus_input() end }
+    )
+    if cb then cb(args) end
+  end)
+end
+
 function Sidebar:new_chat(args, cb)
   local history = Path.history.new(self.code.bufnr)
+  local Avante = require("avante")
+  -- Eagerly update the instance registry so other sidebars can find the new
+  -- name immediately, before the save → reload cycle completes.
+  if self.chat_history and self.chat_history.instance_name then
+    Avante.instance_registry[self.chat_history.instance_name] = nil
+  end
+  if history.instance_name then Avante.instance_registry[history.instance_name] = self end
+  -- Pin this sidebar to the new file BEFORE saving so reload_chat_history()
+  -- uses the correct file and doesn't read a stale metadata.json value.
+  self.current_history_filename = history.filename
   Path.history.save(self.code.bufnr, history)
   self:reload_chat_history()
   self.current_state = nil
@@ -2368,7 +2516,7 @@ function Sidebar:new_chat(args, cb)
 end
 
 local debounced_save_history = Utils.debounce(
-  function(self) Path.history.save(self.code.bufnr, self.chat_history) end,
+  function(self) self:_save_chat_history() end,
   1000
 )
 
@@ -2605,8 +2753,99 @@ end
 function Sidebar:reload_chat_history()
   self.token_count = nil
   if not self.code.bufnr or not api.nvim_buf_is_valid(self.code.bufnr) then return end
-  self.chat_history = Path.history.load(self.code.bufnr)
+
+  local Avante = require("avante")
+  -- Deregister the old instance name before loading the new history so that
+  -- stale entries don't accumulate across /new cycles.
+  if self.chat_history and self.chat_history.instance_name then
+    Avante.instance_registry[self.chat_history.instance_name] = nil
+  end
+
+  -- Load the specific file this sidebar is pinned to (if any), so that a
+  -- concurrent Avante instance saving to the shared metadata.json cannot
+  -- hijack this sidebar's history.
+  self.chat_history = Path.history.load(self.code.bufnr, self.current_history_filename)
+
+  -- Isolation guard: if the history we just loaded is already owned by a
+  -- *different* live sidebar, fork to a fresh independent history.  This
+  -- prevents two Avante windows that share the same source buffer from
+  -- inheriting the same chat timeline, and guarantees each window gets a
+  -- unique instance_name for cross-instance messaging.
+  if self.chat_history and self.chat_history.instance_name then
+    local existing_owner = Avante.instance_registry[self.chat_history.instance_name]
+    if existing_owner ~= nil and existing_owner ~= self then
+      -- The loaded history is already in use — branch off to a fresh session.
+      -- The fresh history is intentionally not saved here; it will be written
+      -- to disk the first time the user sends a message (via save_history()).
+      local fresh = Path.history.new(self.code.bufnr)
+      self.chat_history = fresh
+      self.current_history_filename = fresh.filename
+      self._chat_history_mtime = nil -- no disk file yet; suppress false conflicts
+    end
+  end
+
+  -- Pin ourselves to whatever file we now hold so future reloads stay on the
+  -- same file even if another instance updates metadata.json.
+  if self.chat_history then self.current_history_filename = self.chat_history.filename end
+  -- Record the disk mtime so _save_chat_history() can detect concurrent writes.
+  -- Skip if mtime was already cleared above (fresh-history branch).
+  if self._chat_history_mtime == nil and self.current_history_filename then
+    local fp = Path.history.get_filepath(self.code.bufnr, self.current_history_filename)
+    local stat = vim.uv.fs_stat(tostring(fp))
+    self._chat_history_mtime = stat and stat.mtime.sec or nil
+  end
+  -- Register this sidebar under its (now-unique) instance name.
+  if self.chat_history and self.chat_history.instance_name then
+    Avante.instance_registry[self.chat_history.instance_name] = self
+  end
   self._history_cache_invalidated = true
+  -- Update the result header to reflect the (possibly new) instance name.
+  vim.schedule(function() self:render_result() end)
+end
+
+--- Save self.chat_history to disk, forking to a new file first when a
+--- concurrent Avante instance (in another Neovim process) has modified the
+--- file since we last loaded or saved it.  This prevents two instances that
+--- both open the same "latest" history file from overwriting each other's
+--- messages.
+function Sidebar:_save_chat_history()
+  if not self.chat_history or not self.code.bufnr then return end
+
+  -- Conflict detection: if the file on disk has a newer mtime than the one
+  -- we recorded, someone else wrote to it.  Fork to a fresh file so our
+  -- session is independent going forward.
+  if self.current_history_filename and self._chat_history_mtime then
+    local fp = Path.history.get_filepath(self.code.bufnr, self.current_history_filename)
+    local stat = vim.uv.fs_stat(tostring(fp))
+    local disk_mtime = stat and stat.mtime.sec or nil
+    if disk_mtime and disk_mtime ~= self._chat_history_mtime then
+      -- Another instance wrote to our file.  Branch to a new file that carries
+      -- our in-memory messages so both sessions stay independent.
+      local new_stub = Path.history.new(self.code.bufnr)
+      -- Copy all relevant fields from the current in-memory history.
+      new_stub.title = self.chat_history.title
+      new_stub.timestamp = self.chat_history.timestamp
+      new_stub.entries = self.chat_history.entries
+      new_stub.messages = self.chat_history.messages
+      new_stub.todos = self.chat_history.todos
+      if self.chat_history.memory then new_stub.memory = self.chat_history.memory end
+      if self.chat_history.system_prompt then new_stub.system_prompt = self.chat_history.system_prompt end
+      if self.chat_history.tokens_usage then new_stub.tokens_usage = self.chat_history.tokens_usage end
+      if self.chat_history.acp_session_id then new_stub.acp_session_id = self.chat_history.acp_session_id end
+      self.chat_history = new_stub
+      self.current_history_filename = new_stub.filename
+      self._chat_history_mtime = nil -- will be set after the save below
+    end
+  end
+
+  Path.history.save(self.code.bufnr, self.chat_history)
+
+  -- Update the stored mtime so the NEXT conflict check has a fresh baseline.
+  if self.current_history_filename then
+    local fp = Path.history.get_filepath(self.code.bufnr, self.current_history_filename)
+    local stat = vim.uv.fs_stat(tostring(fp))
+    self._chat_history_mtime = stat and stat.mtime.sec or nil
+  end
 end
 
 ---@param opts? {all?: boolean}
@@ -2728,6 +2967,123 @@ function Sidebar:get_generate_prompts_options(request, cb)
       fields = { { name = "rel_path", description = "Relative path to the file", type = "string" } },
     },
     returns = {},
+  })
+
+  -- Build the sender name now so the closure captures the current value.
+  local sender_name = self.chat_history and self.chat_history.instance_name or "unknown"
+
+  table.insert(tools, {
+    name = "send_message",
+    description = string.format(
+      [[Send a message to another active Avante instance.
+
+⚠️  IMPORTANT: Only use this tool when:
+1. The user EXPLICITLY asks you to send a message to another instance, OR
+2. You have received a message FROM another instance (shown with a "← From [name]" header) and the user wants you to reply.
+
+Do NOT proactively contact other instances on your own initiative.
+
+YOUR instance name: [%s]
+
+To see available target instances call this tool with action="list". Then call it again with action="send" to deliver the message.
+
+When action="send":
+- "target_instance": the exact name of the destination instance (e.g. "swift-fox")
+- "message": the fully-composed text to deliver — be concise and contextual]],
+      sender_name
+    ),
+    ---@type AvanteLLMToolFunc<{ action: "list"|"send", target_instance?: string, message?: string }>
+    func = function(input, opts)
+      local Avante = require("avante")
+      if input.action == "list" then
+        local names = vim.tbl_keys(Avante.instance_registry)
+        -- Exclude self from the list so the model doesn't try to message itself.
+        names = vim.iter(names):filter(function(n) return n ~= sender_name end):totable()
+        if #names == 0 then return "No other active Avante instances found.", nil end
+        return "Active instances: " .. table.concat(names, ", "), nil
+      end
+
+      if input.action == "send" then
+        local target_name = input.target_instance
+        local message_text = input.message
+        if not target_name or target_name == "" then return nil, "target_instance is required" end
+        if not message_text or message_text == "" then return nil, "message is required" end
+
+        local target_sidebar = Avante.instance_registry[target_name]
+        if not target_sidebar then
+          local available = table.concat(
+            vim.iter(vim.tbl_keys(Avante.instance_registry))
+              :filter(function(n) return n ~= sender_name end)
+              :totable(),
+            ", "
+          )
+          return nil,
+            string.format(
+              "Instance '%s' not found. Available: %s",
+              target_name,
+              available ~= "" and available or "(none)"
+            )
+        end
+
+        if target_sidebar == self then return nil, "Cannot send a message to yourself" end
+
+        local on_log = opts.on_log
+        if on_log then on_log(string.format("sending to [%s]: %s", target_name, message_text:sub(1, 80))) end
+
+        local injected = History.Message:new("user", message_text, {
+          from_instance = sender_name,
+          is_user_submission = false,
+          visible = true,
+        })
+        target_sidebar:add_history_messages({ injected })
+        target_sidebar:save_history()
+        if Utils.is_valid_container(target_sidebar.containers.result, true) then
+          pcall(function() target_sidebar:update_content_with_history() end)
+        end
+
+        return string.format("Message delivered to [%s].", target_name), nil
+      end
+
+      return nil, "Unknown action '" .. tostring(input.action) .. "'. Use 'list' or 'send'."
+    end,
+    param = {
+      type = "table",
+      fields = {
+        {
+          name = "action",
+          description = "'list' to see available instances, 'send' to deliver a message",
+          type = "string",
+        },
+        {
+          name = "target_instance",
+          description = "The name of the destination instance (required when action='send')",
+          type = "string",
+          optional = true,
+        },
+        {
+          name = "message",
+          description = "The message text to deliver (required when action='send')",
+          type = "string",
+          optional = true,
+        },
+      },
+      usage = {
+        action = "list",
+      },
+    },
+    returns = {
+      {
+        name = "result",
+        description = "Confirmation or list of available instances",
+        type = "string",
+      },
+      {
+        name = "error",
+        description = "Error message if the send failed",
+        type = "string",
+        optional = true,
+      },
+    },
   })
 
   local selected_filepaths = self.file_selector.selected_filepaths or {}
@@ -2982,10 +3338,9 @@ function Sidebar:handle_submit(request)
       end,
       set_tool_use_store = set_tool_use_store,
       get_history_messages = function(opts) return self:get_history_messages_for_api(opts) end,
-      get_todos = function()
-        local history = Path.history.load(self.code.bufnr)
-        return history.todos
-      end,
+      -- Use in-memory todos to avoid a disk read that could race with another
+      -- Avante instance and return a different session's todos.
+      get_todos = function() return self.chat_history and self.chat_history.todos or {} end,
       update_todos = function(todos) self:update_todos(todos) end,
       session_ctx = {},
       ---@param usage avante.LLMTokenUsage
@@ -3230,8 +3585,10 @@ function Sidebar:get_selected_code_container_height()
 end
 
 function Sidebar:get_todos_container_height()
-  local history = Path.history.load(self.code.bufnr)
-  if #history.todos == 0 then return 0 end
+  -- Use the in-memory chat_history to avoid a disk read that could return a
+  -- different instance's file via the shared metadata.json pointer.
+  local todos = self.chat_history and self.chat_history.todos or {}
+  if #todos == 0 then return 0 end
   return 3
 end
 
@@ -3338,6 +3695,10 @@ function Sidebar:render(opts)
           if not self.code.winid or not api.nvim_win_is_valid(self.code.winid) then return end
           local bufnr = api.nvim_win_get_buf(self.code.winid)
           self.code.bufnr = bufnr
+          -- The code buffer changed (different project/root), so let
+          -- reload_chat_history() pick up the correct file from metadata.json
+          -- for the new buffer rather than staying pinned to the old file.
+          self.current_history_filename = nil
           self:reload_chat_history()
         end)
       end,
@@ -3531,7 +3892,9 @@ function Sidebar:create_selected_files_container()
 end
 
 function Sidebar:create_todos_container()
-  local history = Path.history.load(self.code.bufnr)
+  -- Use in-memory history to avoid loading from disk (which would follow
+  -- the shared metadata.json and could pull in another instance's file).
+  local history = self.chat_history or Path.history.load(self.code.bufnr, self.current_history_filename)
   if #history.todos == 0 then
     if self.containers.todos and Utils.is_valid_container(self.containers.todos) then
       self.containers.todos:unmount()

--- a/lua/avante/slashcommands.lua
+++ b/lua/avante/slashcommands.lua
@@ -11,9 +11,11 @@
 --- - `/clear`: clear chat history
 --- - `/new`: start a new chat
 --- - `/compact`: compact history messages
+--- - `/simplify`: aggressively simplify chat history, keeping only critical engineering context
 --- - `/model`: select model
 --- - `/lines <start>-<end> <question>`: ask about specific lines
 --- - `/commit`: generate a commit message
+--- - `/send <instance-name> <message>`: send a message to another Avante instance
 ---@brief ]]
 
 ---@class avante.SlashCommands
@@ -49,6 +51,11 @@ local builtin_commands = {
     name = "compact",
   },
   {
+    description = "Maximally simplify history, keeping only critical engineering context",
+    details = "Maximally simplify history, keeping only critical engineering context",
+    name = "simplify",
+  },
+  {
     description = "Select model",
     details = "Select model",
     name = "model",
@@ -63,6 +70,12 @@ local builtin_commands = {
     description = "Commit the changes",
     details = "Commit the changes",
     name = "commit",
+  },
+  {
+    shorthelp = "Send a message to another Avante instance",
+    description = "/send <instance-name> <intent>",
+    details = "Ask the current chat's model to draft and send a message to another active Avante instance\n/send <instance-name> <what to communicate>",
+    name = "send",
   },
 }
 
@@ -85,6 +98,7 @@ local callbacks = {
   clear = function(sidebar, args, cb) sidebar:clear_history(args, cb) end,
   new = function(sidebar, args, cb) sidebar:new_chat(args, cb) end,
   compact = function(sidebar, args, cb) sidebar:compact_history_messages(args, cb) end,
+  simplify = function(sidebar, args, cb) sidebar:simplify_history_messages(args, cb) end,
   init = function(sidebar, args, cb) sidebar:init_current_project(args, cb) end,
   lines = function(_, args, cb)
     if cb then cb(args) end
@@ -103,6 +117,7 @@ local callbacks = {
     end
     if cb then cb("") end
   end,
+  send = function(sidebar, args, cb) sidebar:send_message_to_instance(args, cb) end,
 }
 
 ---@return AvanteSlashCommand[]

--- a/lua/avante/types.lua
+++ b/lua/avante/types.lua
@@ -118,7 +118,8 @@ vim.g.avante_login = vim.g.avante_login
 ---@field turn_id string | nil
 ---@field is_calling boolean | nil
 ---@field original_content AvanteLLMMessageContent | nil
----@field acp_tool_call? avante.acp.ToolCall | avante.acp.ToolCallUpdate
+---@field acp_tool_call? avante.acp.ToolCall
+---@field from_instance string | nil   -- instance_name of the sending chat (cross-instance message)
 
 ---@class AvanteLLMToolResult
 ---@field tool_name string
@@ -526,6 +527,8 @@ vim.g.avante_login = vim.g.avante_login
 ---@field system_prompt string | nil
 ---@field tokens_usage avante.LLMTokenUsage | nil
 ---@field acp_session_id string | nil
+---@field instance_id string | nil   -- UUID for this chat session
+---@field instance_name string | nil -- human-readable name (e.g. "swift-fox")
 ---
 ---@class avante.ChatMemory
 ---@field content string
@@ -542,7 +545,7 @@ vim.g.avante_login = vim.g.avante_login
 ---@field content string
 ---@field uri string
 ---
----@alias AvanteSlashCommandBuiltInName "clear" | "help" | "lines" | "commit" | "new" | "init" | "compact" | "model"
+---@alias AvanteSlashCommandBuiltInName "clear" | "help" | "lines" | "commit" | "new" | "init" | "compact" | "model" | "simplify" | "send"
 ---@alias AvanteSlashCommandCallback fun(self: avante.Sidebar, args: string, cb?: fun(args: string): nil): nil
 ---@class AvanteSlashCommand
 ---@field name AvanteSlashCommandBuiltInName | string

--- a/lua/avante/utils/init.lua
+++ b/lua/avante/utils/init.lua
@@ -101,8 +101,8 @@ local function get_cmd_for_shell(input_cmd, shell_cmd)
     cmd = { "powershell.exe", "-NoProfile", "-Command", input_cmd:gsub('"', "'") }
   else
     -- linux and macos we will just do sh -c
-    local effective_shell_cmd = shell_cmd or "sh -c"
-    for _, cmd_part in ipairs(vim.split(effective_shell_cmd, " ")) do
+    shell_cmd = shell_cmd or "sh -c"
+    for _, cmd_part in ipairs(vim.split(shell_cmd, " ")) do
       table.insert(cmd, cmd_part)
     end
     table.insert(cmd, input_cmd)
@@ -1524,6 +1524,8 @@ function M.llm_tool_param_fields_to_json_schema(fields)
   for _, field in ipairs(fields) do
     if field.type == "object" and field.fields then
       local properties_, required_ = M.llm_tool_param_fields_to_json_schema(field.fields)
+      -- Ensure nested properties is always a JSON object, not array
+      if vim.tbl_isempty(properties_) then properties_ = vim.empty_dict() end
       properties[field.name] = {
         type = field.type,
         description = field.get_description and field.get_description() or field.description,

--- a/lua/avante/utils/names.lua
+++ b/lua/avante/utils/names.lua
@@ -1,0 +1,73 @@
+---@mod avante-names avante instance name generation
+---@brief [[
+--- Generates human-readable, memorable names for Avante chat instances.
+--- Each name is an adjective + noun combination chosen at random.
+---@brief ]]
+
+local M = {}
+
+-- Word lists for generating friendly instance names.
+local adjectives = {
+  "amber", "azure", "bold", "bright", "calm", "cedar", "cobalt", "cool",
+  "crisp", "cyan", "dark", "deep", "dim", "dusk", "fern", "firm", "flame",
+  "free", "frost", "gold", "jade", "keen", "light", "lime", "mist", "mint",
+  "moon", "moss", "navy", "noir", "oak", "pale", "pine", "pure", "quick",
+  "rose", "ruby", "sage", "salt", "sand", "silk", "slim", "snow", "soft",
+  "solar", "steel", "storm", "swift", "teal", "warm", "wild", "wise",
+}
+
+local nouns = {
+  "arc", "ash", "bay", "beam", "bell", "brook", "crest", "crow", "dawn",
+  "dune", "elm", "fern", "field", "finch", "fjord", "flame", "flare", "fox",
+  "gale", "glen", "grove", "hawk", "hill", "jade", "kite", "lake", "lark",
+  "leaf", "lynx", "marsh", "moon", "oak", "owl", "peak", "pine", "pond",
+  "raven", "reef", "ridge", "rift", "river", "rock", "seal", "sky", "spark",
+  "stone", "stream", "tide", "vale", "wave", "wren",
+}
+
+--- Registry of all names currently in use to avoid collisions.
+---@type table<string, boolean>
+local used_names = {}
+
+--- Generate a unique adjective-noun instance name.
+--- If a collision occurs the noun is suffixed with a counter (e.g. "swift-fox-2").
+---@return string
+function M.generate()
+  math.randomseed(os.time() + math.random(1000))
+  local max_attempts = 20
+  for _ = 1, max_attempts do
+    local adj = adjectives[math.random(#adjectives)]
+    local noun = nouns[math.random(#nouns)]
+    local name = adj .. "-" .. noun
+    if not used_names[name] then
+      used_names[name] = true
+      return name
+    end
+  end
+  -- Fallback: append a random number to guarantee uniqueness.
+  local adj = adjectives[math.random(#adjectives)]
+  local noun = nouns[math.random(#nouns)]
+  local counter = 2
+  local candidate = adj .. "-" .. noun .. "-" .. counter
+  while used_names[candidate] do
+    counter = counter + 1
+    candidate = adj .. "-" .. noun .. "-" .. counter
+  end
+  used_names[candidate] = true
+  return candidate
+end
+
+--- Mark a name as in use (for names loaded from persisted history).
+---@param name string
+function M.register(name)
+  if name and name ~= "" then used_names[name] = true end
+end
+
+--- Release a name so it may be reused.
+---@param name string
+function M.release(name)
+  if name and name ~= "" then used_names[name] = nil end
+end
+
+return M
+

--- a/lua/avante/utils/path.lua
+++ b/lua/avante/utils/path.lua
@@ -16,6 +16,7 @@ function M.is_win() return IS_WIN end
 ---@param filepath                      string
 ---@return boolean
 function M.is_absolute(filepath)
+  if not filepath then return false end
   if IS_WIN then return #filepath > 1 and string.byte(filepath, 2, 2) == BYTE_COLON end
   return string.byte(filepath, 1, 1) == BYTE_PATHSEP
 end


### PR DESCRIPTION
- claude/vertex_claude: strip temperature for Claude 4+ models (always-on thinking)
- claude: improve temperature error message to hint at extra_request_body removal
- openai: ensure empty tool parameter schemas encode as {} not []
- utils/init: same empty-properties fix for nested tool schema objects
- llm: replace module-level retry timer with per-stream locals to prevent concurrent Avante instances from clobbering each other's rate-limit state
- llm: per-stream session_ctx.is_cancelled flag isolates cancellation across sidebar instances; cancel_inflight_request fires autocmd to let each stream handle its own shutdown
- llm: wrap JSON encoding in pcall with sanitize_for_json() to strip CESU-8 surrogate bytes that cause cjson "surrogates not allowed" errors
- path: same surrogate sanitization for chat-history saves; fix Windows path normalisation (preserve leading drive letter separator)
- llm_tools/helpers: add check_cancelled/reset_cancelled helpers that prefer session_ctx over legacy global; nil-guard get_abs_path input
- llm_tools/init: use check_cancelled/reset_cancelled throughout process_tool_use; wrap tool calls in pcall so unhandled errors produce a tool_result instead of orphaning tool_use messages in history
- llm_tools/grep: prefer ripgrep, add context_lines param, return content with line numbers instead of just file paths
- sidebar: pin each Sidebar instance to a specific history file so concurrent Avante windows don't hijack each other's session via shared metadata.json; add mtime-based conflict detection that forks to a new file on concurrent write; use in-memory todos to avoid racy disk reads
- api: pin sidebar to user-selected history file on history switch
- utils/path.lua: nil-guard is_absolute to avoid crash on nil filepath