### PR TITLE
fix: provider API compatibility and tool schema robustness

### DIFF
--- a/lua/avante/providers/claude.lua
+++ b/lua/avante/providers/claude.lua
@@ -236,8 +236,12 @@ function M:get_rate_limit_sleep_time(headers)
 end
 
 -- Models that do not support the temperature parameter.
--- Claude 4+ generation models (new naming: claude-{tier}-{version}) deprecate temperature entirely.
-local function is_temperature_unsupported(model)
+-- Claude 4+ generation models (new naming: claude-{tier}-{version}) use always-on extended thinking,
+-- which is incompatible with the temperature parameter (API hard error if sent).
+-- See: https://docs.anthropic.com/en/docs/build-with-claude/extended-thinking#important-considerations
+---@param model string|nil
+---@return boolean
+function M.is_temperature_unsupported(model)
   if not model then return false end
   -- Claude 4+ models use new naming convention: claude-{tier}-{major}[-{minor}]-{date}
   -- e.g. claude-opus-4-20250514, claude-sonnet-4-5-20250929, claude-sonnet-4-20250514
@@ -265,10 +269,6 @@ function M:transform_tool(tool, use_prefix)
   local input_schema_properties, required = Utils.llm_tool_param_fields_to_json_schema(tool.param.fields)
   local tool_name = tool.name
   if use_prefix then tool_name = OAUTH_TOOL_PREFIX .. tool.name end
-  -- Ensure properties is always a JSON object (not array) even when empty
-  if not input_schema_properties or vim.tbl_isempty(input_schema_properties) then
-    input_schema_properties = vim.empty_dict()
-  end
   local tool_def = {
     name = tool_name,
     description = tool.get_description and tool.get_description() or tool.description,
@@ -277,9 +277,9 @@ function M:transform_tool(tool, use_prefix)
       properties = input_schema_properties,
       required = required,
     },
+    -- OAuth/claude-code beta requires discriminated tool type
+    type = use_prefix and "custom" or nil,
   }
-  -- OAuth/claude-code beta requires discriminated tool type
-  if use_prefix then tool_def.type = "custom" end
   return tool_def
 end
 
@@ -689,7 +689,7 @@ function M:parse_curl_args(prompt_opts)
   }, request_body)
 
   -- Strip temperature for models that don't support it (e.g. Opus 4 with always-on thinking)
