### PR TITLE
fix(acp): avoid stale client state

### DIFF
--- a/lua/avante/libs/acp_client.lua
+++ b/lua/avante/libs/acp_client.lua
@@ -253,7 +253,7 @@ local LOG_SEPARATOR = string.rep("=", 80) .. "\n"
 ---@class ACPConfig
 ---@field transport_type "stdio" | "websocket" | "tcp"
 ---@field command? string Command to spawn agent (for stdio)
----@field args? string[] Arguments for agent command
+---@field args string[] Arguments for agent command
 ---@field env? table Environment variables
 ---@field host? string Host for tcp/websocket
 ---@field port? number Port for tcp/websocket
@@ -394,7 +394,7 @@ function ACPClient:_create_stdio_transport()
       error("Failed to create pipes for ACP agent")
     end
 
-    local args = vim.deepcopy(self.config.args or {})
+    local args = vim.deepcopy(self.config.args)
     local env = self.config.env
 
     -- Start with system environment and override with config env

--- a/lua/avante/llm.lua
+++ b/lua/avante/llm.lua
@@ -981,6 +981,18 @@ function M._stream_acp(opts)
   end
   local acp_client = opts.acp_client
   local session_id = opts.acp_session_id
+  local acp_client_config = acp_client and acp_client.config
+  local is_same_acp_command_invocation = acp_client_config
+    and acp_client_config.command == acp_provider.command
+    and vim.deep_equal(acp_client_config.args, acp_provider.args)
+  if acp_client and not is_same_acp_command_invocation then
+    Utils.debug("reset stale ACP client", acp_client_config and acp_client_config.command, acp_provider.command)
+    pcall(function() acp_client:stop() end)
+    acp_client = nil
+    session_id = nil
+    opts.acp_client = nil
+    opts.acp_session_id = nil
+  end
   if not acp_client then
     local acp_config = vim.tbl_deep_extend("force", acp_provider, {
       ---@type ACPHandlers

--- a/lua/avante/sidebar.lua
+++ b/lua/avante/sidebar.lua
@@ -147,6 +147,17 @@ local SIDEBAR_CONTAINERS = {
 local Sidebar = {}
 Sidebar.__index = Sidebar
 
+---@param acp_client avante.acp.ACPClient | nil
+---@param provider avante.ProviderName
+---@return avante.acp.ConfigOption[]
+local function get_acp_config_options(acp_client, provider)
+  local acp_provider = Config.acp_providers[provider]
+  if not acp_provider or not acp_client or not acp_client.config_options then return {} end
+  if not acp_client.config or acp_client.config.command ~= acp_provider.command then return {} end
+  if not vim.deep_equal(acp_client.config.args, acp_provider.args) then return {} end
+  return acp_client.config_options
+end
+
 ---@class avante.CodeState
 ---@field winid integer
 ---@field bufnr integer
@@ -1073,11 +1084,9 @@ function Sidebar:render_header(winid, bufnr, header_text, hl, reverse_hl, opts)
   if opts.include_model and Config.windows.sidebar_header.include_model then
     if Config.acp_providers[Config.provider] then
       local parts = { Config.provider }
-      if self.acp_client and self.acp_client.config_options then
-        for _, opt in ipairs(self.acp_client.config_options) do
-          if opt.category == "model" then table.insert(parts, opt.currentValue) end
-          if opt.category == "mode" then table.insert(parts, opt.currentValue) end
-        end
+      for _, opt in ipairs(get_acp_config_options(self.acp_client, Config.provider)) do
+        if opt.category == "model" then table.insert(parts, opt.currentValue) end
+        if opt.category == "mode" then table.insert(parts, opt.currentValue) end
       end
       model_name = table.concat(parts, " | ")
     else
@@ -2241,6 +2250,7 @@ function Sidebar:clear_history(args, cb)
   if next(self.chat_history) ~= nil then
     self.chat_history.messages = {}
     self.chat_history.entries = {}
+    self.chat_history.acp_session_id = nil
     Path.history.save(self.code.bufnr, self.chat_history)
     self._history_cache_invalidated = true
     self:reload_chat_history()
@@ -2401,11 +2411,9 @@ function Sidebar:add_history_messages(messages, opts)
     if message.is_user_submission then
       message.provider = Config.provider
       if Config.acp_providers[Config.provider] then
-        if self.acp_client and self.acp_client.config_options then
-          for _, opt in ipairs(self.acp_client.config_options) do
-            if opt.category == "model" then message.model = opt.currentValue end
-            if opt.category == "mode" then message.mode = opt.currentValue end
-          end
+        for _, opt in ipairs(get_acp_config_options(self.acp_client, Config.provider)) do
+          if opt.category == "model" then message.model = opt.currentValue end
+          if opt.category == "mode" then message.mode = opt.currentValue end
         end
       else
         message.model = Config.get_provider_config(Config.provider).model


### PR DESCRIPTION
Fixes stale ACP state after switching providers or clearing chat history.

Previously, the sidebar could keep reusing `self.acp_client` and `chat_history.acp_session_id` after the selected ACP provider changed. This could make the next request go through the previously selected ACP provider, and could also show stale model/mode values from that provider in the chat history header.

## This fix

1. Uses the existing ACP command invocation (`command` + `args`) to detect stale ACP clients.
2. Resets the cached ACP client/session when the current ACP provider changes.
3. Ignores model/mode config options from a stale ACP client.
4. Clears the stored ACP session id when chat history is cleared.

Fixes #3102

## Test

- `nix develop --command make luastylecheck`
- `nix develop --command make lua-typecheck`
- `nix develop --command make luatest`

## Manual test

- Switched ACP providers between `claude-code` and `codex`.
- Verified each request was handled by the selected ACP provider.
- Switched back from `codex` to `claude-code` and verified stale Codex model/mode values were not shown for Claude Code.
- Ran `/clear` and confirmed `chat_history.acp_session_id` became `nil`.
- Confirmed the next request did not reuse the cleared ACP context.

## Results

<img width="1074" height="1948" alt="image" src="https://github.com/user-attachments/assets/d5d927c1-5d1c-4435-9796-5209c2c529ec" />