-  if is_temperature_unsupported(provider_conf.model) then body.temperature = nil end
+  if M.is_temperature_unsupported(provider_conf.model) then body.temperature = nil end
 
   return {
     url = Utils.url_join(provider_conf.endpoint, api_path),
@@ -718,7 +718,9 @@ function M.on_error(result)
     error_msg = "You don't have any credits or have exceeded your quota. Please check your plan and billing details."
   elseif error_type == "invalid_request_error" and error_msg:match("temperature") then
     error_msg = error_msg
-      .. " Try removing 'temperature' from your provider's extra_request_body config."
+      .. "\nPossible fixes:"
+      .. "\n  - Remove 'temperature' from your provider's extra_request_body config"
+      .. "\n  - Ensure the temperature value is between 0 and 1"
   end
 
   Utils.error(error_msg, { once = true, title = "Avante" })

--- a/lua/avante/providers/claude.lua
+++ b/lua/avante/providers/claude.lua
@@ -235,6 +235,19 @@ function M:get_rate_limit_sleep_time(headers)
   return Utils.datetime_diff(tostring(now), tostring(reset_dt))
 end
 
+-- Models that do not support the temperature parameter.
+-- Claude 4+ generation models (new naming: claude-{tier}-{version}) deprecate temperature entirely.
+local function is_temperature_unsupported(model)
+  if not model then return false end
+  -- Claude 4+ models use new naming convention: claude-{tier}-{major}[-{minor}]-{date}
+  -- e.g. claude-opus-4-20250514, claude-sonnet-4-5-20250929, claude-sonnet-4-20250514
+  -- Also handles bedrock/vertex prefixed names like us.anthropic.claude-opus-4-*
+  if model:match("claude%-opus%-[4-9]") then return true end
+  if model:match("claude%-sonnet%-[4-9]") then return true end
+  if model:match("claude%-haiku%-[4-9]") then return true end
+  return false
+end
+
 -- Prefix for tool names when using OAuth to avoid Anthropic's tool name validation
 local OAUTH_TOOL_PREFIX = "av_"
 
@@ -252,7 +265,11 @@ function M:transform_tool(tool, use_prefix)
   local input_schema_properties, required = Utils.llm_tool_param_fields_to_json_schema(tool.param.fields)
   local tool_name = tool.name
   if use_prefix then tool_name = OAUTH_TOOL_PREFIX .. tool.name end
-  return {
+  -- Ensure properties is always a JSON object (not array) even when empty
+  if not input_schema_properties or vim.tbl_isempty(input_schema_properties) then
+    input_schema_properties = vim.empty_dict()
+  end
+  local tool_def = {
     name = tool_name,
     description = tool.get_description and tool.get_description() or tool.description,
     input_schema = {
@@ -261,6 +278,9 @@ function M:transform_tool(tool, use_prefix)
       required = required,
     },
   }
+  -- OAuth/claude-code beta requires discriminated tool type
+  if use_prefix then tool_def.type = "custom" end
+  return tool_def
 end
 
 function M:is_disable_stream() return false end
@@ -660,18 +680,23 @@ function M:parse_curl_args(prompt_opts)
   local api_path = "/v1/messages"
   if provider_conf.auth_type == "max" then api_path = "/v1/messages?beta=true" end
 
+  local body = vim.tbl_deep_extend("force", {
+    model = provider_conf.model,
+    system = system,
+    messages = messages,
+    tools = tools,
+    stream = true,
+  }, request_body)
+
+  -- Strip temperature for models that don't support it (e.g. Opus 4 with always-on thinking)
+  if is_temperature_unsupported(provider_conf.model) then body.temperature = nil end
+
   return {
     url = Utils.url_join(provider_conf.endpoint, api_path),
     proxy = provider_conf.proxy,
     insecure = provider_conf.allow_insecure,
     headers = Utils.tbl_override(headers, self.extra_headers),
-    body = vim.tbl_deep_extend("force", {
-      model = provider_conf.model,
-      system = system,
-      messages = messages,
-      tools = tools,
-      stream = true,
-    }, request_body),
+    body = body,
   }
 end
 
@@ -692,7 +717,8 @@ function M.on_error(result)
   if error_type == "insufficient_quota" then
     error_msg = "You don't have any credits or have exceeded your quota. Please check your plan and billing details."
   elseif error_type == "invalid_request_error" and error_msg:match("temperature") then
-    error_msg = "Invalid temperature value. Please ensure it's between 0 and 1."
+    error_msg = error_msg
+      .. " Try removing 'temperature' from your provider's extra_request_body config."
   end
 
   Utils.error(error_msg, { once = true, title = "Avante" })
@@ -930,6 +956,7 @@ function M.cleanup_claude()
   if M._file_watcher then
     ---@diagnostic disable-next-line: param-type-mismatch
     M._file_watcher:stop()
+    pcall(function() M._file_watcher:close() end)
     M._file_watcher = nil
   end
 end

--- a/lua/avante/providers/openai.lua
+++ b/lua/avante/providers/openai.lua
@@ -24,10 +24,6 @@ function M:is_disable_stream() return false end
 ---@return AvanteOpenAITool
 function M:transform_tool(tool)
   local input_schema_properties, required = Utils.llm_tool_param_fields_to_json_schema(tool.param.fields)
-  -- Ensure properties is always a JSON object (not array) even when empty
-  if not input_schema_properties or vim.tbl_isempty(input_schema_properties) then
-    input_schema_properties = vim.empty_dict()
-  end
   ---@type AvanteOpenAIToolFunctionParameters
   local parameters = {
     type = "object",

--- a/lua/avante/providers/openai.lua
+++ b/lua/avante/providers/openai.lua
@@ -24,6 +24,10 @@ function M:is_disable_stream() return false end
 ---@return AvanteOpenAITool
 function M:transform_tool(tool)
   local input_schema_properties, required = Utils.llm_tool_param_fields_to_json_schema(tool.param.fields)
+  -- Ensure properties is always a JSON object (not array) even when empty
+  if not input_schema_properties or vim.tbl_isempty(input_schema_properties) then
+    input_schema_properties = vim.empty_dict()
+  end
   ---@type AvanteOpenAIToolFunctionParameters
   local parameters = {
     type = "object",

--- a/lua/avante/providers/vertex_claude.lua
+++ b/lua/avante/providers/vertex_claude.lua
@@ -64,6 +64,12 @@ function M:parse_curl_args(prompt_opts)
     tools = tools,
   })
 
+  -- Strip temperature for models that don't support it (e.g. Claude 4+ with always-on thinking)
+  local model = provider_conf.model or ""
+  if model:match("claude%-opus%-[4-9]") or model:match("claude%-sonnet%-[4-9]") or model:match("claude%-haiku%-[4-9]") then
+    request_body.temperature = nil
+  end
+
   return {
     url = url,
     headers = Utils.tbl_override({

--- a/lua/avante/providers/vertex_claude.lua
+++ b/lua/avante/providers/vertex_claude.lua
@@ -65,10 +65,7 @@ function M:parse_curl_args(prompt_opts)
   })
 
   -- Strip temperature for models that don't support it (e.g. Claude 4+ with always-on thinking)
-  local model = provider_conf.model or ""
-  if model:match("claude%-opus%-[4-9]") or model:match("claude%-sonnet%-[4-9]") or model:match("claude%-haiku%-[4-9]") then
-    request_body.temperature = nil
-  end
+  if P.claude.is_temperature_unsupported(provider_conf.model) then request_body.temperature = nil end
 
   return {
     url = url,

--- a/lua/avante/utils/init.lua
+++ b/lua/avante/utils/init.lua
@@ -101,8 +101,8 @@ local function get_cmd_for_shell(input_cmd, shell_cmd)
     cmd = { "powershell.exe", "-NoProfile", "-Command", input_cmd:gsub('"', "'") }
   else
     -- linux and macos we will just do sh -c
-    shell_cmd = shell_cmd or "sh -c"
-    for _, cmd_part in ipairs(vim.split(shell_cmd, " ")) do
+    local effective_shell_cmd = shell_cmd or "sh -c"
+    for _, cmd_part in ipairs(vim.split(effective_shell_cmd, " ")) do
       table.insert(cmd, cmd_part)
     end
     table.insert(cmd, input_cmd)

--- a/lua/avante/utils/init.lua
+++ b/lua/avante/utils/init.lua
@@ -101,8 +101,8 @@ local function get_cmd_for_shell(input_cmd, shell_cmd)
     cmd = { "powershell.exe", "-NoProfile", "-Command", input_cmd:gsub('"', "'") }
   else
     -- linux and macos we will just do sh -c
-    local effective_shell_cmd = shell_cmd or "sh -c"
-    for _, cmd_part in ipairs(vim.split(effective_shell_cmd, " ")) do
+    shell_cmd = shell_cmd or "sh -c"
+    for _, cmd_part in ipairs(vim.split(shell_cmd, " ")) do
       table.insert(cmd, cmd_part)
     end
     table.insert(cmd, input_cmd)
@@ -1524,6 +1524,8 @@ function M.llm_tool_param_fields_to_json_schema(fields)
   for _, field in ipairs(fields) do
     if field.type == "object" and field.fields then
       local properties_, required_ = M.llm_tool_param_fields_to_json_schema(field.fields)
+      -- Ensure nested properties is always a JSON object, not array
+      if vim.tbl_isempty(properties_) then properties_ = vim.empty_dict() end
       properties[field.name] = {
         type = field.type,
         description = field.get_description and field.get_description() or field.description,


### PR DESCRIPTION
## Summary

- **Claude 4+ temperature**: Strip the `temperature` parameter for Claude Opus 4, Sonnet 4, and Haiku 4 models, which use always-on extended thinking and reject `temperature` with a hard API error. Works for both the `claude` and `vertex_claude` providers. Also improves the temperature validation error message to hint users to remove it from `extra_request_body`.
- **Empty tool schemas as `{}`**: When a tool has no parameters, `input_schema.properties` must be a JSON object (`{}`) not an array (`[]`). Fixed for Claude, Vertex Claude, and OpenAI providers, and also for nested object properties in `utils/init.lua`.
- **Shell command fix**: Minor variable shadowing fix in `get_cmd_for_shell` (Linux/macOS path).

## Test plan
- [ ] Configure a Claude 4 model (e.g. `claude-opus-4.5`) and confirm no temperature error
- [ ] Add a tool with no parameters and confirm the API request succeeds
