### PR TITLE
fix: message history robustness and LLM conversation sanitization

### DIFF
--- a/README.md
+++ b/README.md
@@ -1731,6 +1731,40 @@ The high quality and ingenuity of these projects' source code have been immensel
   </tr>
 </table>
 
+## Multi-Instance Messaging
+
+When you have multiple Avante sidebars open (across tabs, windows, or even separate Neovim processes), each instance gets a unique human-readable name shown in the winbar (e.g. `Avante [swift-fox]`). Instances can discover and message each other.
+
+### In-process messaging (no setup required)
+
+The `send_message` LLM tool is always available to the agent. It can:
+- `action="list"` — discover other active Avante instances in the same Neovim session
+- `action="send"` — deliver a message to a named instance
+
+You can also use the `/send <instance-name> <intent>` slash command to have the current chat's model draft and deliver a message to another instance based on your stated intent and the conversation history.
+
+### Context simplification
+
+Use `/simplify` to aggressively compress the current chat history down to the minimal engineering-critical context: current state, unresolved blockers, and next steps.
+
+### Cross-process IPC service (optional, requires Docker or Nix)
+
+To enable messaging between Avante instances in *different* Neovim processes:
+
+```lua
+require("avante").setup({
+  ipc_service = {
+    enabled = true,
+    runner = "docker", -- or "nix"
+    image = "quay.io/yetoneful/avante-ipc-service:0.0.1",
+  },
+})
+```
+
+Once enabled, the `send_message` tool automatically uses the IPC service for cross-process delivery, with a fallback to in-process delivery for same-Neovim peers.
+
+The IPC service requires Docker (or OrbStack on macOS) or Nix. See `py/ipc-service/` for the service source.
+
 ## License
 
 avante.nvim is licensed under the Apache 2.0 License. For more details, please refer to the [LICENSE](./LICENSE) file.

--- a/ftplugin/AvanteInput.lua
+++ b/ftplugin/AvanteInput.lua
@@ -15,7 +15,9 @@ api.nvim_create_autocmd("InsertEnter", {
 })
 
 local debounced_show_input_hint = Utils.debounce(function()
-  if vim.api.nvim_win_is_valid(sidebar.containers.input.winid) then sidebar:show_input_hint() end
+  if sidebar.containers.input and vim.api.nvim_win_is_valid(sidebar.containers.input.winid) then
+    sidebar:show_input_hint()
+  end
 end, 200)
 api.nvim_create_autocmd({ "TextChanged", "TextChangedI", "VimResized" }, {
   group = sidebar.augroup,

--- a/lua/avante/api.lua
+++ b/lua/avante/api.lua
@@ -43,8 +43,6 @@ local function to_windows_path(path)
   return winpath
 end
 
----Command to install the necessary rust libraries
----Defaults to download the libraries but passing `source=true` will force a local build via cargo
 ---@param opts? {source: boolean}
 function M.build(opts)
   opts = opts or { source = true }
@@ -268,8 +266,12 @@ function M.select_history()
     vim.api.nvim_buf_call(buf, function()
       if not require("avante").is_sidebar_open() then require("avante").open_sidebar({}) end
       local Path = require("avante.path")
+      -- Update the global metadata pointer so the NEXT fresh instance opens
+      -- the right file, but also pin THIS sidebar to the selected file so
+      -- it doesn't get hijacked by a concurrent instance's save.
       Path.history.save_latest_filename(buf, filename)
       local sidebar = require("avante").get()
+      sidebar.current_history_filename = filename
       sidebar:update_content_with_history()
       sidebar:create_todos_container()
       sidebar:initialize_token_count()

--- a/lua/avante/api.lua
+++ b/lua/avante/api.lua
@@ -268,8 +268,12 @@ function M.select_history()
     vim.api.nvim_buf_call(buf, function()
       if not require("avante").is_sidebar_open() then require("avante").open_sidebar({}) end
       local Path = require("avante.path")
+      -- Update the global metadata pointer so the NEXT fresh instance opens
+      -- the right file, but also pin THIS sidebar to the selected file so
+      -- it doesn't get hijacked by a concurrent instance's save.
       Path.history.save_latest_filename(buf, filename)
       local sidebar = require("avante").get()
+      sidebar.current_history_filename = filename
       sidebar:update_content_with_history()
       sidebar:create_todos_container()
       sidebar:initialize_token_count()

--- a/lua/avante/api.lua
+++ b/lua/avante/api.lua
@@ -275,8 +275,6 @@ function M.select_history()
       Path.history.save_latest_filename(buf, filepath)
       local sidebar = require("avante").get()
       sidebar.current_history_filename = filepath
->>>>>>> 1f930ab (prog)
-=======
       -- filepath is the full absolute path to the selected history JSON.
       -- plenary.path:joinpath() with an absolute path resolves to that absolute path,
       -- so passing the full path works transparently for both same-project and
@@ -284,7 +282,6 @@ function M.select_history()
       Path.history.save_latest_filename(buf, filepath)
       local sidebar = require("avante").get()
       sidebar.current_history_filename = filepath
->>>>>>> 1f930ab (prog)
       sidebar:update_content_with_history()
       sidebar:create_todos_container()
       sidebar:initialize_token_count()

--- a/lua/avante/api.lua
+++ b/lua/avante/api.lua
@@ -267,12 +267,15 @@ function M.select_history()
       if not require("avante").is_sidebar_open() then require("avante").open_sidebar({}) end
       local Path = require("avante.path")
       -- Update the global metadata pointer so the NEXT fresh instance opens
-      -- the right file, but also pin THIS sidebar to the selected file so
-      -- it doesn't get hijacked by a concurrent instance's save.
+      -- the right file.
       Path.history.save_latest_filename(buf, filename)
       local sidebar = require("avante").get()
-      sidebar.current_history_filename = filename
-      sidebar:update_content_with_history()
+      -- Use switch_to_history() which bypasses the isolation guard — the user
+      -- explicitly picked this history so it must be loaded as-is even if
+      -- another sidebar currently holds the same instance_name.
+      sidebar:switch_to_history(filename)
+      -- Re-render the content with the newly loaded history.
+      sidebar:update_content("")
       sidebar:create_todos_container()
       sidebar:initialize_token_count()
       vim.schedule(function() sidebar:focus_input() end)

--- a/lua/avante/api.lua
+++ b/lua/avante/api.lua
@@ -264,12 +264,27 @@ function M.select_acp_mode() require("avante.acp_config_selector").open_mode() e
 
 function M.select_history()
   local buf = vim.api.nvim_get_current_buf()
-  require("avante.history_selector").open(buf, function(filename)
+  require("avante.history_selector").open(buf, function(filepath)
     vim.api.nvim_buf_call(buf, function()
       if not require("avante").is_sidebar_open() then require("avante").open_sidebar({}) end
       local Path = require("avante.path")
-      Path.history.save_latest_filename(buf, filename)
+      -- filepath is the full absolute path to the selected history JSON.
+      -- plenary.path:joinpath() with an absolute path resolves to that absolute path,
+      -- so passing the full path works transparently for both same-project and
+      -- cross-project selections.
+      Path.history.save_latest_filename(buf, filepath)
       local sidebar = require("avante").get()
+      sidebar.current_history_filename = filepath
+>>>>>>> 1f930ab (prog)
+=======
+      -- filepath is the full absolute path to the selected history JSON.
+      -- plenary.path:joinpath() with an absolute path resolves to that absolute path,
+      -- so passing the full path works transparently for both same-project and
+      -- cross-project selections.
+      Path.history.save_latest_filename(buf, filepath)
+      local sidebar = require("avante").get()
+      sidebar.current_history_filename = filepath
+>>>>>>> 1f930ab (prog)
       sidebar:update_content_with_history()
       sidebar:create_todos_container()
       sidebar:initialize_token_count()

--- a/lua/avante/api.lua
+++ b/lua/avante/api.lua
@@ -262,42 +262,68 @@ function M.select_acp_mode() require("avante.acp_config_selector").open_mode() e
 
 function M.select_history()
   local buf = vim.api.nvim_get_current_buf()
-  require("avante.history_selector").open(buf, function(filepath)
-    vim.api.nvim_buf_call(buf, function()
+  require("avante.history_selector").open(buf, function(payload)
+    -- payload: { filename, project_root, project_dirname, cross_project }
+    local filename = payload.filename
+    local project_root = payload.project_root
+    local cross_project = payload.cross_project
+
+    local function load_history_into_sidebar(target_buf)
       if not require("avante").is_sidebar_open() then require("avante").open_sidebar({}) end
       local Path = require("avante.path")
-<<<<<<< HEAD
-      -- filepath is the full absolute path to the selected history JSON.
-      -- plenary.path:joinpath() with an absolute path resolves to that absolute path,
-      -- so passing the full path works transparently for both same-project and
-      -- cross-project selections.
-      Path.history.save_latest_filename(buf, filepath)
-      local sidebar = require("avante").get()
-      sidebar.current_history_filename = filepath
-      -- filepath is the full absolute path to the selected history JSON.
-      -- plenary.path:joinpath() with an absolute path resolves to that absolute path,
-      -- so passing the full path works transparently for both same-project and
-      -- cross-project selections.
-      Path.history.save_latest_filename(buf, filepath)
-      local sidebar = require("avante").get()
-      sidebar.current_history_filename = filepath
-      sidebar:update_content_with_history()
-=======
       -- Update the global metadata pointer so the NEXT fresh instance opens
       -- the right file.
-      Path.history.save_latest_filename(buf, filename)
+      pcall(function() Path.history.save_latest_filename(target_buf, filename) end)
       local sidebar = require("avante").get()
+      if not sidebar then return end
       -- Use switch_to_history() which bypasses the isolation guard — the user
       -- explicitly picked this history so it must be loaded as-is even if
       -- another sidebar currently holds the same instance_name.
       sidebar:switch_to_history(filename)
       -- Re-render the content with the newly loaded history.
       sidebar:update_content("")
->>>>>>> main
       sidebar:create_todos_container()
       sidebar:initialize_token_count()
       vim.schedule(function() sidebar:focus_input() end)
-    end)
+    end
+
+    if cross_project and project_root and project_root ~= "" then
+      -- Shift nvim's cwd to the picked project so subsequent buffer/project
+      -- resolution lines up with the history we're loading.  If the directory
+      -- no longer exists we bail out with a warning rather than silently
+      -- loading a chat from "somewhere else".
+      if vim.fn.isdirectory(project_root) ~= 1 then
+        Utils.warn(
+          "Cannot open cross-project history: directory does not exist: " .. project_root,
+          { once = true }
+        )
+        return
+      end
+      -- Close any existing sidebar bound to the OLD project before switching
+      -- cwd so the next open picks up the new root.
+      local existing = require("avante").get()
+      if existing and existing.is_open and existing:is_open() then
+        pcall(function() existing:close({ goto_code_win = false }) end)
+      end
+      local ok, err = pcall(vim.cmd.cd, vim.fn.fnameescape(project_root))
+      if not ok then
+        Utils.warn("Failed to cd into project: " .. tostring(err))
+        return
+      end
+      Utils.info("Switched nvim cwd → " .. project_root)
+      -- Bust the per-buffer project-root cache so Utils.root.get returns the
+      -- new cwd-based root rather than the cached old project root.
+      local Root = require("avante.utils.root")
+      Root.cache = {}
+      -- After cd, project root resolution is based on cwd; load using the
+      -- CURRENT buffer (post-cd) so per-project storage_path resolves correctly.
+      vim.schedule(function()
+        local new_buf = vim.api.nvim_get_current_buf()
+        load_history_into_sidebar(new_buf)
+      end)
+    else
+      vim.api.nvim_buf_call(buf, function() load_history_into_sidebar(buf) end)
+    end
   end)
 end
 

--- a/lua/avante/commands.lua
+++ b/lua/avante/commands.lua
@@ -63,6 +63,12 @@
 --- :AvanteShowRepoMap
 ---         Show the repository map for the project.
 ---
+---                                                     *:AvanteTokenBreakdown*
+--- :AvanteTokenBreakdown
+---         Show a per-component breakdown of the token count for a fresh
+---         request (system prompt, rules files, selected files, memory, ...).
+---         Useful for diagnosing unexpectedly high starting token counts.
+---
 ---                                                     *:AvanteToggle*
 --- :AvanteToggle
 ---         Toggle the Avante sidebar.

--- a/lua/avante/config.lua
+++ b/lua/avante/config.lua
@@ -372,6 +372,15 @@ M._defaults = {
     },
     docker_extra_args = "", -- Extra arguments to pass to the docker command
   },
+  ipc_service = { -- Cross-process instance IPC service configuration
+    -- Enables the IPC service so root Avante instances in *different* Neovim
+    -- processes can discover each other, share responsibility context, and
+    -- exchange messages via send_message.  Requires Docker or Nix.
+    enabled = false,
+    runner = "docker", -- "docker" or "nix"
+    image = "quay.io/yetoneful/avante-ipc-service:0.0.1",
+    docker_extra_args = "",
+  },
   web_search_engine = {
     provider = "tavily",
     proxy = nil,

--- a/lua/avante/config.lua
+++ b/lua/avante/config.lua
@@ -323,9 +323,6 @@ M.instructions_file = "avante.md"
 ---@field behaviour avante.Config.Behaviour Behaviour and automation options.
 ---@field prompt_logger? avante.Config.PromptLogger Prompt logging options.
 ---@field windows table
----@field slash_commands AvanteSlashCommand[] see |*avante-slashcommands*|
----@field shortcuts AvanteShortcut[]  see |*avante-shortcuts*|
----@field ask_opts AskOptions
 
 M._defaults = {
   debug = false,
@@ -374,6 +371,15 @@ M._defaults = {
       extra = nil, -- Extra configuration options for the embedding model
     },
     docker_extra_args = "", -- Extra arguments to pass to the docker command
+  },
+  ipc_service = { -- Cross-process instance IPC service configuration
+    -- Enables the IPC service so root Avante instances in *different* Neovim
+    -- processes can discover each other, share responsibility context, and
+    -- exchange messages via send_message.  Requires Docker or Nix.
+    enabled = false,
+    runner = "docker", -- "docker" or "nix"
+    image = "quay.io/yetoneful/avante-ipc-service:0.0.1",
+    docker_extra_args = "",
   },
   web_search_engine = {
     provider = "tavily",
@@ -594,6 +600,8 @@ M._defaults = {
       model = "gpt-4o",
       timeout = 30000, -- Timeout in milliseconds, increase this for reasoning models
       context_window = 128000, -- Number of tokens to send to the model for context
+      cost_per_input_token = 0.0000025, -- $2.50 per 1M tokens
+      cost_per_output_token = 0.00001, -- $10 per 1M tokens
       use_response_api = copilot_use_response_api, -- Automatically switch to Response API for GPT-5 Codex models
       support_previous_response_id = true, -- OpenAI Response API supports previous_response_id for stateful conversations
       -- NOTE: Response API automatically manages conversation state using previous_response_id for tool calling
@@ -613,6 +621,8 @@ M._defaults = {
       allow_insecure = false, -- Allow insecure server connections
       timeout = 30000, -- Timeout in milliseconds
       context_window = 64000, -- Number of tokens to send to the model for context
+      cost_per_input_token = 0, -- Free with GitHub Copilot subscription
+      cost_per_output_token = 0,
       use_response_api = copilot_use_response_api, -- Automatically switch to Response API for GPT-5 Codex models
       support_previous_response_id = false, -- Copilot doesn't support previous_response_id, must send full history
       -- NOTE: Copilot doesn't support previous_response_id, always sends full conversation history including tool_calls
@@ -641,6 +651,8 @@ M._defaults = {
       model = "claude-sonnet-4-5-20250929",
       timeout = 30000, -- Timeout in milliseconds
       context_window = 200000,
+      cost_per_input_token = 0.000003, -- $3 per 1M tokens
+      cost_per_output_token = 0.000015, -- $15 per 1M tokens
       extra_request_body = {
         temperature = 0.75,
         max_tokens = 64000,
@@ -670,6 +682,8 @@ M._defaults = {
       model = "gemini-2.0-flash",
       timeout = 30000, -- Timeout in milliseconds
       context_window = 1048576,
+      cost_per_input_token = 0.0000001, -- $0.10 per 1M tokens
+      cost_per_output_token = 0.0000004, -- $0.40 per 1M tokens
       use_ReAct_prompt = true,
       extra_request_body = {
         generationConfig = {
@@ -683,6 +697,8 @@ M._defaults = {
       model = "gemini-1.5-flash-002",
       timeout = 30000, -- Timeout in milliseconds
       context_window = 1048576,
+      cost_per_input_token = 0.000000075, -- $0.075 per 1M tokens
+      cost_per_output_token = 0.0000003, -- $0.30 per 1M tokens
       use_ReAct_prompt = true,
       extra_request_body = {
         generationConfig = {
@@ -704,6 +720,8 @@ M._defaults = {
     ollama = {
       endpoint = "http://127.0.0.1:11434",
       timeout = 30000, -- Timeout in milliseconds
+      cost_per_input_token = 0, -- Local model, free
+      cost_per_output_token = 0,
       use_ReAct_prompt = true,
       extra_request_body = {
         options = {
@@ -738,6 +756,8 @@ M._defaults = {
       __inherited_from = "claude",
       model = "claude-3-5-haiku-20241022",
       timeout = 30000, -- Timeout in milliseconds
+      cost_per_input_token = 0.0000008, -- $0.80 per 1M tokens
+      cost_per_output_token = 0.000004, -- $4 per 1M tokens
       extra_request_body = {
         temperature = 0.75,
         max_tokens = 8192,
@@ -748,6 +768,8 @@ M._defaults = {
       __inherited_from = "claude",
       model = "claude-3-opus-20240229",
       timeout = 30000, -- Timeout in milliseconds
+      cost_per_input_token = 0.000015, -- $15 per 1M tokens
+      cost_per_output_token = 0.000075, -- $75 per 1M tokens
       extra_request_body = {
         temperature = 0.75,
         max_tokens = 20480,
@@ -756,6 +778,8 @@ M._defaults = {
     ["openai-gpt-4o-mini"] = {
       __inherited_from = "openai",
       model = "gpt-4o-mini",
+      cost_per_input_token = 0.00000015, -- $0.15 per 1M tokens
+      cost_per_output_token = 0.0000006, -- $0.60 per 1M tokens
     },
     aihubmix = {
       __inherited_from = "openai",
@@ -1085,11 +1109,22 @@ M._defaults = {
     debounce = 600,
     throttle = 600,
   },
+  --- Dispatch agent configuration
+  --- Controls how dispatch_agent selects providers for sub-tasks (e.g. file reading)
+  dispatch = {
+    --- Maximum ratio of a provider's context_window that a dispatch request+file may occupy.
+    --- The cheapest provider whose context fits the payload within this ratio is selected.
+    --- @type number
+    max_context_ratio = 0.6,
+  },
   disabled_tools = {},
   ---@type AvanteLLMToolPublic[] | fun(): AvanteLLMToolPublic[]
   custom_tools = {},
+  ---@type AvanteSlashCommand[]
   slash_commands = {},
+  ---@type AvanteShortcut[]
   shortcuts = {},
+  ---@type AskOptions
   ask_opts = {},
 }
 
@@ -1097,7 +1132,6 @@ M._defaults = {
 ---@diagnostic disable-next-line: missing-fields
 M._options = {}
 
----@diagnostic disable-next-line: param-type-mismatch
 local function get_config_dir_path() return vim.fs.joinpath(vim.fn.expand("~"), ".config", "avante.nvim") end
 local function get_config_file_path() return vim.fs.joinpath(get_config_dir_path(), "config.json") end
 

--- a/lua/avante/config.lua
+++ b/lua/avante/config.lua
@@ -328,9 +328,6 @@ M.instructions_file = "avante.md"
 ---@field behaviour avante.Config.Behaviour Behaviour and automation options.
 ---@field prompt_logger avante.Config.PromptLogger Prompt logging options.
 ---@field windows table
----@field slash_commands AvanteSlashCommand[] see |*avante-slashcommands*|
----@field shortcuts AvanteShortcut[]  see |*avante-shortcuts*|
----@field ask_opts AskOptions
 
 M._defaults = {
   debug = false,
@@ -599,6 +596,8 @@ M._defaults = {
       model = "gpt-4o",
       timeout = 30000,
       context_window = 128000, -- Number of tokens to send to the model for context
+      cost_per_input_token = 0.0000025, -- $2.50 per 1M tokens
+      cost_per_output_token = 0.00001, -- $10 per 1M tokens
       use_response_api = copilot_use_response_api, -- Automatically switch to Response API for GPT-5 Codex models
       support_previous_response_id = true, -- OpenAI Response API supports previous_response_id for stateful conversations
       extra_request_body = {
@@ -617,6 +616,8 @@ M._defaults = {
       allow_insecure = false, -- Allow insecure server connections
       timeout = 30000, -- Timeout in milliseconds
       context_window = 64000, -- Number of tokens to send to the model for context
+      cost_per_input_token = 0, -- Free with GitHub Copilot subscription
+      cost_per_output_token = 0,
       use_response_api = copilot_use_response_api, -- Automatically switch to Response API for GPT-5 Codex models
       support_previous_response_id = false, -- Copilot doesn't support previous_response_id, must send full history
       -- NOTE: Copilot doesn't support previous_response_id, always sends full conversation history including tool_calls
@@ -645,6 +646,8 @@ M._defaults = {
       model = "claude-sonnet-4-5-20250929",
       timeout = 30000, -- Timeout in milliseconds
       context_window = 200000,
+      cost_per_input_token = 0.000003, -- $3 per 1M tokens
+      cost_per_output_token = 0.000015, -- $15 per 1M tokens
       extra_request_body = {
         temperature = 0.75,
         max_tokens = 64000,
@@ -675,6 +678,8 @@ M._defaults = {
       model = "gemini-2.0-flash",
       timeout = 30000, -- Timeout in milliseconds
       context_window = 1048576,
+      cost_per_input_token = 0.0000001, -- $0.10 per 1M tokens
+      cost_per_output_token = 0.0000004, -- $0.40 per 1M tokens
       use_ReAct_prompt = true,
       extra_request_body = {
         generationConfig = {
@@ -688,6 +693,8 @@ M._defaults = {
       model = "gemini-1.5-flash-002",
       timeout = 30000, -- Timeout in milliseconds
       context_window = 1048576,
+      cost_per_input_token = 0.000000075, -- $0.075 per 1M tokens
+      cost_per_output_token = 0.0000003, -- $0.30 per 1M tokens
       use_ReAct_prompt = true,
       extra_request_body = {
         generationConfig = {
@@ -709,6 +716,8 @@ M._defaults = {
     ollama = {
       endpoint = "http://127.0.0.1:11434",
       timeout = 30000, -- Timeout in milliseconds
+      cost_per_input_token = 0, -- Local model, free
+      cost_per_output_token = 0,
       use_ReAct_prompt = true,
       extra_request_body = {
         options = {
@@ -744,6 +753,8 @@ M._defaults = {
       endpoint = "https://api.anthropic.com",
       model = "claude-3-5-haiku-20241022",
       timeout = 30000, -- Timeout in milliseconds
+      cost_per_input_token = 0.0000008, -- $0.80 per 1M tokens
+      cost_per_output_token = 0.000004, -- $4 per 1M tokens
       extra_request_body = {
         temperature = 0.75,
         max_tokens = 8192,
@@ -755,6 +766,8 @@ M._defaults = {
       endpoint = "https://api.anthropic.com",
       model = "claude-3-opus-20240229",
       timeout = 30000, -- Timeout in milliseconds
+      cost_per_input_token = 0.000015, -- $15 per 1M tokens
+      cost_per_output_token = 0.000075, -- $75 per 1M tokens
       extra_request_body = {
         temperature = 0.75,
         max_tokens = 20480,
@@ -763,6 +776,8 @@ M._defaults = {
     ["openai-gpt-4o-mini"] = {
       __inherited_from = "openai",
       model = "gpt-4o-mini",
+      cost_per_input_token = 0.00000015, -- $0.15 per 1M tokens
+      cost_per_output_token = 0.0000006, -- $0.60 per 1M tokens
     },
     aihubmix = {
       __inherited_from = "openai",
@@ -1087,11 +1102,22 @@ M._defaults = {
     debounce = 600,
     throttle = 600,
   },
+  --- Dispatch agent configuration
+  --- Controls how dispatch_agent selects providers for sub-tasks
+  dispatch = {
+    --- Maximum ratio of a provider's context_window that a dispatch request+file may occupy.
+    --- The cheapest provider whose context fits the payload within this ratio is selected.
+    --- @type number
+    max_context_ratio = 0.6,
+  },
   disabled_tools = {},
   ---@type AvanteLLMToolPublic[] | fun(): AvanteLLMToolPublic[]
   custom_tools = {},
+  ---@type AvanteSlashCommand[]
   slash_commands = {},
+  ---@type AvanteShortcut[]
   shortcuts = {},
+  ---@type AskOptions
   ask_opts = {},
 }
 
@@ -1099,7 +1125,6 @@ M._defaults = {
 ---@diagnostic disable-next-line: missing-fields
 M._options = {}
 
----@diagnostic disable-next-line: param-type-mismatch
 local function get_config_dir_path() return vim.fs.joinpath(vim.fn.expand("~"), ".config", "avante.nvim") end
 local function get_config_file_path() return vim.fs.joinpath(get_config_dir_path(), "config.json") end
 

--- a/lua/avante/config.lua
+++ b/lua/avante/config.lua
@@ -323,9 +323,6 @@ M.instructions_file = "avante.md"
 ---@field behaviour avante.Config.Behaviour Behaviour and automation options.
 ---@field prompt_logger? avante.Config.PromptLogger Prompt logging options.
 ---@field windows table
----@field slash_commands AvanteSlashCommand[] see |*avante-slashcommands*|
----@field shortcuts AvanteShortcut[]  see |*avante-shortcuts*|
----@field ask_opts AskOptions
 
 M._defaults = {
   debug = false,
@@ -594,6 +591,8 @@ M._defaults = {
       model = "gpt-4o",
       timeout = 30000, -- Timeout in milliseconds, increase this for reasoning models
       context_window = 128000, -- Number of tokens to send to the model for context
+      cost_per_input_token = 0.0000025, -- $2.50 per 1M tokens
+      cost_per_output_token = 0.00001, -- $10 per 1M tokens
       use_response_api = copilot_use_response_api, -- Automatically switch to Response API for GPT-5 Codex models
       support_previous_response_id = true, -- OpenAI Response API supports previous_response_id for stateful conversations
       -- NOTE: Response API automatically manages conversation state using previous_response_id for tool calling
@@ -613,6 +612,8 @@ M._defaults = {
       allow_insecure = false, -- Allow insecure server connections
       timeout = 30000, -- Timeout in milliseconds
       context_window = 64000, -- Number of tokens to send to the model for context
+      cost_per_input_token = 0, -- Free with GitHub Copilot subscription
+      cost_per_output_token = 0,
       use_response_api = copilot_use_response_api, -- Automatically switch to Response API for GPT-5 Codex models
       support_previous_response_id = false, -- Copilot doesn't support previous_response_id, must send full history
       -- NOTE: Copilot doesn't support previous_response_id, always sends full conversation history including tool_calls
@@ -641,6 +642,8 @@ M._defaults = {
       model = "claude-sonnet-4-5-20250929",
       timeout = 30000, -- Timeout in milliseconds
       context_window = 200000,
+      cost_per_input_token = 0.000003, -- $3 per 1M tokens
+      cost_per_output_token = 0.000015, -- $15 per 1M tokens
       extra_request_body = {
         temperature = 0.75,
         max_tokens = 64000,
@@ -670,6 +673,8 @@ M._defaults = {
       model = "gemini-2.0-flash",
       timeout = 30000, -- Timeout in milliseconds
       context_window = 1048576,
+      cost_per_input_token = 0.0000001, -- $0.10 per 1M tokens
+      cost_per_output_token = 0.0000004, -- $0.40 per 1M tokens
       use_ReAct_prompt = true,
       extra_request_body = {
         generationConfig = {
@@ -683,6 +688,8 @@ M._defaults = {
       model = "gemini-1.5-flash-002",
       timeout = 30000, -- Timeout in milliseconds
       context_window = 1048576,
+      cost_per_input_token = 0.000000075, -- $0.075 per 1M tokens
+      cost_per_output_token = 0.0000003, -- $0.30 per 1M tokens
       use_ReAct_prompt = true,
       extra_request_body = {
         generationConfig = {
@@ -704,6 +711,8 @@ M._defaults = {
     ollama = {
       endpoint = "http://127.0.0.1:11434",
       timeout = 30000, -- Timeout in milliseconds
+      cost_per_input_token = 0, -- Local model, free
+      cost_per_output_token = 0,
       use_ReAct_prompt = true,
       extra_request_body = {
         options = {
@@ -738,6 +747,8 @@ M._defaults = {
       __inherited_from = "claude",
       model = "claude-3-5-haiku-20241022",
       timeout = 30000, -- Timeout in milliseconds
+      cost_per_input_token = 0.0000008, -- $0.80 per 1M tokens
+      cost_per_output_token = 0.000004, -- $4 per 1M tokens
       extra_request_body = {
         temperature = 0.75,
         max_tokens = 8192,
@@ -748,6 +759,8 @@ M._defaults = {
       __inherited_from = "claude",
       model = "claude-3-opus-20240229",
       timeout = 30000, -- Timeout in milliseconds
+      cost_per_input_token = 0.000015, -- $15 per 1M tokens
+      cost_per_output_token = 0.000075, -- $75 per 1M tokens
       extra_request_body = {
         temperature = 0.75,
         max_tokens = 20480,
@@ -756,6 +769,8 @@ M._defaults = {
     ["openai-gpt-4o-mini"] = {
       __inherited_from = "openai",
       model = "gpt-4o-mini",
+      cost_per_input_token = 0.00000015, -- $0.15 per 1M tokens
+      cost_per_output_token = 0.0000006, -- $0.60 per 1M tokens
     },
     aihubmix = {
       __inherited_from = "openai",
@@ -1085,11 +1100,22 @@ M._defaults = {
     debounce = 600,
     throttle = 600,
   },
+  --- Dispatch agent configuration
+  --- Controls how dispatch_agent selects providers for sub-tasks (e.g. file reading)
+  dispatch = {
+    --- Maximum ratio of a provider's context_window that a dispatch request+file may occupy.
+    --- The cheapest provider whose context fits the payload within this ratio is selected.
+    --- @type number
+    max_context_ratio = 0.6,
+  },
   disabled_tools = {},
   ---@type AvanteLLMToolPublic[] | fun(): AvanteLLMToolPublic[]
   custom_tools = {},
+  ---@type AvanteSlashCommand[]
   slash_commands = {},
+  ---@type AvanteShortcut[]
   shortcuts = {},
+  ---@type AskOptions
   ask_opts = {},
 }
 
@@ -1097,7 +1123,6 @@ M._defaults = {
 ---@diagnostic disable-next-line: missing-fields
 M._options = {}
 
----@diagnostic disable-next-line: param-type-mismatch
 local function get_config_dir_path() return vim.fs.joinpath(vim.fn.expand("~"), ".config", "avante.nvim") end
 local function get_config_file_path() return vim.fs.joinpath(get_config_dir_path(), "config.json") end
 

--- a/lua/avante/dispatch_registry.lua
+++ b/lua/avante/dispatch_registry.lua
@@ -1,0 +1,221 @@
+--- Dispatch registry: tracks all dispatched sub-agents across the sidebar session.
+---
+--- Each dispatch is fire-and-forget from the primary chat's perspective.  The
+--- registry provides:
+---   * `register()`   - create a new dispatch entry (status = "running")
+---   * `complete()`   - mark a dispatch as done and store its result
+---   * `fail()`       - mark a dispatch as failed
+---   * `get()`        - retrieve a single dispatch by id
+---   * `get_all()`    - all dispatches for a session
+---   * `get_context()` - formatted string for injection into prompts
+---   * `pick_cheapest_provider()` - select lowest-cost provider that fits payload
+
+local Config = require("avante.config")
+local Providers = require("avante.providers")
+
+---@class avante.Dispatch
+---@field id string
+---@field prompt string
+---@field status "running" | "completed" | "failed"
+---@field last_message string
+---@field result string | nil
+---@field error string | nil
+---@field provider string | nil
+---@field model string | nil
+---@field created_at number
+---@field completed_at number | nil
+
+---@class avante.DispatchRegistry
+local M = {}
+
+---@type table<string, avante.Dispatch[]>
+M._sessions = {}
+
+---@type table<string, integer>
+M._counters = {}
+
+---@type table<string, fun(dispatch: avante.Dispatch): nil>
+M._on_complete_callbacks = {}
+
+---@param session_id string
+---@param cb fun(dispatch: avante.Dispatch): nil
+function M.set_on_complete(session_id, cb) M._on_complete_callbacks[session_id] = cb end
+
+--- Register a new dispatch and return its id.
+---@param session_id string
+---@param prompt string
+---@param provider_name? string
+---@param model_name? string
+---@return string dispatch_id
+function M.register(session_id, prompt, provider_name, model_name)
+  if not M._sessions[session_id] then
+    M._sessions[session_id] = {}
+    M._counters[session_id] = 0
+  end
+  M._counters[session_id] = M._counters[session_id] + 1
+  local id = tostring(M._counters[session_id])
+  ---@type avante.Dispatch
+  local dispatch = {
+    id = id,
+    prompt = prompt,
+    status = "running",
+    last_message = "Starting...",
+    result = nil,
+    error = nil,
+    provider = provider_name,
+    model = model_name,
+    created_at = os.clock(),
+    completed_at = nil,
+  }
+  table.insert(M._sessions[session_id], dispatch)
+  return id
+end
+
+--- Update the "last_message" for a running dispatch (progress reporting).
+---@param session_id string
+---@param dispatch_id string
+---@param message string
+function M.update_progress(session_id, dispatch_id, message)
+  local dispatch = M.get(session_id, dispatch_id)
+  if dispatch then dispatch.last_message = message end
+end
+
+--- Mark a dispatch as completed.
+---@param session_id string
+---@param dispatch_id string
+---@param result string
+function M.complete(session_id, dispatch_id, result)
+  local dispatch = M.get(session_id, dispatch_id)
+  if not dispatch then return end
+  dispatch.status = "completed"
+  dispatch.result = result
+  dispatch.last_message = "Completed"
+  dispatch.completed_at = os.clock()
+  local cb = M._on_complete_callbacks[session_id]
+  if cb then vim.schedule(function() cb(dispatch) end) end
+end
+
+--- Mark a dispatch as failed.
+---@param session_id string
+---@param dispatch_id string
+---@param error_msg string
+function M.fail(session_id, dispatch_id, error_msg)
+  local dispatch = M.get(session_id, dispatch_id)
+  if not dispatch then return end
+  dispatch.status = "failed"
+  dispatch.error = error_msg
+  dispatch.last_message = "Failed: " .. error_msg
+  dispatch.completed_at = os.clock()
+  local cb = M._on_complete_callbacks[session_id]
+  if cb then vim.schedule(function() cb(dispatch) end) end
+end
+
+--- Retrieve a single dispatch.
+---@param session_id string
+---@param dispatch_id string
+---@return avante.Dispatch | nil
+function M.get(session_id, dispatch_id)
+  local dispatches = M._sessions[session_id]
+  if not dispatches then return nil end
+  for _, d in ipairs(dispatches) do
+    if d.id == dispatch_id then return d end
+  end
+  return nil
+end
+
+--- Retrieve all dispatches for a session.
+---@param session_id string
+---@return avante.Dispatch[]
+function M.get_all(session_id) return M._sessions[session_id] or {} end
+
+--- Build a human-readable context block describing all active and recently
+--- completed dispatches. Injected into prompts so the primary agent knows
+--- what is in flight.
+---@param session_id string
+---@return string
+function M.get_context(session_id)
+  local dispatches = M._sessions[session_id]
+  if not dispatches or #dispatches == 0 then return "" end
+
+  -- Count running dispatches so we can advise the agent how to proceed.
+  local running_count = 0
+  for _, d in ipairs(dispatches) do
+    if d.status == "running" then running_count = running_count + 1 end
+  end
+
+  local lines = { "## Active & Recent Dispatches" }
+  if running_count > 0 then
+    table.insert(
+      lines,
+      string.format(
+        "%d dispatch(es) still running. If your only remaining work is to wait on them, "
+          .. "call `dispatch_await` (NOT `dispatch_status` in a loop). `dispatch_await` blocks "
+          .. "until one finishes, returns its full result inline, and compacts the polling "
+          .. "noise out of your context.",
+        running_count
+      )
+    )
+  end
+  for _, d in ipairs(dispatches) do
+    local status_icon = d.status == "running" and "running" or d.status == "completed" and "completed" or "failed"
+    local prompt_preview = d.prompt:sub(1, 120) .. (#d.prompt > 120 and "..." or "")
+    local summary = string.format("- Dispatch #%s [%s]: %s", d.id, status_icon, prompt_preview)
+    table.insert(lines, summary)
+    if d.status == "running" then
+      table.insert(lines, "  Last update: " .. d.last_message)
+    elseif d.status == "completed" and d.result then
+      local result_preview = d.result:sub(1, 2000)
+      if #d.result > 2000 then result_preview = result_preview .. "\n...[truncated]" end
+      table.insert(lines, "  Result: " .. result_preview)
+    elseif d.status == "failed" and d.error then
+      table.insert(lines, "  Error: " .. d.error)
+    end
+  end
+
+  return table.concat(lines, "\n")
+end
+
+--- Remove all dispatches for a session (e.g. on sidebar close).
+---@param session_id string
+function M.clear(session_id)
+  M._sessions[session_id] = nil
+  M._counters[session_id] = nil
+  M._on_complete_callbacks[session_id] = nil
+end
+
+--- Pick the cheapest provider whose context_window can fit the given
+--- token count within the configured max_context_ratio.
+--- Returns nil if no provider fits.
+---@param estimated_tokens integer
+---@return string | nil provider_name
+---@return table | nil provider_config
+function M.pick_cheapest_provider(estimated_tokens)
+  local dispatch_config = Config.dispatch or {}
+  local max_ratio = dispatch_config.max_context_ratio or 0.6
+
+  ---@type {name: string, config: AvanteDefaultBaseProvider, cost: number}[]
+  local candidates = {}
+
+  for name, _ in pairs(Config.providers) do
+    local ok, provider_conf = pcall(function() return Providers.parse_config(Providers.get_config(name)) end)
+    if ok and provider_conf then
+      local context_window = provider_conf.context_window
+      if context_window and context_window > 0 then
+        local max_allowed = math.floor(context_window * max_ratio)
+        if estimated_tokens <= max_allowed then
+          local cost = provider_conf.cost_per_input_token or math.huge
+          table.insert(candidates, { name = name, config = provider_conf, cost = cost })
+        end
+      end
+    end
+  end
+
+  if #candidates == 0 then return nil, nil end
+
+  table.sort(candidates, function(a, b) return a.cost < b.cost end)
+
+  local best = candidates[1]
+  return best.name, best.config
+end
+
+return M

--- a/lua/avante/history/helpers.lua
+++ b/lua/avante/history/helpers.lua
@@ -3,49 +3,57 @@ local Utils = require("avante.utils")
 local M = {}
 
 ---If message is a text message return the text.
+---A message content may be a plain string, a single-item table, or a multi-item
+---table (e.g. thinking + text, text + tool_use, …).  We concatenate every "text"
+---entry we find so callers get the full textual payload without asserting a
+---specific layout.
 ---@param message avante.HistoryMessage
 ---@return string | nil
 function M.get_text_data(message)
   local content = message.message.content
+  if type(content) == "string" then return content end
   if type(content) == "table" then
-    assert(#content == 1, "more than one entry in message content")
-    local item = content[1]
-    if type(item) == "string" then
-      return item
-    elseif type(item) == "table" and item.type == "text" then
-      return item.content
+    local parts = {}
+    for _, item in ipairs(content) do
+      if type(item) == "string" then
+        table.insert(parts, item)
+      elseif type(item) == "table" and item.type == "text" then
+        table.insert(parts, item.text or item.content or "")
+      end
     end
-  elseif type(content) == "string" then
-    return content
+    if #parts > 0 then return table.concat(parts, "\n") end
   end
 end
 
 ---If message is a "tool use" message returns information about the tool invocation.
+---Returns the first tool_use entry found; ignores any additional content items
+---(e.g. an accompanying thinking or text block).
 ---@param message avante.HistoryMessage
 ---@return AvanteLLMToolUse | nil
 function M.get_tool_use_data(message)
   local content = message.message.content
   if type(content) == "table" then
-    assert(#content == 1, "more than one entry in message content")
-    local item = content[1]
-    if item.type == "tool_use" then
-      ---@cast item AvanteLLMToolUse
-      return item
+    for _, item in ipairs(content) do
+      if type(item) == "table" and item.type == "tool_use" then
+        ---@cast item AvanteLLMToolUse
+        return item
+      end
     end
   end
 end
 
 ---If message is a "tool result" message returns results of the tool invocation.
+---Returns the first tool_result entry found; ignores any additional content items.
 ---@param message avante.HistoryMessage
 ---@return AvanteLLMToolResult | nil
 function M.get_tool_result_data(message)
   local content = message.message.content
   if type(content) == "table" then
-    assert(#content == 1, "more than one entry in message content")
-    local item = content[1]
-    if item.type == "tool_result" then
-      ---@cast item AvanteLLMToolResult
-      return item
+    for _, item in ipairs(content) do
+      if type(item) == "table" and item.type == "tool_result" then
+        ---@cast item AvanteLLMToolResult
+        return item
+      end
     end
   end
 end
@@ -90,7 +98,8 @@ end
 ---@return boolean
 function M.is_thinking_message(message)
   local content = message.message.content
-  return type(content) == "table" and (content[1].type == "thinking" or content[1].type == "redacted_thinking")
+  if type(content) ~= "table" or #content == 0 then return false end
+  return content[1].type == "thinking" or content[1].type == "redacted_thinking"
 end
 
 ---@param message avante.HistoryMessage

--- a/lua/avante/history/message.lua
+++ b/lua/avante/history/message.lua
@@ -17,6 +17,7 @@ M.__index = M
 ---@field is_user_submission? boolean
 ---@field just_for_display? boolean
 ---@field visible? boolean
+---@field from_instance? string -- instance_name of the sending chat (cross-instance message)
 ---
 ---@param role "user" | "assistant"
 ---@param content AvanteLLMMessageContentItem

--- a/lua/avante/history_selector.lua
+++ b/lua/avante/history_selector.lua
@@ -58,7 +58,10 @@ function M.open(bufnr, cb)
       cb(item_ids[1])
     end,
     get_preview_content = function(item_id)
-      local history = Path.history.load(vim.api.nvim_get_current_buf(), item_id)
+      -- Use the captured bufnr (the code buffer) rather than the current buffer,
+      -- which inside the selector might be a floating/preview window pointing at
+      -- a completely different project root.
+      local history = Path.history.load(bufnr, item_id)
       local Sidebar = require("avante.sidebar")
       local content = Sidebar.render_history_content(history)
       return content, "markdown"

--- a/lua/avante/history_selector.lua
+++ b/lua/avante/history_selector.lua
@@ -7,28 +7,184 @@ local Selector = require("avante.ui.selector")
 ---@class avante.HistorySelector
 local M = {}
 
+-- Number of most-recent conversations to show per project.
+local HISTORY_PER_PROJECT = 5
+
+-- Extract a plain-text snippet from a message's content field.
+-- Content may be a string (modern user messages) or an array of typed blocks.
+---@param content any
+---@return string
+local function extract_text(content)
+  if type(content) == "string" then return content end
+  if type(content) == "table" then
+    for _, block in ipairs(content) do
+      if type(block) == "table" and block.type == "text" and type(block.text) == "string" then
+        return block.text
+      end
+    end
+  end
+  return ""
+end
+
+-- Collapse whitespace and truncate a string to max_len, appending "…" if cut.
+---@param s string
+---@param max_len integer
+---@return string
+local function truncate(s, max_len)
+  s = s:gsub("[\n\r\t]+", " "):gsub("%s+", " "):match("^%s*(.-)%s*$") or ""
+  if #s <= max_len then return s end
+  return s:sub(1, max_len - 1) .. "…"
+end
+
+-- Return the role of a message, handling both modern (msg.role) and legacy
+-- (msg.message.role via the Message class wrapper) formats.
+---@param msg table
+---@return string
+local function msg_role(msg)
+  return msg.role or (type(msg.message) == "table" and msg.message.role) or ""
+end
+
+-- Return the content of a message, handling both formats.
+---@param msg table
+---@return any
+local function msg_content(msg)
+  return msg.content or (type(msg.message) == "table" and msg.message.content) or ""
+end
+
+-- Build the display label for a history entry.
+-- Format: "project_name | <first user msg>…<last msg>"
 ---@param history avante.ChatHistory
----@return table?
-local function to_selector_item(history)
+---@param project_name string
+---@param full_filepath string  absolute path to the .json file (used as the item id)
+---@return avante.ui.SelectorItem
+local function to_selector_item(history, project_name, full_filepath)
   local messages = History.get_history_messages(history)
-  local timestamp = #messages > 0 and messages[#messages].timestamp or history.timestamp
-  local name = history.title .. " - " .. timestamp .. " (" .. #messages .. ")"
-  name = name:gsub("\n", "\\n")
-  return {
-    name = name,
-    filename = history.filename,
-  }
+
+  -- First user message text
+  local first_text = ""
+  for _, msg in ipairs(messages) do
+    if msg_role(msg) == "user" then
+      local text = extract_text(msg_content(msg))
+      if text ~= "" then
+        first_text = text
+        break
+      end
+    end
+  end
+
+  -- Last message text (any role)
+  local last_text = ""
+  for i = #messages, 1, -1 do
+    local text = extract_text(msg_content(messages[i]))
+    if text ~= "" then
+      last_text = text
+      break
+    end
+  end
+
+  local label
+  if first_text == "" and last_text == "" then
+    label = project_name .. " | (empty)"
+  elseif last_text == "" or first_text == last_text then
+    label = project_name .. " | " .. truncate(first_text, 70)
+  else
+    label = project_name .. " | " .. truncate(first_text, 40) .. " … " .. truncate(last_text, 40)
+  end
+
+  return { id = full_filepath, title = label }
+end
+
+-- Return the N most-recent history filepaths from a history directory, sorted
+-- by descending numeric filename (414.json > 413.json).  Non-numeric filenames
+-- and metadata.json are skipped.
+---@param history_dir_path table  plenary.path object
+---@param n integer
+---@return string[]  absolute file paths
+local function get_recent_filepaths(history_dir_path, n)
+  local files = vim.fn.glob(tostring(history_dir_path:joinpath("*.json")), true, true)
+  local candidates = {}
+  for _, filepath in ipairs(files) do
+    if not filepath:match("metadata%.json$") then
+      local num = tonumber(vim.fn.fnamemodify(filepath, ":t:r"))
+      if num then table.insert(candidates, { filepath = filepath, num = num }) end
+    end
+  end
+  table.sort(candidates, function(a, b) return a.num > b.num end)
+  local result = {}
+  for i = 1, math.min(n, #candidates) do
+    table.insert(result, candidates[i].filepath)
+  end
+  return result
+end
+
+-- Build plain-text representation of a conversation for the "wr" write action.
+-- Includes only user/assistant message text; tool-use/result blocks are skipped.
+---@param history avante.ChatHistory
+---@return string
+local function render_plain_text(history)
+  local messages = History.get_history_messages(history)
+  local lines = {}
+  for _, msg in ipairs(messages) do
+    local role = msg_role(msg)
+    -- Skip internal tool-orchestration messages
+    if role ~= "user" and role ~= "assistant" then goto continue end
+
+    local content = msg_content(msg)
+    local text = ""
+    if type(content) == "string" then
+      text = content
+    elseif type(content) == "table" then
+      -- Gather only text blocks; skip tool_use / tool_result
+      local parts = {}
+      for _, block in ipairs(content) do
+        if type(block) == "table" and block.type == "text" and type(block.text) == "string" then
+          table.insert(parts, block.text)
+        end
+      end
+      text = table.concat(parts, "\n")
+    end
+
+    text = vim.trim(text)
+    if text == "" then goto continue end
+
+    table.insert(lines, string.upper(role) .. ":")
+    table.insert(lines, text)
+    table.insert(lines, "")
+    ::continue::
+  end
+  return table.concat(lines, "\n")
 end
 
 ---@param bufnr integer
----@param cb fun(filename: string)
+---@param cb fun(filepath: string)  called with the FULL absolute path of the selected history JSON
 function M.open(bufnr, cb)
+  local PlPath = require("plenary.path")
+  local projects = Path.list_projects()
+
+  if not projects or #projects == 0 then
+    Utils.warn("No avante history found.")
+    return
+  end
+
   local selector_items = {}
 
-  local histories = Path.history.list(bufnr)
+  for _, project in ipairs(projects) do
+    -- Use the last component of the real project root as the display name.
+    local project_name = vim.fn.fnamemodify(project.root, ":t")
+    if not project_name or project_name == "" then project_name = project.name end
 
-  for _, history in ipairs(histories) do
-    table.insert(selector_items, to_selector_item(history))
+    local history_dir = PlPath:new(project.directory):joinpath("history")
+    if not history_dir:exists() then goto continue end
+
+    local recent_paths = get_recent_filepaths(history_dir, HISTORY_PER_PROJECT)
+    for _, filepath in ipairs(recent_paths) do
+      local history = Path.history.from_file(PlPath:new(filepath))
+      if history then
+        table.insert(selector_items, to_selector_item(history, project_name, filepath))
+      end
+    end
+
+    ::continue::
   end
 
   if #selector_items == 0 then
@@ -36,43 +192,58 @@ function M.open(bufnr, cb)
     return
   end
 
-  local current_selector -- To be able to close it from the keymap
+  Selector:new({
+    provider = Config.selector.provider,
+    title = string.format("Avante History (top %d per project)", HISTORY_PER_PROJECT),
+    items = selector_items,
 
-  current_selector = Selector:new({
-    provider = Config.selector.provider, -- This should be 'native' for the current setup
-    title = "Avante History (Select, then choose action)", -- Updated title
-    items = vim
-      .iter(selector_items)
-      :map(
-        function(item)
-          return {
-            id = item.filename,
-            title = item.name,
-          }
-        end
-      )
-      :totable(),
     on_select = function(item_ids)
       if not item_ids then return end
       if #item_ids == 0 then return end
       cb(item_ids[1])
     end,
+
     get_preview_content = function(item_id)
-      local history = Path.history.load(vim.api.nvim_get_current_buf(), item_id)
+      local history = Path.history.from_file(PlPath:new(item_id))
+      if not history then return "", "markdown" end
       local Sidebar = require("avante.sidebar")
       local content = Sidebar.render_history_content(history)
       return content, "markdown"
     end,
-    on_delete_item = function(item_id_to_delete)
-      if not item_id_to_delete then
-        Utils.warn("No item ID provided for deletion.")
+
+    on_delete_item = function(item_id)
+      if not item_id then return end
+      vim.fn.delete(item_id)
+    end,
+
+    on_write_item = function(item_id)
+      local history = Path.history.from_file(PlPath:new(item_id))
+      if not history then
+        Utils.warn("Could not load history for writing.")
         return
       end
-      Path.history.delete(bufnr, item_id_to_delete) -- bufnr from M.open's scope
+
+      local plain = render_plain_text(history)
+      -- Default output path: cwd/<numeric_stem>_conversation.txt
+      local cwd = vim.fn.getcwd()
+      local stem = vim.fn.fnamemodify(item_id, ":t:r")
+      local default_dest = cwd .. "/" .. stem .. "_conversation.txt"
+
+      vim.ui.input({ prompt = "Write conversation to: ", default = default_dest }, function(dest)
+        if not dest or dest == "" then return end
+        local f = io.open(dest, "w")
+        if not f then
+          Utils.error("Could not open file for writing: " .. dest)
+          return
+        end
+        f:write(plain)
+        f:close()
+        Utils.info("Conversation written to: " .. dest)
+      end)
     end,
+
     on_open = function() M.open(bufnr, cb) end,
-  })
-  current_selector:open()
+  }):open()
 end
 
 return M

--- a/lua/avante/history_selector.lua
+++ b/lua/avante/history_selector.lua
@@ -7,24 +7,9 @@ local Selector = require("avante.ui.selector")
 ---@class avante.HistorySelector
 local M = {}
 
--- Number of most-recent conversations to show per project.
-local HISTORY_PER_PROJECT = 5
-
--- Extract a plain-text snippet from a message's content field.
--- Content may be a string (modern user messages) or an array of typed blocks.
----@param content any
----@return string
-local function extract_text(content)
-  if type(content) == "string" then return content end
-  if type(content) == "table" then
-    for _, block in ipairs(content) do
-      if type(block) == "table" and block.type == "text" and type(block.text) == "string" then
-        return block.text
-      end
-    end
-  end
-  return ""
-end
+-- Sentinel item ids used for non-history rows in the picker.
+local EXPAND_ID = "__avante_expand_other_projects__"
+local SEPARATOR_ID = "__avante_separator__"
 
 -- Collapse whitespace and truncate a string to max_len, appending "…" if cut.
 ---@param s string
@@ -36,97 +21,62 @@ local function truncate(s, max_len)
   return s:sub(1, max_len - 1) .. "…"
 end
 
--- Return the role of a message, handling both modern (msg.role) and legacy
--- (msg.message.role via the Message class wrapper) formats.
----@param msg table
+-- Format a mtime as "5m ago", "3h ago", "2d ago", or a date stamp for older
+-- entries.
+---@param mtime integer  seconds since epoch
 ---@return string
-local function msg_role(msg)
-  return msg.role or (type(msg.message) == "table" and msg.message.role) or ""
+local function format_relative_time(mtime)
+  if not mtime or mtime <= 0 then return "" end
+  local now = os.time()
+  local diff = now - mtime
+  if diff < 0 then diff = 0 end
+  if diff < 60 then return diff .. "s ago" end
+  if diff < 3600 then return math.floor(diff / 60) .. "m ago" end
+  if diff < 86400 then return math.floor(diff / 3600) .. "h ago" end
+  if diff < 86400 * 7 then return math.floor(diff / 86400) .. "d ago" end
+  if diff < 86400 * 30 then return math.floor(diff / (86400 * 7)) .. "w ago" end
+  return os.date("%Y-%m-%d", mtime) --[[@as string]]
 end
 
--- Return the content of a message, handling both formats.
----@param msg table
----@return any
-local function msg_content(msg)
-  return msg.content or (type(msg.message) == "table" and msg.message.content) or ""
-end
-
--- Build the display label for a history entry.
--- Format: "project_name | <first user msg>…<last msg>"
----@param history avante.ChatHistory
----@param project_name string
----@param full_filepath string  absolute path to the .json file (used as the item id)
+---@param summary avante.HistoryInstanceSummary
+---@param include_project boolean  if true, prefix label with project basename
 ---@return avante.ui.SelectorItem
-local function to_selector_item(history, project_name, full_filepath)
-  local messages = History.get_history_messages(history)
+local function to_selector_item(summary, include_project)
+  local time_str = format_relative_time(summary.mtime)
+  local first = summary.first_message_text
+  if first == "" then first = summary.last_message_text end
+  if first == "" then first = "(empty)" end
+  first = truncate(first, 80)
 
-  -- First user message text
-  local first_text = ""
-  for _, msg in ipairs(messages) do
-    if msg_role(msg) == "user" then
-      local text = extract_text(msg_content(msg))
-      if text ~= "" then
-        first_text = text
-        break
-      end
-    end
+  local pieces = {}
+  if include_project then
+    local project_name = vim.fn.fnamemodify(summary.project_root, ":t")
+    if project_name == "" then project_name = summary.project_dirname end
+    table.insert(pieces, "[" .. project_name .. "]")
   end
+  table.insert(pieces, summary.instance_name)
+  if time_str ~= "" then table.insert(pieces, time_str) end
+  table.insert(pieces, first)
+  if summary.is_legacy then table.insert(pieces, "(legacy)") end
 
-  -- Last message text (any role)
-  local last_text = ""
-  for i = #messages, 1, -1 do
-    local text = extract_text(msg_content(messages[i]))
-    if text ~= "" then
-      last_text = text
-      break
-    end
-  end
-
-  local label
-  if first_text == "" and last_text == "" then
-    label = project_name .. " | (empty)"
-  elseif last_text == "" or first_text == last_text then
-    label = project_name .. " | " .. truncate(first_text, 70)
-  else
-    label = project_name .. " | " .. truncate(first_text, 40) .. " … " .. truncate(last_text, 40)
-  end
-
-  return { id = full_filepath, title = label }
+  return {
+    -- Encode both the relative filename and the project storage key in the
+    -- item id so we can disambiguate cross-project picks unambiguously.
+    id = summary.filename .. "\0" .. summary.project_dirname,
+    title = table.concat(pieces, "  "),
+  }
 end
 
--- Return the N most-recent history filepaths from a history directory, sorted
--- by descending numeric filename (414.json > 413.json).  Non-numeric filenames
--- and metadata.json are skipped.
----@param history_dir_path table  plenary.path object
----@param n integer
----@return string[]  absolute file paths
-local function get_recent_filepaths(history_dir_path, n)
-  local files = vim.fn.glob(tostring(history_dir_path:joinpath("*.json")), true, true)
-  local candidates = {}
-  for _, filepath in ipairs(files) do
-    if not filepath:match("metadata%.json$") then
-      local num = tonumber(vim.fn.fnamemodify(filepath, ":t:r"))
-      if num then table.insert(candidates, { filepath = filepath, num = num }) end
-    end
-  end
-  table.sort(candidates, function(a, b) return a.num > b.num end)
-  local result = {}
-  for i = 1, math.min(n, #candidates) do
-    table.insert(result, candidates[i].filepath)
-  end
-  return result
-end
-
--- Build plain-text representation of a conversation for the "wr" write action.
--- Includes only user/assistant message text; tool-use/result blocks are skipped.
+-- Build plain-text representation of a conversation for the write action.
 ---@param history avante.ChatHistory
 ---@return string
 local function render_plain_text(history)
   local messages = History.get_history_messages(history)
   local lines = {}
+  local function msg_role(m) return m.role or (type(m.message) == "table" and m.message.role) or "" end
+  local function msg_content(m) return m.content or (type(m.message) == "table" and m.message.content) or "" end
   for _, msg in ipairs(messages) do
     local role = msg_role(msg)
-    -- Skip internal tool-orchestration messages
     if role ~= "user" and role ~= "assistant" then goto continue end
 
     local content = msg_content(msg)
@@ -134,7 +84,6 @@ local function render_plain_text(history)
     if type(content) == "string" then
       text = content
     elseif type(content) == "table" then
-      -- Gather only text blocks; skip tool_use / tool_result
       local parts = {}
       for _, block in ipairs(content) do
         if type(block) == "table" and block.type == "text" and type(block.text) == "string" then
@@ -155,81 +104,154 @@ local function render_plain_text(history)
   return table.concat(lines, "\n")
 end
 
----@param bufnr integer
----@param cb fun(filepath: string)  called with the FULL absolute path of the selected history JSON
-function M.open(bufnr, cb)
+-- Load a multi-part instance history by absolute storage path (used for
+-- preview / write actions on cross-project picks, where bufnr won't resolve
+-- to the right project dir).
+---@param summary avante.HistoryInstanceSummary
+---@return avante.ChatHistory | nil
+local function load_history_by_summary(summary)
   local PlPath = require("plenary.path")
-  local projects = Path.list_projects()
+  local instance_dir = PlPath:new(Config.history.storage_path)
+    :joinpath("projects")
+    :joinpath(summary.project_dirname)
+    :joinpath("history")
+    :joinpath(summary.instance_dirname)
+  if not instance_dir:exists() then return nil end
+  local json_files = vim.fn.glob(tostring(instance_dir:joinpath("*.json")), true, true)
+  table.sort(json_files, function(a, b)
+    local na = tonumber(vim.fn.fnamemodify(a, ":t:r")) or 0
+    local nb = tonumber(vim.fn.fnamemodify(b, ":t:r")) or 0
+    return na < nb
+  end)
+  if #json_files == 0 then return nil end
+  local history = Path.history.from_file(PlPath:new(json_files[1]))
+  if not history then return nil end
+  history.filename = summary.filename
+  for i = 2, #json_files do
+    local part = Path.history.from_file(PlPath:new(json_files[i]))
+    if part then
+      if part.messages then vim.list_extend(history.messages, part.messages) end
+      if part.entries then vim.list_extend(history.entries, part.entries) end
+    end
+  end
+  return history
+end
 
-  if not projects or #projects == 0 then
-    Utils.warn("No avante history found.")
-    return
+---@param bufnr integer
+---@param cb fun(payload: { filename: string, project_root: string, project_dirname: string, cross_project: boolean })
+---@param include_other_projects boolean
+local function open_picker(bufnr, cb, include_other_projects)
+  local current = Path.history.list_instances(bufnr) or {}
+  local current_project_root = Utils.root.get({ buf = bufnr }) or ""
+
+  local others = {}
+  if include_other_projects then others = Path.history.list_all_instances(current_project_root) or {} end
+
+  local items_by_id = {}
+  local function index(s) items_by_id[s.filename .. "\0" .. s.project_dirname] = s end
+  for _, s in ipairs(current) do
+    index(s)
+  end
+  for _, s in ipairs(others) do
+    index(s)
   end
 
+  ---@type avante.ui.SelectorItem[]
   local selector_items = {}
+  for _, s in ipairs(current) do
+    table.insert(selector_items, to_selector_item(s, false))
+  end
 
-  for _, project in ipairs(projects) do
-    -- Use the last component of the real project root as the display name.
-    local project_name = vim.fn.fnamemodify(project.root, ":t")
-    if not project_name or project_name == "" then project_name = project.name end
-
-    local history_dir = PlPath:new(project.directory):joinpath("history")
-    if not history_dir:exists() then goto continue end
-
-    local recent_paths = get_recent_filepaths(history_dir, HISTORY_PER_PROJECT)
-    for _, filepath in ipairs(recent_paths) do
-      local history = Path.history.from_file(PlPath:new(filepath))
-      if history then
-        table.insert(selector_items, to_selector_item(history, project_name, filepath))
-      end
+  if include_other_projects then
+    if #others > 0 and #current > 0 then
+      table.insert(selector_items, { id = SEPARATOR_ID, title = string.rep("─", 60) })
     end
-
-    ::continue::
+    for _, s in ipairs(others) do
+      table.insert(selector_items, to_selector_item(s, true))
+    end
+  else
+    -- Always offer the expand option at the bottom (even when current is empty).
+    table.insert(selector_items, {
+      id = EXPAND_ID,
+      title = "▶ Show histories from other projects (will switch nvim cwd on pick)",
+    })
   end
 
   if #selector_items == 0 then
-    Utils.warn("No history items found.")
+    Utils.warn("No avante history found for this project.")
     return
   end
 
+  local title = include_other_projects and "Avante History (all projects, mtime-sorted)"
+    or "Avante History (this project, mtime-sorted)"
+
   Selector:new({
     provider = Config.selector.provider,
-    title = string.format("Avante History (top %d per project)", HISTORY_PER_PROJECT),
+    title = title,
     items = selector_items,
 
     on_select = function(item_ids)
-      if not item_ids then return end
-      if #item_ids == 0 then return end
-      cb(item_ids[1])
+      if not item_ids or #item_ids == 0 then return end
+      local picked = item_ids[1]
+      if picked == EXPAND_ID then
+        vim.schedule(function() open_picker(bufnr, cb, true) end)
+        return
+      end
+      if picked == SEPARATOR_ID then return end
+
+      local summary = items_by_id[picked]
+      if not summary then return end
+
+      cb({
+        filename = summary.filename,
+        project_root = summary.project_root,
+        project_dirname = summary.project_dirname,
+        cross_project = summary.project_root ~= current_project_root,
+      })
     end,
 
     get_preview_content = function(item_id)
-      -- Use the captured bufnr (the code buffer) rather than the current buffer,
-      -- which inside the selector might be a floating/preview window pointing at
-      -- a completely different project root.
-      local history = Path.history.load(bufnr, item_id)
+      if item_id == EXPAND_ID or item_id == SEPARATOR_ID then return "", "markdown" end
+      local summary = items_by_id[item_id]
+      if not summary then return "", "markdown" end
+      local history = load_history_by_summary(summary)
+      if not history then return "", "markdown" end
       local Sidebar = require("avante.sidebar")
       local content = Sidebar.render_history_content(history)
       return content, "markdown"
     end,
 
     on_delete_item = function(item_id)
-      if not item_id then return end
-      vim.fn.delete(item_id)
+      if item_id == EXPAND_ID or item_id == SEPARATOR_ID then return end
+      local summary = items_by_id[item_id]
+      if not summary then return end
+      -- Mark the instance as deleted (sentinel file) without touching the JSONs.
+      -- We can't use Path.history.mark_instance_deleted(bufnr, ...) for
+      -- cross-project picks because the bufnr resolves to a DIFFERENT project
+      -- dir, so write the sentinel directly using the storage path we know.
+      local PlPath = require("plenary.path")
+      local sentinel = PlPath:new(Config.history.storage_path)
+        :joinpath("projects")
+        :joinpath(summary.project_dirname)
+        :joinpath("history")
+        :joinpath(summary.instance_dirname)
+        :joinpath(".deleted")
+      pcall(function() sentinel:write(tostring(os.time()), "w") end)
+      Utils.info("Marked '" .. summary.instance_name .. "' as deleted (instance dir kept on disk)")
     end,
 
     on_write_item = function(item_id)
-      local history = Path.history.from_file(PlPath:new(item_id))
+      if item_id == EXPAND_ID or item_id == SEPARATOR_ID then return end
+      local summary = items_by_id[item_id]
+      if not summary then return end
+      local history = load_history_by_summary(summary)
       if not history then
         Utils.warn("Could not load history for writing.")
         return
       end
-
       local plain = render_plain_text(history)
-      -- Default output path: cwd/<numeric_stem>_conversation.txt
       local cwd = vim.fn.getcwd()
-      local stem = vim.fn.fnamemodify(item_id, ":t:r")
-      local default_dest = cwd .. "/" .. stem .. "_conversation.txt"
+      local default_dest = cwd .. "/" .. summary.instance_name .. "_conversation.txt"
 
       vim.ui.input({ prompt = "Write conversation to: ", default = default_dest }, function(dest)
         if not dest or dest == "" then return end
@@ -244,8 +266,13 @@ function M.open(bufnr, cb)
       end)
     end,
 
-    on_open = function() M.open(bufnr, cb) end,
+    on_open = function() open_picker(bufnr, cb, include_other_projects) end,
   }):open()
 end
 
+---@param bufnr integer
+---@param cb fun(payload: { filename: string, project_root: string, project_dirname: string, cross_project: boolean })
+function M.open(bufnr, cb) open_picker(bufnr, cb, false) end
+
 return M
+

--- a/lua/avante/init.lua
+++ b/lua/avante/init.lua
@@ -133,6 +133,7 @@ local Suggestion = require("avante.suggestion")
 local Config = require("avante.config")
 local Diff = require("avante.diff")
 local RagService = require("avante.rag_service")
+local IpcService = require("avante.ipc_service")
 
 ---@class Avante
 local M = {
@@ -148,6 +149,9 @@ local M = {
   current = { sidebar = nil, selection = nil, suggestion = nil },
   ---@type table<string, any> Global ACP client registry for cleanup on exit
   acp_clients = {},
+  --- instance_name → Sidebar: cross-instance messaging registry
+  ---@type table<string, avante.Sidebar>
+  instance_registry = {},
 }
 
 M.did_setup = false
@@ -423,7 +427,13 @@ function H.autocmds()
       local tab = tonumber(ev.file)
       local s = M.sidebars[tab]
       local sl = M.selections[tab]
-      if s then s:reset() end
+      if s then
+        -- Remove this sidebar from the cross-instance registry before reset.
+        if s.chat_history and s.chat_history.instance_name then
+          M.instance_registry[s.chat_history.instance_name] = nil
+        end
+        s:reset()
+      end
       if sl then sl:delete_autocmds() end
       if tab ~= nil then M.sidebars[tab] = nil end
     end,
@@ -649,6 +659,51 @@ function M.setup(opts)
   end
 
   if Config.rag_service.enabled then run_rag_service() end
+
+  -- Launch the IPC service when enabled.  Once the service is ready, all
+  -- currently open sidebars register themselves and start their heartbeat +
+  -- message-poll timers.  New sidebars register in reload_chat_history().
+  if Config.ipc_service and Config.ipc_service.enabled then
+    local started_at = os.time()
+    local function try_ipc_ready()
+      if IpcService.is_ready() then
+        Utils.debug("IPC service is ready; registering open sidebars")
+        -- Register every currently open sidebar.
+        for _, sidebar in pairs(M.instance_registry) do
+          if sidebar and sidebar.chat_history then
+            sidebar:ipc_register()
+          end
+        end
+      else
+        local elapsed = os.time() - started_at
+        if elapsed < 60 * 5 then
+          vim.defer_fn(try_ipc_ready, 5000)
+        else
+          Utils.warn("IPC service did not become ready within 5 minutes — giving up")
+        end
+      end
+    end
+    vim.schedule(function()
+      Utils.info("Starting IPC Service ...")
+      IpcService.launch_ipc_service(function()
+        vim.defer_fn(try_ipc_ready, 2000)
+      end)
+    end)
+
+    -- Unregister all sidebars from IPC on nvim exit.
+    api.nvim_create_autocmd("VimLeavePre", {
+      group = H.augroup,
+      desc = "Unregister all Avante sidebars from the IPC service",
+      callback = function()
+        for _, sidebar in pairs(M.instance_registry) do
+          if sidebar and sidebar.chat_history then
+            pcall(function() sidebar:ipc_unregister() end)
+          end
+        end
+        IpcService.stop_timers()
+      end,
+    })
+  end
 
   local has_cmp, cmp = pcall(require, "cmp")
   if has_cmp then

--- a/lua/avante/init.lua
+++ b/lua/avante/init.lua
@@ -148,6 +148,9 @@ local M = {
   current = { sidebar = nil, selection = nil, suggestion = nil },
   ---@type table<string, any> Global ACP client registry for cleanup on exit
   acp_clients = {},
+  --- instance_name → Sidebar: cross-instance messaging registry
+  ---@type table<string, avante.Sidebar>
+  instance_registry = {},
 }
 
 M.did_setup = false
@@ -423,7 +426,13 @@ function H.autocmds()
       local tab = tonumber(ev.file)
       local s = M.sidebars[tab]
       local sl = M.selections[tab]
-      if s then s:reset() end
+      if s then
+        -- Remove this sidebar from the cross-instance registry before reset.
+        if s.chat_history and s.chat_history.instance_name then
+          M.instance_registry[s.chat_history.instance_name] = nil
+        end
+        s:reset()
+      end
       if sl then sl:delete_autocmds() end
       if tab ~= nil then M.sidebars[tab] = nil end
     end,

--- a/lua/avante/init.lua
+++ b/lua/avante/init.lua
@@ -133,6 +133,7 @@ local Suggestion = require("avante.suggestion")
 local Config = require("avante.config")
 local Diff = require("avante.diff")
 local RagService = require("avante.rag_service")
+local IpcService = require("avante.ipc_service")
 
 ---@class Avante
 local M = {
@@ -658,6 +659,51 @@ function M.setup(opts)
   end
 
   if Config.rag_service.enabled then run_rag_service() end
+
+  -- Launch the IPC service when enabled.  Once the service is ready, all
+  -- currently open sidebars register themselves and start their heartbeat +
+  -- message-poll timers.  New sidebars register in reload_chat_history().
+  if Config.ipc_service and Config.ipc_service.enabled then
+    local started_at = os.time()
+    local function try_ipc_ready()
+      if IpcService.is_ready() then
+        Utils.debug("IPC service is ready; registering open sidebars")
+        -- Register every currently open sidebar.
+        for _, sidebar in pairs(M.instance_registry) do
+          if sidebar and sidebar.chat_history then
+            sidebar:ipc_register()
+          end
+        end
+      else
+        local elapsed = os.time() - started_at
+        if elapsed < 60 * 5 then
+          vim.defer_fn(try_ipc_ready, 5000)
+        else
+          Utils.warn("IPC service did not become ready within 5 minutes — giving up")
+        end
+      end
+    end
+    vim.schedule(function()
+      Utils.info("Starting IPC Service ...")
+      IpcService.launch_ipc_service(function()
+        vim.defer_fn(try_ipc_ready, 2000)
+      end)
+    end)
+
+    -- Unregister all sidebars from IPC on nvim exit.
+    api.nvim_create_autocmd("VimLeavePre", {
+      group = H.augroup,
+      desc = "Unregister all Avante sidebars from the IPC service",
+      callback = function()
+        for _, sidebar in pairs(M.instance_registry) do
+          if sidebar and sidebar.chat_history then
+            pcall(function() sidebar:ipc_unregister() end)
+          end
+        end
+        IpcService.stop_timers()
+      end,
+    })
+  end
 
   local has_cmp, cmp = pcall(require, "cmp")
   if has_cmp then

--- a/lua/avante/ipc_service.lua
+++ b/lua/avante/ipc_service.lua
@@ -228,6 +228,7 @@ end
 function M.register(name, instance_id, description, project)
   _instance_id = instance_id
   _instance_name = name
+  Utils.debug("ipc_service: register", name, instance_id, project)
   post_async("/api/v1/register", {
     name = name,
     instance_id = instance_id,
@@ -242,6 +243,7 @@ end
 ---Unregister this instance (call on sidebar close).
 function M.unregister()
   if not _instance_id then return end
+  Utils.debug("ipc_service: unregister", _instance_id, _instance_name)
   M.stop_timers()
   post_async("/api/v1/unregister", { instance_id = _instance_id }, nil)
   _instance_id = nil
@@ -343,6 +345,7 @@ end
 ---Start periodic heartbeat and message-poll timers.
 ---@param on_message fun(from_name: string, message: string)
 function M.start_timers(on_message)
+  Utils.debug("ipc_service: start_timers for", _instance_name)
   _on_message_cb = on_message
 
   if _heartbeat_timer then
@@ -362,6 +365,7 @@ end
 
 ---Stop heartbeat and poll timers.
 function M.stop_timers()
+  Utils.debug("ipc_service: stop_timers for", _instance_name)
   if _heartbeat_timer then
     _heartbeat_timer:stop()
     _heartbeat_timer:close()

--- a/lua/avante/ipc_service.lua
+++ b/lua/avante/ipc_service.lua
@@ -1,0 +1,379 @@
+---@mod avante-ipc-service Avante IPC service
+---@brief [[
+---
+--- The IPC service is a lightweight Docker/Nix sidecar that lets root Avante
+--- sidebar instances running in *separate Neovim processes* discover each other,
+--- share responsibility summaries, and exchange messages.
+---
+--- Without this service, `send_message` only works between sidebars inside the
+--- same nvim process.  With it, any nvim process with Avante open can see and
+--- message every other live instance on the machine.
+---
+--->
+---   require("avante").setup({
+---     ipc_service = {
+---       enabled = false,
+---       runner = "docker",      -- "docker" or "nix"
+---       image  = "quay.io/yetoneful/avante-ipc-service:0.0.1",
+---       docker_extra_args = "",
+---     },
+---   })
+---<
+---
+---@brief ]]
+
+local curl = require("plenary.curl")
+local PlenaryPath = require("plenary.path")
+local Config = require("avante.config")
+local Utils = require("avante.utils")
+
+local M = {}
+
+local container_name = "avante-ipc-service"
+local service_path = "/tmp/" .. container_name
+
+-- Port for the IPC service (distinct from RAG service port 20250).
+local IPC_PORT = 20251
+
+-- How often (ms) to send heartbeats / poll for incoming messages.
+local HEARTBEAT_INTERVAL_MS = 10000 -- 10 seconds
+local POLL_INTERVAL_MS = 3000 -- 3 seconds
+
+-- Module-level state.
+local _instance_id = nil ---@type string | nil
+local _instance_name = nil ---@type string | nil
+local _heartbeat_timer = nil ---@type any
+local _poll_timer = nil ---@type any
+-- Callback invoked when messages arrive: fun(from_name: string, message: string)
+local _on_message_cb = nil ---@type fun(from_name: string, message: string) | nil
+
+---@return string
+function M.get_ipc_service_url() return string.format("http://localhost:%d", IPC_PORT) end
+
+---@return string
+function M.get_ipc_service_image()
+  if Config.ipc_service and Config.ipc_service.image then return Config.ipc_service.image end
+  return "quay.io/yetoneful/avante-ipc-service:0.0.1"
+end
+
+---@return string
+function M.get_ipc_service_runner()
+  return (Config.ipc_service and Config.ipc_service.runner) or "docker"
+end
+
+---@return string
+function M.get_data_path()
+  local p = PlenaryPath:new(vim.fn.stdpath("data")):joinpath("avante/ipc_service")
+  if not p:exists() then p:mkdir({ parents = true }) end
+  return tostring(p)
+end
+
+-- ---------------------------------------------------------------------------
+-- Readiness check
+-- ---------------------------------------------------------------------------
+
+---@return boolean
+function M.is_ready()
+  local url = M.get_ipc_service_url() .. "/api/health"
+  local cmd = { "curl", "-s", "-o", "/dev/null", "-w", "%{http_code}", url }
+  local result = vim.system(cmd, { text = true }):wait()
+  return result.code == 0 and vim.trim(result.stdout or "") == "200"
+end
+
+-- ---------------------------------------------------------------------------
+-- Launch / stop
+-- ---------------------------------------------------------------------------
+
+---@param cb fun()
+function M.launch_ipc_service(cb)
+  if M.get_ipc_service_runner() == "docker" then
+    local image = M.get_ipc_service_image()
+    local data_path = M.get_data_path()
+    local docker_extra = (Config.ipc_service and Config.ipc_service.docker_extra_args) or ""
+
+    -- Check existing container state.
+    local inspect = vim.system({ "docker", "inspect", "--format", "{{.State.Status}}", container_name }, { text = true }):wait()
+    local status = vim.trim(inspect.stdout or "")
+
+    if status == "running" then
+      -- Check if it's the same image.
+      local cur_img_result = vim.system({ "docker", "inspect", "--format", "{{.Config.Image}}", container_name }, { text = true }):wait()
+      local cur_img = vim.trim(cur_img_result.stdout or "")
+      if cur_img == image then
+        cb()
+        return
+      end
+      Utils.debug(string.format("ipc container running with different image (%s vs %s), restarting", cur_img, image))
+      M.stop_ipc_service()
+    elseif status ~= "" then
+      -- Exists but not running.
+      M.stop_ipc_service()
+    end
+
+    local cmd_ = string.format(
+      "docker run --platform=linux/amd64 -d -p 0.0.0.0:%d:%d --name %s -v %s:/data -e DATA_DIR=/data %s %s",
+      IPC_PORT,
+      IPC_PORT,
+      container_name,
+      data_path,
+      docker_extra,
+      image
+    )
+    vim.fn.jobstart(cmd_, {
+      detach = true,
+      on_exit = function(_, exit_code)
+        if exit_code ~= 0 then
+          Utils.error(string.format("avante-ipc-service container failed to start (exit %d)", exit_code))
+        else
+          Utils.debug("avante-ipc-service container started")
+          cb()
+        end
+      end,
+    })
+  elseif M.get_ipc_service_runner() == "nix" then
+    local check_result = vim.system({ "pgrep", "-f", service_path }, { text = true }):wait().stdout
+    if check_result ~= "" then
+      Utils.debug("avante-ipc-service already running")
+      cb()
+      return
+    end
+
+    local dirname = Utils.trim(
+      string.sub(debug.getinfo(1).source, 2, #"/lua/avante/ipc_service.lua" * -1),
+      { suffix = "/" }
+    )
+    local ipc_service_dir = dirname .. "/py/ipc-service"
+
+    -- Spawn the nix-shell service detached. Because the process runs
+    -- indefinitely (it IS the service), the on_exit callback would never
+    -- fire during normal operation, so we cannot use it to signal readiness.
+    -- Instead, call cb() immediately and let the try_ipc_ready polling loop
+    -- in init.lua detect when the service actually responds to /api/health.
+    vim.system({ "sh", "run.sh", service_path }, {
+      detach = true,
+      cwd = ipc_service_dir,
+      env = {
+        PORT = tostring(IPC_PORT),
+        DATA_DIR = service_path,
+      },
+    })
+    cb()
+  end
+end
+
+function M.stop_ipc_service()
+  if M.get_ipc_service_runner() == "docker" then
+    local status = vim.trim((vim.system({ "docker", "inspect", "--format", "{{.State.Status}}", container_name }, { text = true }):wait().stdout) or "")
+    if status ~= "" then vim.system({ "docker", "rm", "-fv", container_name }):wait() end
+  else
+    local pid = vim.trim((vim.system({ "pgrep", "-f", service_path }, { text = true }):wait().stdout) or "")
+    if pid ~= "" then vim.system({ "kill", "-9", pid }):wait() end
+  end
+end
+
+-- ---------------------------------------------------------------------------
+-- HTTP helpers (non-blocking)
+-- ---------------------------------------------------------------------------
+
+---@param path string
+---@param body table
+---@param cb fun(ok: boolean, data: any)|nil
+local function post_async(path, body, cb)
+  local url = M.get_ipc_service_url() .. path
+  local ok, json = pcall(vim.json.encode, body)
+  if not ok then
+    Utils.debug("ipc_service: failed to encode request body: " .. tostring(json))
+    if cb then cb(false, nil) end
+    return
+  end
+  curl.post(url, {
+    body = json,
+    headers = { ["Content-Type"] = "application/json" },
+    callback = function(res)
+      if not res or res.status ~= 200 then
+        if cb then cb(false, nil) end
+        return
+      end
+      local ok2, data = pcall(vim.json.decode, res.body)
+      if cb then cb(ok2, data) end
+    end,
+  })
+end
+
+---@param path string
+---@param cb fun(ok: boolean, data: any)
+local function get_async(path, cb)
+  local url = M.get_ipc_service_url() .. path
+  curl.get(url, {
+    callback = function(res)
+      if not res or res.status ~= 200 then
+        cb(false, nil)
+        return
+      end
+      local ok, data = pcall(vim.json.decode, res.body)
+      cb(ok, data)
+    end,
+  })
+end
+
+-- ---------------------------------------------------------------------------
+-- Registry API
+-- ---------------------------------------------------------------------------
+
+---Register (or re-register) this sidebar with the IPC service.
+---@param name string Instance name, e.g. "swift-fox"
+---@param instance_id string Stable UUID from chat_history
+---@param description string Current responsibility summary
+---@param project string Absolute project root path
+function M.register(name, instance_id, description, project)
+  _instance_id = instance_id
+  _instance_name = name
+  post_async("/api/v1/register", {
+    name = name,
+    instance_id = instance_id,
+    nvim_pid = vim.fn.getpid(),
+    project = project or "",
+    description = description or "",
+  }, function(ok)
+    if not ok then Utils.debug("ipc_service: register failed") end
+  end)
+end
+
+---Unregister this instance (call on sidebar close).
+function M.unregister()
+  if not _instance_id then return end
+  M.stop_timers()
+  post_async("/api/v1/unregister", { instance_id = _instance_id }, nil)
+  _instance_id = nil
+  _instance_name = nil
+end
+
+---Update the responsibility description advertised to coworkers.
+---@param description string
+function M.update_description(description)
+  if not _instance_id then return end
+  post_async("/api/v1/update_description", {
+    instance_id = _instance_id,
+    description = description or "",
+  }, nil)
+end
+
+-- ---------------------------------------------------------------------------
+-- Instance listing (synchronous — called from tool func on the main thread)
+-- ---------------------------------------------------------------------------
+
+---Return all live peer instances (excluding self).
+---@return { name: string, project: string, description: string }[]
+function M.list_instances()
+  if not _instance_id then return {} end
+  local url = M.get_ipc_service_url()
+    .. "/api/v1/instances?exclude_instance_id="
+    .. vim.uri_encode(_instance_id)
+  local res = curl.get(url, { timeout = 3000 })
+  if not res or res.status ~= 200 then return {} end
+  local ok, data = pcall(vim.json.decode, res.body)
+  if not ok or type(data) ~= "table" then return {} end
+  return data
+end
+
+---Send a message to a named peer (synchronous).
+---@param to_name string
+---@param message string
+---@return boolean ok
+---@return string|nil err
+function M.send_message(to_name, message)
+  if not _instance_name then return false, "IPC: not registered" end
+  local url = M.get_ipc_service_url() .. "/api/v1/send_message"
+  local ok, json = pcall(vim.json.encode, {
+    from_name = _instance_name,
+    to_name = to_name,
+    message = message,
+  })
+  if not ok then return false, "IPC: encode error" end
+  local res = curl.post(url, {
+    body = json,
+    headers = { ["Content-Type"] = "application/json" },
+    timeout = 3000,
+  })
+  if not res then return false, "IPC: no response" end
+  if res.status == 404 then
+    local ok2, data = pcall(vim.json.decode, res.body or "")
+    local detail = (ok2 and data and data.detail) or "target not found"
+    return false, detail
+  end
+  if res.status ~= 200 then return false, string.format("IPC: HTTP %d", res.status) end
+  return true, nil
+end
+
+-- ---------------------------------------------------------------------------
+-- Heartbeat + message polling timers
+-- ---------------------------------------------------------------------------
+
+---Send a heartbeat, re-registering if the service has forgotten us.
+local function do_heartbeat()
+  if not _instance_id or not _instance_name then return end
+  post_async("/api/v1/heartbeat", {
+    instance_id = _instance_id,
+  }, function(ok, _)
+    if not ok then
+      -- 404 means the service was restarted; re-register.
+      Utils.debug("ipc_service: heartbeat failed, re-registering...")
+      M.register(_instance_name, _instance_id, nil, nil)
+    end
+  end)
+end
+
+---Poll for pending messages and deliver them via the registered callback.
+local function do_poll()
+  if not _instance_name then return end
+  get_async("/api/v1/poll_messages/" .. _instance_name, function(ok, data)
+    if not ok or type(data) ~= "table" then return end
+    if #data == 0 then return end
+    if not _on_message_cb then return end
+    vim.schedule(function()
+      for _, msg in ipairs(data) do
+        if _on_message_cb and msg.from_name and msg.message then
+          _on_message_cb(msg.from_name, msg.message)
+        end
+      end
+    end)
+  end)
+end
+
+---Start periodic heartbeat and message-poll timers.
+---@param on_message fun(from_name: string, message: string)
+function M.start_timers(on_message)
+  _on_message_cb = on_message
+
+  if _heartbeat_timer then
+    _heartbeat_timer:stop()
+    _heartbeat_timer:close()
+  end
+  _heartbeat_timer = vim.uv.new_timer()
+  _heartbeat_timer:start(HEARTBEAT_INTERVAL_MS, HEARTBEAT_INTERVAL_MS, vim.schedule_wrap(do_heartbeat))
+
+  if _poll_timer then
+    _poll_timer:stop()
+    _poll_timer:close()
+  end
+  _poll_timer = vim.uv.new_timer()
+  _poll_timer:start(POLL_INTERVAL_MS, POLL_INTERVAL_MS, vim.schedule_wrap(do_poll))
+end
+
+---Stop heartbeat and poll timers.
+function M.stop_timers()
+  if _heartbeat_timer then
+    _heartbeat_timer:stop()
+    _heartbeat_timer:close()
+    _heartbeat_timer = nil
+  end
+  if _poll_timer then
+    _poll_timer:stop()
+    _poll_timer:close()
+    _poll_timer = nil
+  end
+  _on_message_cb = nil
+end
+
+return M
+

--- a/lua/avante/llm.lua
+++ b/lua/avante/llm.lua
@@ -546,6 +546,54 @@ function M.generate_prompts(opts)
     messages = vim.list_extend(messages, { { role = "user", content = opts.instructions } })
   end
 
+  -- Normalize the messages array so it satisfies all provider constraints:
+  --   1. No two consecutive messages with the same role (merge their content).
+  --   2. The last message must be role = "user".
+  -- Violating either rule causes hard API errors on Anthropic-compatible models
+  -- ("assistant message prefill" / "conversation must end with a user message").
+  do
+    local normalized = {}
+    for _, msg in ipairs(messages) do
+      local prev = normalized[#normalized]
+      if prev and prev.role == msg.role then
+        -- Merge content into the previous message of the same role.
+        if type(prev.content) == "string" and type(msg.content) == "string" then
+          prev.content = prev.content .. "\n\n" .. msg.content
+        elseif type(prev.content) == "table" and type(msg.content) == "string" then
+          table.insert(prev.content, { type = "text", text = msg.content })
+        elseif type(prev.content) == "string" and type(msg.content) == "table" then
+          local merged = { { type = "text", text = prev.content } }
+          for _, item in ipairs(msg.content) do
+            table.insert(merged, item)
+          end
+          prev.content = merged
+        else
+          -- Both table form -- extend in place.
+          for _, item in ipairs(msg.content) do
+            table.insert(prev.content, item)
+          end
+        end
+      else
+        -- Different role -- add as a distinct entry (shallow-copy so we do not
+        -- mutate the caller's history_messages array).
+        table.insert(normalized, vim.tbl_extend("keep", {}, msg))
+      end
+    end
+    -- If the final message is still "assistant" after merging, drop it so the
+    -- conversation ends with a user turn. A dangling assistant message means
+    -- either a partially-streamed response slipped through the state filter, or
+    -- context messages were assembled in the wrong order. Either way the model
+    -- should reply to the preceding user message.
+    if #normalized > 0 and normalized[#normalized].role == "assistant" then
+      Utils.debug(
+        "generate_prompts: dropping trailing assistant message to satisfy "
+          .. "provider turn-order constraint"
+      )
+      table.remove(normalized)
+    end
+    messages = normalized
+  end
+
   opts.session_ctx = opts.session_ctx or {}
   opts.session_ctx.system_prompt = system_prompt
   opts.session_ctx.messages = messages
@@ -619,20 +667,114 @@ local parse_headers = function(headers_file)
   return headers
 end
 
---- Recursively sanitize a value so it can be safely JSON-encoded.
---- Removes UTF-8 surrogate code points (U+D800–U+DFFF) from all strings, replacing each
---- 3-byte surrogate sequence with the Unicode replacement character U+FFFD.
---- `vim.json.encode` (backed by cjson) rejects strings containing surrogate bytes with
---- "surrogates not allowed", which can happen when file content, clipboard data, or
---- terminal output contains lone surrogate pairs encoded in modified UTF-8 (CESU-8).
+--- Sanitize a string so it contains only valid UTF-8 and no surrogate code points.
+---
+--- Two sources of bad bytes can reach JSON encoding:
+---   1. CESU-8 / modified-UTF-8 surrogates (3 bytes: 0xED [0xA0-0xBF] [0x80-0xBF]).
+---      Produced by the JVM and some editors for codepoints above U+FFFF.
+---   2. Arbitrary non-UTF-8 bytes from binary file content, latin-1 encoded comments,
+---      clipboard data, grep output, etc.  vim.json.encode (cjson) encodes these as
+---      WTF-8 lone surrogates (\uDCxx), which strict API parsers reject with
+---      "surrogates not allowed".
+---
+--- Strategy: strip CESU-8 surrogate triplets first, then validate byte-by-byte and
+--- replace any remaining invalid bytes with U+FFFD.
+---@param s string
+---@return string
+local function sanitize_string(s)
+  -- Step 1: strip CESU-8 / modified-UTF-8 surrogate triplets.
+  s = s:gsub("\xED[\xA0-\xBF][\x80-\xBF]", "\xEF\xBF\xBD")
+
+  -- Step 2: validate remaining bytes as UTF-8; replace bad bytes with U+FFFD.
+  local out = {}
+  local i = 1
+  local len = #s
+  local repl = "\xEF\xBF\xBD" -- U+FFFD
+  while i <= len do
+    local b = s:byte(i)
+    if b < 0x80 then
+      -- ASCII: always valid.
+      out[#out + 1] = s:sub(i, i)
+      i = i + 1
+    elseif b < 0xC2 then
+      -- Lone continuation byte (0x80-0xBF) or overlong 2-byte leader (0xC0-0xC1).
+      out[#out + 1] = repl
+      i = i + 1
+    elseif b < 0xE0 then
+      -- 2-byte sequence: leader 0xC2-0xDF, one continuation 0x80-0xBF.
+      if i + 1 <= len then
+        local b2 = s:byte(i + 1)
+        if b2 >= 0x80 and b2 <= 0xBF then
+          out[#out + 1] = s:sub(i, i + 1)
+          i = i + 2
+        else
+          out[#out + 1] = repl
+          i = i + 1
+        end
+      else
+        out[#out + 1] = repl
+        i = i + 1
+      end
+    elseif b < 0xF0 then
+      -- 3-byte sequence: leader 0xE0-0xEF, two continuations.
+      if i + 2 <= len then
+        local b2, b3 = s:byte(i + 1), s:byte(i + 2)
+        local ok2 = b2 >= 0x80 and b2 <= 0xBF
+        local ok3 = b3 >= 0x80 and b3 <= 0xBF
+        -- Over-long: E0 must be followed by A0-BF.
+        if b == 0xE0 and b2 < 0xA0 then ok2 = false end
+        -- Surrogate range ED A0-BF already handled in step 1; defensive check.
+        if b == 0xED and b2 >= 0xA0 then ok2 = false end
+        if ok2 and ok3 then
+          out[#out + 1] = s:sub(i, i + 2)
+          i = i + 3
+        else
+          out[#out + 1] = repl
+          i = i + 1
+        end
+      else
+        out[#out + 1] = repl
+        i = i + 1
+      end
+    elseif b < 0xF5 then
+      -- 4-byte sequence: leader 0xF0-0xF4, three continuations.
+      -- F0 must be followed by 90-BF (over-long); F4 by 80-8F (max U+10FFFF).
+      if i + 3 <= len then
+        local b2, b3, b4 = s:byte(i + 1), s:byte(i + 2), s:byte(i + 3)
+        local ok2 = b2 >= 0x80 and b2 <= 0xBF
+        local ok3 = b3 >= 0x80 and b3 <= 0xBF
+        local ok4 = b4 >= 0x80 and b4 <= 0xBF
+        if b == 0xF0 and b2 < 0x90 then ok2 = false end
+        if b == 0xF4 and b2 > 0x8F then ok2 = false end
+        if ok2 and ok3 and ok4 then
+          out[#out + 1] = s:sub(i, i + 3)
+          i = i + 4
+        else
+          out[#out + 1] = repl
+          i = i + 1
+        end
+      else
+        out[#out + 1] = repl
+        i = i + 1
+      end
+    else
+      -- 0xF5-0xFF are never valid UTF-8.
+      out[#out + 1] = repl
+      i = i + 1
+    end
+  end
+  return table.concat(out)
+end
+
+--- Recursively sanitize a value so it can be safely JSON-encoded by cjson / vim.json.encode.
+--- All strings are passed through sanitize_string which ensures valid UTF-8 with no
+--- surrogate code points.  Tables are traversed recursively; other types are returned as-is.
 ---@param value any
 ---@return any
 local function sanitize_for_json(value)
   local t = type(value)
   if t == "string" then
-    -- UTF-8 surrogates occupy 3 bytes: 0xED [0xA0-0xBF] [0x80-0xBF]
-    -- Replace with U+FFFD (0xEF 0xBF 0xBD) to preserve string length parity.
-    return (value:gsub("\xED[\xA0-\xBF][\x80-\xBF]", "\xEF\xBF\xBD"))
+    return sanitize_string(value)
   elseif t == "table" then
     -- Preserve vim.empty_dict() marker so cjson encodes as {} not []
     if vim.tbl_isempty(value) and not vim.islist(value) then return vim.empty_dict() end

--- a/lua/avante/llm.lua
+++ b/lua/avante/llm.lua
@@ -473,9 +473,14 @@ function M.generate_prompts(opts)
           end
         end
       else
-        -- Different role -- add as a distinct entry (shallow-copy so we do not
-        -- mutate the caller's history_messages array).
-        table.insert(normalized, vim.tbl_extend("keep", {}, msg))
+        -- Different role -- add as a distinct entry.  We deep-copy so that the
+        -- merge branches above (which call table.insert on prev.content) never
+        -- mutate the original history message's content table.  A shallow copy
+        -- via vim.tbl_extend would leave prev.content pointing at the same
+        -- Lua table as the source message; subsequent merges would then
+        -- corrupt the caller's history_messages, causing duplicate tool_use /
+        -- tool_result blocks to accumulate across recursive _stream calls.
+        table.insert(normalized, vim.deepcopy(msg))
       end
     end
     -- If the final message is still "assistant" after merging, drop it so the

--- a/lua/avante/llm.lua
+++ b/lua/avante/llm.lua
@@ -484,6 +484,134 @@ function M.calculate_tokens(opts)
   return tokens
 end
 
+--- Strip CESU-8 surrogate pairs and any other invalid UTF-8 byte sequences,
+--- replacing them with the UTF-8 replacement character U+FFFD.
+--- cjson rejects strings that contain surrogate code points (0xED 0xA0-0xBF …)
+--- with "surrogates not allowed", so all user-supplied strings must be cleaned
+--- before being JSON-encoded.
+---@param s string
+---@return string
+local function sanitize_string(s)
+  if type(s) ~= "string" then return s end
+  local out = {}
+  local repl = "ï¿½" -- U+FFFD replacement character in UTF-8
+  local len = #s
+  local i = 1
+  while i <= len do
+    local b = s:byte(i)
+    if b < 0x80 then
+      -- ASCII fast path.
+      out[#out + 1] = s:sub(i, i)
+      i = i + 1
+    elseif b >= 0xED and b <= 0xED then
+      -- Surrogate range: ED [A0-BF] [80-BF] — always invalid UTF-8.
+      if i + 2 <= len then
+        local b2 = s:byte(i + 1)
+        if b2 >= 0xA0 and b2 <= 0xBF then
+          out[#out + 1] = repl
+          i = i + 3 -- skip the full 3-byte surrogate sequence
+        else
+          out[#out + 1] = repl
+          i = i + 1
+        end
+      else
+        out[#out + 1] = repl
+        i = i + 1
+      end
+    elseif b < 0xC0 then
+      -- Stray continuation byte (0x80-0xBF outside a multi-byte sequence).
+      out[#out + 1] = repl
+      i = i + 1
+    elseif b < 0xE0 then
+      -- 2-byte sequence: leader 0xC2-0xDF, one continuation 0x80-0xBF.
+      if i + 1 <= len then
+        local b2 = s:byte(i + 1)
+        if b2 >= 0x80 and b2 <= 0xBF then
+          out[#out + 1] = s:sub(i, i + 1)
+          i = i + 2
+        else
+          out[#out + 1] = repl
+          i = i + 1
+        end
+      else
+        out[#out + 1] = repl
+        i = i + 1
+      end
+    elseif b < 0xF0 then
+      -- 3-byte sequence: leader 0xE0-0xEF, two continuations.
+      if i + 2 <= len then
+        local b2, b3 = s:byte(i + 1), s:byte(i + 2)
+        local ok2 = b2 >= 0x80 and b2 <= 0xBF
+        local ok3 = b3 >= 0x80 and b3 <= 0xBF
+        -- Over-long: E0 must be followed by A0-BF.
+        if b == 0xE0 and b2 < 0xA0 then ok2 = false end
+        -- Surrogate range ED A0-BF already handled in step 1; defensive check.
+        if b == 0xED and b2 >= 0xA0 then ok2 = false end
+        if ok2 and ok3 then
+          out[#out + 1] = s:sub(i, i + 2)
+          i = i + 3
+        else
+          out[#out + 1] = repl
+          i = i + 1
+        end
+      else
+        out[#out + 1] = repl
+        i = i + 1
+      end
+    elseif b < 0xF5 then
+      -- 4-byte sequence: leader 0xF0-0xF4, three continuations.
+      -- F0 must be followed by 90-BF (over-long); F4 by 80-8F (max U+10FFFF).
+      if i + 3 <= len then
+        local b2, b3, b4 = s:byte(i + 1), s:byte(i + 2), s:byte(i + 3)
+        local ok2 = b2 >= 0x80 and b2 <= 0xBF
+        local ok3 = b3 >= 0x80 and b3 <= 0xBF
+        local ok4 = b4 >= 0x80 and b4 <= 0xBF
+        if b == 0xF0 and b2 < 0x90 then ok2 = false end
+        if b == 0xF4 and b2 > 0x8F then ok2 = false end
+        if ok2 and ok3 and ok4 then
+          out[#out + 1] = s:sub(i, i + 3)
+          i = i + 4
+        else
+          out[#out + 1] = repl
+          i = i + 1
+        end
+      else
+        out[#out + 1] = repl
+        i = i + 1
+      end
+    else
+      -- 0xF5-0xFF are never valid UTF-8.
+      out[#out + 1] = repl
+      i = i + 1
+    end
+  end
+  return table.concat(out)
+end
+
+--- Recursively sanitize a value so it can be safely JSON-encoded by cjson / vim.json.encode.
+--- All strings are passed through sanitize_string which ensures valid UTF-8 with no
+--- surrogate code points.  Tables are traversed recursively; other types are returned as-is.
+---@param value any
+---@return any
+local function sanitize_for_json(value)
+  local t = type(value)
+  if t == "string" then
+    return sanitize_string(value)
+  elseif t == "table" then
+    -- Preserve vim.empty_dict() marker so cjson encodes as {} not []
+    if vim.tbl_isempty(value) and not vim.islist(value) then return vim.empty_dict() end
+    local out = {}
+    for k, v in pairs(value) do
+      out[sanitize_for_json(k)] = sanitize_for_json(v)
+    end
+    -- Preserve array vs. hash-table metatable so cjson encodes them correctly.
+    if vim.islist(value) then return vim.list_slice(out, 1) end
+    return out
+  else
+    return value
+  end
+end
+
 local parse_headers = function(headers_file)
   local headers = {}
   local file = io.open(headers_file, "r")
@@ -592,8 +720,16 @@ function M.curl(opts)
       raw = spec.rawArgs,
     }
   else
-    -- For regular JSON requests, encode as JSON and write to file
-    local json_content = vim.json.encode(spec.body)
+    -- For regular JSON requests, encode as JSON and write to file.
+    -- sanitize_for_json strips invalid UTF-8 surrogates that cause cjson to reject the body.
+    local ok, json_content = pcall(vim.json.encode, sanitize_for_json(spec.body))
+    if not ok then
+      Utils.error("Failed to encode request body: " .. tostring(json_content), { title = "Avante" })
+      if handler_opts.on_stop then
+        handler_opts.on_stop({ reason = "error", error = { message = "Failed to encode request body: " .. tostring(json_content) } })
+      end
+      return
+    end
     fn.writefile(vim.split(json_content, "\n"), curl_body_file)
     curl_options = {
       headers = spec.headers,

--- a/lua/avante/llm.lua
+++ b/lua/avante/llm.lua
@@ -11,6 +11,7 @@ local Config = require("avante.config")
 local Path = require("avante.path")
 local Providers = require("avante.providers")
 local LLMToolHelpers = require("avante.llm_tools.helpers")
+local DispatchRegistry = require("avante.dispatch_registry")
 local LLMTools = require("avante.llm_tools")
 local History = require("avante.history")
 local HistoryRender = require("avante.history.render")
@@ -461,6 +462,14 @@ function M.generate_prompts(opts)
   if agents_rules then system_prompt = system_prompt .. "\n\n" .. agents_rules end
   local cursor_rules = Prompts.get_cursor_rules_prompt(selected_files)
   if cursor_rules then system_prompt = system_prompt .. "\n\n" .. cursor_rules end
+
+  -- Inject dispatch agent status context so the primary agent knows what is in-flight
+  if opts.session_ctx and opts.session_ctx.dispatch_session_id then
+    local dispatch_context = DispatchRegistry.get_context(opts.session_ctx.dispatch_session_id)
+    if dispatch_context and dispatch_context ~= "" then
+      system_prompt = system_prompt .. "\n\n" .. dispatch_context
+    end
+  end
 
   ---@type AvantePromptOptions
   return {

--- a/lua/avante/llm.lua
+++ b/lua/avante/llm.lua
@@ -11,6 +11,7 @@ local Config = require("avante.config")
 local Path = require("avante.path")
 local Providers = require("avante.providers")
 local LLMToolHelpers = require("avante.llm_tools.helpers")
+local DispatchRegistry = require("avante.dispatch_registry")
 local LLMTools = require("avante.llm_tools")
 local History = require("avante.history")
 local HistoryRender = require("avante.history.render")
@@ -561,6 +562,14 @@ function M.generate_prompts(opts)
   if agents_rules then system_prompt = system_prompt .. "\n\n" .. agents_rules end
   local cursor_rules = Prompts.get_cursor_rules_prompt(selected_files)
   if cursor_rules then system_prompt = system_prompt .. "\n\n" .. cursor_rules end
+
+  -- Inject dispatch agent status context so the primary agent knows what is in-flight
+  if opts.session_ctx and opts.session_ctx.dispatch_session_id then
+    local dispatch_context = DispatchRegistry.get_context(opts.session_ctx.dispatch_session_id)
+    if dispatch_context and dispatch_context ~= "" then
+      system_prompt = system_prompt .. "\n\n" .. dispatch_context
+    end
+  end
 
   ---@type AvantePromptOptions
   return {

--- a/lua/avante/llm.lua
+++ b/lua/avante/llm.lua
@@ -445,6 +445,54 @@ function M.generate_prompts(opts)
     messages = vim.list_extend(messages, { { role = "user", content = opts.instructions } })
   end
 
+  -- Normalize the messages array so it satisfies all provider constraints:
+  --   1. No two consecutive messages with the same role (merge their content).
+  --   2. The last message must be role = "user".
+  -- Violating either rule causes hard API errors on Anthropic-compatible models
+  -- ("assistant message prefill" / "conversation must end with a user message").
+  do
+    local normalized = {}
+    for _, msg in ipairs(messages) do
+      local prev = normalized[#normalized]
+      if prev and prev.role == msg.role then
+        -- Merge content into the previous message of the same role.
+        if type(prev.content) == "string" and type(msg.content) == "string" then
+          prev.content = prev.content .. "\n\n" .. msg.content
+        elseif type(prev.content) == "table" and type(msg.content) == "string" then
+          table.insert(prev.content, { type = "text", text = msg.content })
+        elseif type(prev.content) == "string" and type(msg.content) == "table" then
+          local merged = { { type = "text", text = prev.content } }
+          for _, item in ipairs(msg.content) do
+            table.insert(merged, item)
+          end
+          prev.content = merged
+        else
+          -- Both table form -- extend in place.
+          for _, item in ipairs(msg.content) do
+            table.insert(prev.content, item)
+          end
+        end
+      else
+        -- Different role -- add as a distinct entry (shallow-copy so we do not
+        -- mutate the caller's history_messages array).
+        table.insert(normalized, vim.tbl_extend("keep", {}, msg))
+      end
+    end
+    -- If the final message is still "assistant" after merging, drop it so the
+    -- conversation ends with a user turn. A dangling assistant message means
+    -- either a partially-streamed response slipped through the state filter, or
+    -- context messages were assembled in the wrong order. Either way the model
+    -- should reply to the preceding user message.
+    if #normalized > 0 and normalized[#normalized].role == "assistant" then
+      Utils.debug(
+        "generate_prompts: dropping trailing assistant message to satisfy "
+          .. "provider turn-order constraint"
+      )
+      table.remove(normalized)
+    end
+    messages = normalized
+  end
+
   opts.session_ctx = opts.session_ctx or {}
   opts.session_ctx.system_prompt = system_prompt
   opts.session_ctx.messages = messages

--- a/lua/avante/llm.lua
+++ b/lua/avante/llm.lua
@@ -574,9 +574,14 @@ function M.generate_prompts(opts)
           end
         end
       else
-        -- Different role -- add as a distinct entry (shallow-copy so we do not
-        -- mutate the caller's history_messages array).
-        table.insert(normalized, vim.tbl_extend("keep", {}, msg))
+        -- Different role -- add as a distinct entry.  We deep-copy so that the
+        -- merge branches above (which call table.insert on prev.content) never
+        -- mutate the original history message's content table.  A shallow copy
+        -- via vim.tbl_extend would leave prev.content pointing at the same
+        -- Lua table as the source message; subsequent merges would then
+        -- corrupt the caller's history_messages, causing duplicate tool_use /
+        -- tool_result blocks to accumulate across recursive _stream calls.
+        table.insert(normalized, vim.deepcopy(msg))
       end
     end
     -- If the final message is still "assistant" after merging, drop it so the

--- a/lua/avante/llm.lua
+++ b/lua/avante/llm.lua
@@ -29,9 +29,28 @@ local group = api.nvim_create_augroup("avante_llm", { clear = true })
 ---@param prev_memory string | nil
 ---@param history_messages avante.HistoryMessage[]
 ---@param cb fun(memory: avante.ChatMemory | nil): nil
-function M.summarize_memory(prev_memory, history_messages, cb)
-  local system_prompt =
-    [[You are an expert coding assistant. Your goal is to generate a concise, structured summary of the conversation below that captures all essential information needed to continue development after context replacement. Include tasks performed, code areas modified or reviewed, key decisions or assumptions, test results or errors, and outstanding tasks or next steps.]]
+---@param prev_memory string | nil
+---@param history_messages avante.HistoryMessage[]
+---@param cb fun(memory: avante.ChatMemory | nil): nil
+---@param mode? "compact" | "simplify"  -- "compact" (default): readable structured summary; "simplify": ultra-terse bullet points
+function M.summarize_memory(prev_memory, history_messages, cb, mode)
+  local system_prompt
+  local user_prompt_suffix
+  if mode == "simplify" then
+    system_prompt = [[You are an expert software engineering assistant.
+Your task is to create the most compact possible summary of a coding conversation.
+Be EXTREMELY concise. Include only what an engineer MUST know to continue the work:
+- Current state of the code (what was built, changed, or fixed)
+- Exact errors or blockers still unresolved
+- The precise next step(s) remaining
+- Any critical decisions, constraints, or gotchas
+Omit all explanations, rationale, and conversational filler. Output dense, terse bullet points.]]
+    user_prompt_suffix = "\n\nProvide the minimal engineering-context summary. Use terse bullet points only."
+  else
+    system_prompt = [[You are an expert coding assistant. Your goal is to generate a concise, structured summary of the conversation below that captures all essential information needed to continue development after context replacement. Include tasks performed, code areas modified or reviewed, key decisions or assumptions, test results or errors, and outstanding tasks or next steps.]]
+    user_prompt_suffix = "\n\nPlease summarize this conversation, covering:\n1. Tasks performed and outcomes\n2. Code files, modules, or functions modified or examined\n3. Important decisions or assumptions made\n4. Errors encountered and test or build results\n5. Remaining tasks, open questions, or next steps\nProvide the summary in a clear, concise format."
+  end
+
   if #history_messages == 0 then
     cb(nil)
     return
@@ -55,9 +74,7 @@ function M.summarize_memory(prev_memory, history_messages, cb)
     :map(function(msg) return msg.message.role .. ": " .. HistoryRender.message_to_text(msg, history_messages) end)
     :totable()
   local conversation_text = table.concat(conversation_items, "\n")
-  local user_prompt = "Here is the conversation so far:\n"
-    .. conversation_text
-    .. "\n\nPlease summarize this conversation, covering:\n1. Tasks performed and outcomes\n2. Code files, modules, or functions modified or examined\n3. Important decisions or assumptions made\n4. Errors encountered and test or build results\n5. Remaining tasks, open questions, or next steps\nProvide the summary in a clear, concise format."
+  local user_prompt = "Here is the conversation so far:\n" .. conversation_text .. user_prompt_suffix
   if prev_memory then user_prompt = user_prompt .. "\n\nThe previous summary is:\n\n" .. prev_memory end
   local messages = {
     {
@@ -92,6 +109,89 @@ function M.summarize_memory(prev_memory, history_messages, cb)
             last_message_uuid = latest_message_uuid,
           }
           cb(memory)
+        else
+          cb(nil)
+        end
+      end,
+    },
+  })
+end
+
+--- Alias for `summarize_memory` with mode="simplify".
+--- Kept as a separate entry-point so call-sites remain explicit.
+---@param prev_memory string | nil
+---@param history_messages avante.HistoryMessage[]
+---@param cb fun(memory: avante.ChatMemory | nil): nil
+function M.simplify_history(prev_memory, history_messages, cb)
+  M.summarize_memory(prev_memory, history_messages, cb, "simplify")
+end
+
+--- Draft a message to send to another Avante chat instance.
+--- The LLM uses the current conversation history as context and composes a
+--- self-contained message that captures the user's intent so that the
+--- receiving instance has all the information it needs.
+---@param history_messages avante.HistoryMessage[]  current chat's history
+---@param user_intent string                        what the user wants to communicate
+---@param sender_name string                        instance name of the sending chat
+---@param target_name string                        instance name of the receiving chat
+---@param cb fun(drafted_message: string | nil): nil
+function M.draft_inter_instance_message(history_messages, user_intent, sender_name, target_name, cb)
+  local system_prompt = string.format(
+    [[You are the AI assistant for the coding chat session "%s".
+You are composing a message to send to another AI assistant session named "%s".
+Both sessions are running concurrently inside the same editor on the same codebase.
+
+Given the conversation history below and the user's stated intent, draft a clear,
+self-contained message for the receiving session.  The message must:
+- Include all context the receiving session needs (it cannot see our history)
+- Be concise but complete — the receiver will act on it directly
+- Sound like a peer-to-peer handoff, not a forwarded chat log
+
+Output ONLY the message body — no preamble, no "Here is the message:", no quotes.]],
+    sender_name,
+    target_name
+  )
+
+  local conversation_items = vim
+    .iter(history_messages)
+    :filter(function(msg) return not msg.is_dummy and not msg.just_for_display end)
+    :map(function(msg) return msg.message.role .. ": " .. HistoryRender.message_to_text(msg, history_messages) end)
+    :totable()
+  local conversation_text = table.concat(conversation_items, "\n")
+
+  local user_prompt = "Current conversation history:\n"
+    .. conversation_text
+    .. "\n\nUser's intent for the message to send:\n"
+    .. user_intent
+    .. "\n\nDraft the message to send to ["
+    .. target_name
+    .. "]:"
+
+  local messages = { { role = "user", content = user_prompt } }
+  local response_content = ""
+  local provider = Providers.get_memory_summary_provider()
+
+  M.curl({
+    provider = provider,
+    prompt_opts = {
+      system_prompt = system_prompt,
+      messages = messages,
+    },
+    handler_opts = {
+      on_start = function(_) end,
+      on_chunk = function(chunk)
+        if not chunk then return end
+        response_content = response_content .. chunk
+      end,
+      on_stop = function(stop_opts)
+        if stop_opts.error ~= nil then
+          Utils.error(string.format("draft_inter_instance_message failed: %s", vim.inspect(stop_opts.error)))
+          cb(nil)
+          return
+        end
+        if stop_opts.reason == "complete" then
+          response_content = Utils.trim_think_content(response_content)
+          cb(response_content ~= "" and response_content or nil)
         else
           cb(nil)
         end

--- a/lua/avante/llm.lua
+++ b/lua/avante/llm.lua
@@ -778,15 +778,7 @@ function M.curl(opts)
   return active_job
 end
 
-local retry_timer = nil
-local abort_retry_timer = false
-local function stop_retry_timer()
-  if retry_timer then
-    retry_timer:stop()
-    pcall(function() retry_timer:close() end)
-    retry_timer = nil
-  end
-end
+
 
 -- Intelligently truncate chat history for session recovery to avoid token limits
 ---@param history_messages table[]
@@ -1751,8 +1743,25 @@ end
 
 ---@param opts AvanteLLMStreamOptions
 function M._stream(opts)
-  -- Reset the cancellation flag at the start of a new request
+  -- Initialise the per-session cancellation flag.  Using session_ctx isolates each
+  -- avante instance so that cancelling one stream does not affect concurrent streams
+  -- running in other sidebar instances.
+  opts.session_ctx = opts.session_ctx or {}
+  opts.session_ctx.is_cancelled = false
+  -- Keep the legacy global in sync for any code that still reads it directly.
   if LLMToolHelpers then LLMToolHelpers.is_cancelled = false end
+
+  -- Per-stream retry-timer state. Using per-stream locals instead of module-level
+  -- variables prevents multiple avante instances from clobbering each other's timers.
+  local retry_timer = nil
+  local stream_cancelled = false
+  local function stop_retry_timer()
+    if retry_timer then
+      retry_timer:stop()
+      pcall(function() retry_timer:close() end)
+      retry_timer = nil
+    end
+  end
 
   local acp_provider = Config.acp_providers[Config.provider]
   if acp_provider then return M._stream_acp(opts) end
@@ -1911,7 +1920,13 @@ function M._stream(opts)
         })
         if result ~= nil or error ~= nil then return handle_tool_result(result, error) end
       end
-      if stop_opts.reason == "cancelled" then dispatch_cancel_message() end
+      if stop_opts.reason == "cancelled" then
+        stream_cancelled = true -- signal any running retry countdown to stop
+        -- Per-session flag: lets process_tool_use polling detect the cancel
+        -- without touching other instances' session_ctx.
+        opts.session_ctx.is_cancelled = true
+        dispatch_cancel_message()
+      end
       local history_messages = opts.get_history_messages and opts.get_history_messages({ all = true }) or {}
       local pending_tools, pending_tool_use_messages = History.get_pending_tools(history_messages)
       if stop_opts.reason == "complete" and Config.mode == "agentic" then
@@ -1993,10 +2008,12 @@ function M._stream(opts)
         Utils.info("Rate limit reached. Retrying in " .. retry_count .. " seconds", { title = "Avante" })
 
         local function countdown()
-          if abort_retry_timer then
+          -- stream_cancelled is set to true when on_stop fires with reason "cancelled"
+          -- (triggered by the CANCEL_PATTERN autocmd from cancel_inflight_request).
+          -- dispatch_cancel_message() is already called at that point; here we just stop.
+          if stream_cancelled then
             Utils.info("Retry aborted due to user requested cancellation.")
             stop_retry_timer()
-            dispatch_cancel_message()
             return
           end
 
@@ -2168,7 +2185,6 @@ function M.stream(opts)
 
   opts.mode = opts.mode or Config.mode
 
-  abort_retry_timer = false
   if Config.dual_boost.enabled and valid_dual_boost_modes[opts.mode] then
     M._dual_boost_stream(
       opts,
@@ -2181,13 +2197,15 @@ function M.stream(opts)
 end
 
 function M.cancel_inflight_request()
-  if LLMToolHelpers.is_cancelled ~= nil then LLMToolHelpers.is_cancelled = true end
+  -- Close any open confirmation popup immediately.
   if LLMToolHelpers.confirm_popup ~= nil then
     LLMToolHelpers.confirm_popup:cancel()
     LLMToolHelpers.confirm_popup = nil
   end
-  abort_retry_timer = true
-
+  -- Fire the CANCEL_PATTERN autocmd.  Each active _stream() invocation has registered
+  -- a once-handler that (a) shuts down the curl job and (b) calls on_stop({reason="cancelled"}),
+  -- which in turn sets session_ctx.is_cancelled=true so tool-execution polling stops,
+  -- and stream_cancelled=true so any running rate-limit retry countdown stops.
   api.nvim_exec_autocmds("User", { pattern = M.CANCEL_PATTERN })
 end
 

--- a/lua/avante/llm.lua
+++ b/lua/avante/llm.lua
@@ -29,9 +29,28 @@ local group = api.nvim_create_augroup("avante_llm", { clear = true })
 ---@param prev_memory string | nil
 ---@param history_messages avante.HistoryMessage[]
 ---@param cb fun(memory: avante.ChatMemory | nil): nil
-function M.summarize_memory(prev_memory, history_messages, cb)
-  local system_prompt =
-    [[You are an expert coding assistant. Your goal is to generate a concise, structured summary of the conversation below that captures all essential information needed to continue development after context replacement. Include tasks performed, code areas modified or reviewed, key decisions or assumptions, test results or errors, and outstanding tasks or next steps.]]
+---@param prev_memory string | nil
+---@param history_messages avante.HistoryMessage[]
+---@param cb fun(memory: avante.ChatMemory | nil): nil
+---@param mode? "compact" | "simplify"  -- "compact" (default): readable structured summary; "simplify": ultra-terse bullet points
+function M.summarize_memory(prev_memory, history_messages, cb, mode)
+  local system_prompt
+  local user_prompt_suffix
+  if mode == "simplify" then
+    system_prompt = [[You are an expert software engineering assistant.
+Your task is to create the most compact possible summary of a coding conversation.
+Be EXTREMELY concise. Include only what an engineer MUST know to continue the work:
+- Current state of the code (what was built, changed, or fixed)
+- Exact errors or blockers still unresolved
+- The precise next step(s) remaining
+- Any critical decisions, constraints, or gotchas
+Omit all explanations, rationale, and conversational filler. Output dense, terse bullet points.]]
+    user_prompt_suffix = "\n\nProvide the minimal engineering-context summary. Use terse bullet points only."
+  else
+    system_prompt = [[You are an expert coding assistant. Your goal is to generate a concise, structured summary of the conversation below that captures all essential information needed to continue development after context replacement. Include tasks performed, code areas modified or reviewed, key decisions or assumptions, test results or errors, and outstanding tasks or next steps.]]
+    user_prompt_suffix = "\n\nPlease summarize this conversation, covering:\n1. Tasks performed and outcomes\n2. Code files, modules, or functions modified or examined\n3. Important decisions or assumptions made\n4. Errors encountered and test or build results\n5. Remaining tasks, open questions, or next steps\nProvide the summary in a clear, concise format."
+  end
+
   if #history_messages == 0 then
     cb(nil)
     return
@@ -55,9 +74,7 @@ function M.summarize_memory(prev_memory, history_messages, cb)
     :map(function(msg) return msg.message.role .. ": " .. HistoryRender.message_to_text(msg, history_messages) end)
     :totable()
   local conversation_text = table.concat(conversation_items, "\n")
-  local user_prompt = "Here is the conversation so far:\n"
-    .. conversation_text
-    .. "\n\nPlease summarize this conversation, covering:\n1. Tasks performed and outcomes\n2. Code files, modules, or functions modified or examined\n3. Important decisions or assumptions made\n4. Errors encountered and test or build results\n5. Remaining tasks, open questions, or next steps\nProvide the summary in a clear, concise format."
+  local user_prompt = "Here is the conversation so far:\n" .. conversation_text .. user_prompt_suffix
   if prev_memory then user_prompt = user_prompt .. "\n\nThe previous summary is:\n\n" .. prev_memory end
   local messages = {
     {
@@ -92,6 +109,89 @@ function M.summarize_memory(prev_memory, history_messages, cb)
             last_message_uuid = latest_message_uuid,
           }
           cb(memory)
+        else
+          cb(nil)
+        end
+      end,
+    },
+  })
+end
+
+--- Alias for `summarize_memory` with mode="simplify".
+--- Kept as a separate entry-point so call-sites remain explicit.
+---@param prev_memory string | nil
+---@param history_messages avante.HistoryMessage[]
+---@param cb fun(memory: avante.ChatMemory | nil): nil
+function M.simplify_history(prev_memory, history_messages, cb)
+  M.summarize_memory(prev_memory, history_messages, cb, "simplify")
+end
+
+--- Draft a message to send to another Avante chat instance.
+--- The LLM uses the current conversation history as context and composes a
+--- self-contained message that captures the user's intent so that the
+--- receiving instance has all the information it needs.
+---@param history_messages avante.HistoryMessage[]  current chat's history
+---@param user_intent string                        what the user wants to communicate
+---@param sender_name string                        instance name of the sending chat
+---@param target_name string                        instance name of the receiving chat
+---@param cb fun(drafted_message: string | nil): nil
+function M.draft_inter_instance_message(history_messages, user_intent, sender_name, target_name, cb)
+  local system_prompt = string.format(
+    [[You are the AI assistant for the coding chat session "%s".
+You are composing a message to send to another AI assistant session named "%s".
+Both sessions are running concurrently inside the same editor on the same codebase.
+
+Given the conversation history below and the user's stated intent, draft a clear,
+self-contained message for the receiving session.  The message must:
+- Include all context the receiving session needs (it cannot see our history)
+- Be concise but complete — the receiver will act on it directly
+- Sound like a peer-to-peer handoff, not a forwarded chat log
+
+Output ONLY the message body — no preamble, no "Here is the message:", no quotes.]],
+    sender_name,
+    target_name
+  )
+
+  local conversation_items = vim
+    .iter(history_messages)
+    :filter(function(msg) return not msg.is_dummy and not msg.just_for_display end)
+    :map(function(msg) return msg.message.role .. ": " .. HistoryRender.message_to_text(msg, history_messages) end)
+    :totable()
+  local conversation_text = table.concat(conversation_items, "\n")
+
+  local user_prompt = "Current conversation history:\n"
+    .. conversation_text
+    .. "\n\nUser's intent for the message to send:\n"
+    .. user_intent
+    .. "\n\nDraft the message to send to ["
+    .. target_name
+    .. "]:"
+
+  local messages = { { role = "user", content = user_prompt } }
+  local response_content = ""
+  local provider = Providers.get_memory_summary_provider()
+
+  M.curl({
+    provider = provider,
+    prompt_opts = {
+      system_prompt = system_prompt,
+      messages = messages,
+    },
+    handler_opts = {
+      on_start = function(_) end,
+      on_chunk = function(chunk)
+        if not chunk then return end
+        response_content = response_content .. chunk
+      end,
+      on_stop = function(stop_opts)
+        if stop_opts.error ~= nil then
+          Utils.error(string.format("draft_inter_instance_message failed: %s", vim.inspect(stop_opts.error)))
+          cb(nil)
+          return
+        end
+        if stop_opts.reason == "complete" then
+          response_content = Utils.trim_think_content(response_content)
+          cb(response_content ~= "" and response_content or nil)
         else
           cb(nil)
         end
@@ -510,6 +610,35 @@ local parse_headers = function(headers_file)
   return headers
 end
 
+--- Recursively sanitize a value so it can be safely JSON-encoded.
+--- Removes UTF-8 surrogate code points (U+D800–U+DFFF) from all strings, replacing each
+--- 3-byte surrogate sequence with the Unicode replacement character U+FFFD.
+--- `vim.json.encode` (backed by cjson) rejects strings containing surrogate bytes with
+--- "surrogates not allowed", which can happen when file content, clipboard data, or
+--- terminal output contains lone surrogate pairs encoded in modified UTF-8 (CESU-8).
+---@param value any
+---@return any
+local function sanitize_for_json(value)
+  local t = type(value)
+  if t == "string" then
+    -- UTF-8 surrogates occupy 3 bytes: 0xED [0xA0-0xBF] [0x80-0xBF]
+    -- Replace with U+FFFD (0xEF 0xBF 0xBD) to preserve string length parity.
+    return (value:gsub("\xED[\xA0-\xBF][\x80-\xBF]", "\xEF\xBF\xBD"))
+  elseif t == "table" then
+    -- Preserve vim.empty_dict() marker so cjson encodes as {} not []
+    if vim.tbl_isempty(value) and not vim.islist(value) then return vim.empty_dict() end
+    local out = {}
+    for k, v in pairs(value) do
+      out[sanitize_for_json(k)] = sanitize_for_json(v)
+    end
+    -- Preserve array vs. hash-table metatable so cjson encodes them correctly.
+    if vim.islist(value) then return vim.list_slice(out, 1) end
+    return out
+  else
+    return value
+  end
+end
+
 ---@param opts avante.CurlOpts
 function M.curl(opts)
   local provider = opts.provider
@@ -592,8 +721,16 @@ function M.curl(opts)
       raw = spec.rawArgs,
     }
   else
-    -- For regular JSON requests, encode as JSON and write to file
-    local json_content = vim.json.encode(spec.body)
+    -- For regular JSON requests, encode as JSON and write to file.
+    -- sanitize_for_json strips invalid UTF-8 surrogates that cause cjson to reject the body.
+    local ok, json_content = pcall(vim.json.encode, sanitize_for_json(spec.body))
+    if not ok then
+      Utils.error("Failed to encode request body: " .. tostring(json_content), { title = "Avante" })
+      if handler_opts.on_stop then
+        handler_opts.on_stop({ reason = "error", error = { message = "Failed to encode request body: " .. tostring(json_content) } })
+      end
+      return
+    end
     fn.writefile(vim.split(json_content, "\n"), curl_body_file)
     curl_options = {
       headers = spec.headers,
@@ -776,16 +913,6 @@ function M.curl(opts)
   })
 
   return active_job
-end
-
-local retry_timer = nil
-local abort_retry_timer = false
-local function stop_retry_timer()
-  if retry_timer then
-    retry_timer:stop()
-    pcall(function() retry_timer:close() end)
-    retry_timer = nil
-  end
 end
 
 -- Intelligently truncate chat history for session recovery to avoid token limits
@@ -1253,10 +1380,9 @@ function M._stream_acp(opts)
             end
             return
           end
-          ---@type string[]
-          local file_lines = lines or {}
-          if line ~= nil and limit ~= nil then file_lines = vim.list_slice(file_lines, line, line + limit) end
-          local content = table.concat(file_lines, "\n")
+          lines = lines or {}
+          if line ~= nil and limit ~= nil then lines = vim.list_slice(lines, line, line + limit) end
+          local content = table.concat(lines, "\n")
           if
             last_tool_call_message
             and last_tool_call_message.acp_tool_call
@@ -1751,8 +1877,25 @@ end
 
 ---@param opts AvanteLLMStreamOptions
 function M._stream(opts)
-  -- Reset the cancellation flag at the start of a new request
+  -- Initialise the per-session cancellation flag.  Using session_ctx isolates each
+  -- avante instance so that cancelling one stream does not affect concurrent streams
+  -- running in other sidebar instances.
+  opts.session_ctx = opts.session_ctx or {}
+  opts.session_ctx.is_cancelled = false
+  -- Keep the legacy global in sync for any code that still reads it directly.
   if LLMToolHelpers then LLMToolHelpers.is_cancelled = false end
+
+  -- Per-stream retry-timer state. Using per-stream locals instead of module-level
+  -- variables prevents multiple avante instances from clobbering each other's timers.
+  local retry_timer = nil
+  local stream_cancelled = false
+  local function stop_retry_timer()
+    if retry_timer then
+      retry_timer:stop()
+      pcall(function() retry_timer:close() end)
+      retry_timer = nil
+    end
+  end
 
   local acp_provider = Config.acp_providers[Config.provider]
   if acp_provider then return M._stream_acp(opts) end
@@ -1911,7 +2054,13 @@ function M._stream(opts)
         })
         if result ~= nil or error ~= nil then return handle_tool_result(result, error) end
       end
-      if stop_opts.reason == "cancelled" then dispatch_cancel_message() end
+      if stop_opts.reason == "cancelled" then
+        stream_cancelled = true -- signal any running retry countdown to stop
+        -- Per-session flag: lets process_tool_use polling detect the cancel
+        -- without touching other instances' session_ctx.
+        opts.session_ctx.is_cancelled = true
+        dispatch_cancel_message()
+      end
       local history_messages = opts.get_history_messages and opts.get_history_messages({ all = true }) or {}
       local pending_tools, pending_tool_use_messages = History.get_pending_tools(history_messages)
       if stop_opts.reason == "complete" and Config.mode == "agentic" then
@@ -1993,10 +2142,12 @@ function M._stream(opts)
         Utils.info("Rate limit reached. Retrying in " .. retry_count .. " seconds", { title = "Avante" })
 
         local function countdown()
-          if abort_retry_timer then
+          -- stream_cancelled is set to true when on_stop fires with reason "cancelled"
+          -- (triggered by the CANCEL_PATTERN autocmd from cancel_inflight_request).
+          -- dispatch_cancel_message() is already called at that point; here we just stop.
+          if stream_cancelled then
             Utils.info("Retry aborted due to user requested cancellation.")
             stop_retry_timer()
-            dispatch_cancel_message()
             return
           end
 
@@ -2168,7 +2319,6 @@ function M.stream(opts)
 
   opts.mode = opts.mode or Config.mode
 
-  abort_retry_timer = false
   if Config.dual_boost.enabled and valid_dual_boost_modes[opts.mode] then
     M._dual_boost_stream(
       opts,
@@ -2181,13 +2331,15 @@ function M.stream(opts)
 end
 
 function M.cancel_inflight_request()
-  if LLMToolHelpers.is_cancelled ~= nil then LLMToolHelpers.is_cancelled = true end
+  -- Close any open confirmation popup immediately.
   if LLMToolHelpers.confirm_popup ~= nil then
     LLMToolHelpers.confirm_popup:cancel()
     LLMToolHelpers.confirm_popup = nil
   end
-  abort_retry_timer = true
-
+  -- Fire the CANCEL_PATTERN autocmd.  Each active _stream() invocation has registered
+  -- a once-handler that (a) shuts down the curl job and (b) calls on_stop({reason="cancelled"}),
+  -- which in turn sets session_ctx.is_cancelled=true so tool-execution polling stops,
+  -- and stream_cancelled=true so any running rate-limit retry countdown stops.
   api.nvim_exec_autocmds("User", { pattern = M.CANCEL_PATTERN })
 end
 

--- a/lua/avante/llm.lua
+++ b/lua/avante/llm.lua
@@ -646,6 +646,167 @@ function M.calculate_tokens(opts)
   return tokens
 end
 
+--- Return a per-component token breakdown for the given prompt options.
+--- Each entry in the returned list is { name: string, tokens: integer }.
+--- The second return value is the grand total.
+---@param opts AvanteGeneratePromptsOptions
+---@return { name: string, tokens: integer }[], integer
+function M.calculate_tokens_breakdown(opts)
+  if Config.acp_providers[Config.provider] then return {}, 0 end
+
+  local project_instruction_file = Config.instructions_file or "avante.md"
+  local project_root = tostring(Utils.root.get())
+  local instruction_file_path = vim.fs.joinpath(project_root, project_instruction_file)
+  local instructions_content = ""
+
+  if vim.uv.fs_stat(instruction_file_path) and not opts._instructions_loaded then
+    local lines = Utils.read_file_from_buf_or_disk(vim.fs.abspath(instruction_file_path))
+    instructions_content = lines and table.concat(lines, "\n") or ""
+  end
+
+  local mode = opts.mode or Config.mode
+  local system_info = Utils.get_system_info()
+
+  -- Resolve selected_files (same logic as generate_prompts)
+  local selected_files = opts.selected_files or {}
+  if opts.selected_filepaths then
+    for _, filepath in ipairs(opts.selected_filepaths) do
+      local lines, error = Utils.read_file_from_buf_or_disk(filepath)
+      if error == nil then
+        local content = table.concat(lines or {}, "\n")
+        local filetype = Utils.get_filetype(filepath)
+        table.insert(selected_files, { path = filepath, content = content, file_type = filetype })
+      end
+    end
+  end
+
+  -- Strip files already viewed via tool_use (same as generate_prompts)
+  local viewed_files = {}
+  if opts.history_messages then
+    for _, message in ipairs(opts.history_messages) do
+      local use = History.Helpers.get_tool_use_data(message)
+      if use and use.name == "view" and use.input.path then
+        local uniform_path = Utils.uniform_path(use.input.path)
+        viewed_files[uniform_path] = use.id
+      end
+    end
+  end
+  selected_files = vim.iter(selected_files):filter(function(file) return viewed_files[file.path] == nil end):totable()
+
+  local is_acp_provider = false
+  if not opts.provider then is_acp_provider = Config.acp_providers[Config.provider] ~= nil end
+  local model_name = "unknown"
+  local use_react_prompt = false
+  if not is_acp_provider then
+    local provider = opts.provider or Providers[Config.provider]
+    model_name = provider.model or "unknown"
+    local provider_conf = Providers.parse_config(provider)
+    use_react_prompt = provider_conf.use_ReAct_prompt
+  end
+
+  Path.prompts.initialize(Path.prompts.get_templates_dir(project_root), project_root)
+
+  local template_opts = {
+    ask = opts.ask,
+    code_lang = opts.code_lang,
+    selected_files = selected_files,
+    selected_code = opts.selected_code,
+    recently_viewed_files = opts.recently_viewed_files,
+    project_context = opts.project_context,
+    diagnostics = opts.diagnostics,
+    system_info = system_info,
+    model_name = model_name,
+    memory = opts.memory,
+    enable_fastapply = Config.behaviour.enable_fastapply,
+    use_react_prompt = use_react_prompt,
+  }
+
+  ---@type { name: string, tokens: integer }[]
+  local breakdown = {}
+  local total = 0
+
+  local function add(name, content)
+    if not content or content == "" or content == "null" then return end
+    local t = Utils.tokens.calculate_tokens(content)
+    if t > 0 then
+      table.insert(breakdown, { name = name, tokens = t })
+      total = total + t
+    end
+  end
+
+  -- Base system prompt (rendered from mode templates)
+  local base_system_prompt = Path.prompts.render_mode(mode, template_opts)
+  add("System prompt (base template)", base_system_prompt)
+
+  -- Custom system prompt from user config
+  if Config.system_prompt ~= nil then
+    local custom_system_prompt
+    if type(Config.system_prompt) == "function" then custom_system_prompt = Config.system_prompt() end
+    if type(Config.system_prompt) == "string" then custom_system_prompt = Config.system_prompt end
+    if custom_system_prompt and custom_system_prompt ~= "" and custom_system_prompt ~= "null" then
+      add("Custom system prompt (config.system_prompt)", custom_system_prompt)
+    end
+  end
+
+  -- Agents rules: AGENTS.md, CLAUDE.md, OPENCODE.md, .cursorrules, .windsurfrules, etc.
+  local agents_rules = Prompts.get_agents_rules_prompt()
+  if agents_rules then add("Agents rules (AGENTS.md / CLAUDE.md / .cursorrules …)", agents_rules) end
+
+  -- Cursor rules: .cursor/rules/*.mdc files with alwaysApply or matching globs
+  local cursor_rules = Prompts.get_cursor_rules_prompt(selected_files)
+  if cursor_rules then add("Cursor rules (.cursor/rules/*.mdc)", cursor_rules) end
+
+  -- Project context (repo map) – only when @codebase mention is used
+  if opts.project_context ~= nil and opts.project_context ~= "" and opts.project_context ~= "null" then
+    local project_context = Path.prompts.render_file("_project.avanterules", template_opts)
+    add("Project context / repo map (@codebase)", project_context)
+  end
+
+  -- Diagnostics
+  if opts.diagnostics ~= nil and opts.diagnostics ~= "" and opts.diagnostics ~= "null" then
+    local diagnostics = Path.prompts.render_file("_diagnostics.avanterules", template_opts)
+    add("Diagnostics (@diagnostics)", diagnostics)
+  end
+
+  -- Selected files / code context
+  if #selected_files > 0 or opts.selected_code ~= nil then
+    local code_context = Path.prompts.render_file("_context.avanterules", template_opts)
+    add("Selected files / code context", code_context)
+  end
+
+  -- Conversation memory summary
+  if opts.memory ~= nil and opts.memory ~= "" and opts.memory ~= "null" then
+    local memory = Path.prompts.render_file("_memory.avanterules", template_opts)
+    add("Conversation memory (summary)", memory)
+  end
+
+  -- Instructions file (avante.md in project root)
+  add(string.format("Instructions file (%s)", project_instruction_file), instructions_content)
+
+  -- History messages
+  if opts.history_messages and #opts.history_messages > 0 then
+    local history_tokens = 0
+    for _, msg in ipairs(opts.history_messages) do
+      history_tokens = history_tokens + Utils.tokens.calculate_tokens(msg.message.content)
+    end
+    if history_tokens > 0 then
+      table.insert(
+        breakdown,
+        { name = string.format("History messages (%d)", #opts.history_messages), tokens = history_tokens }
+      )
+      total = total + history_tokens
+    end
+  end
+
+  -- Dispatch agent context (only when a dispatch session is active)
+  if opts.session_ctx and opts.session_ctx.dispatch_session_id then
+    local dispatch_context = DispatchRegistry.get_context(opts.session_ctx.dispatch_session_id)
+    if dispatch_context then add("Dispatch agent context", dispatch_context) end
+  end
+
+  return breakdown, total
+end
+
 --- Strip CESU-8 surrogate pairs and any other invalid UTF-8 byte sequences,
 --- replacing them with the UTF-8 replacement character U+FFFD.
 --- cjson rejects strings that contain surrogate code points (0xED 0xA0-0xBF …)

--- a/lua/avante/llm_tools/dispatch_agent.lua
+++ b/lua/avante/llm_tools/dispatch_agent.lua
@@ -5,6 +5,7 @@ local Base = require("avante.llm_tools.base")
 local History = require("avante.history")
 local Line = require("avante.ui.line")
 local Highlights = require("avante.highlights")
+local DispatchRegistry = require("avante.dispatch_registry")
 
 ---@class AvanteLLMTool
 local M = setmetatable({}, Base)
@@ -14,30 +15,49 @@ M.name = "dispatch_agent"
 M.get_description = function()
   local provider = Providers[Config.provider]
   if Config.provider:match("copilot") and provider.model and provider.model:match("gpt") then
-    return [[Launch a new agent that has access to the following tools: `glob`, `grep`, `ls`, `view`, `attempt_completion`. When you are searching for a keyword or file and are not confident that you will find the right match on the first try, use the Agent tool to perform the search for you.]]
+    return [[Launch a new agent that has access to the following tools: `glob`, `grep`, `ls`, `view`, `attempt_completion`. Use dispatch_agent when you need to search for keywords, files, or patterns across the codebase, or gather and SYNTHESIZE context while you continue working on other tasks.
+
+IMPORTANT: dispatch_agent is ASYNCHRONOUS. It returns immediately with a dispatch ID. The sub-agent runs in the background. Results will be delivered to you automatically when the dispatch completes. You can continue working on other tasks while dispatches are running. Check the dispatch status section at the top of the conversation for updates.
+
+KEY RULE: The sub-agent must REDUCE and SYNTHESIZE information — it must NOT dump raw file contents. Ask specific questions; get concise answers back.]]
   end
 
-  return [[Launch a new agent that has access to the following tools: `glob`, `grep`, `ls`, `view`, `attempt_completion`. When you are searching for a keyword or file and are not confident that you will find the right match on the first try, use the Agent tool to perform the search for you. For example:
+  return [[Launch a new agent that has access to the following tools: `glob`, `grep`, `ls`, `view`, `attempt_completion`. Use dispatch_agent when you need to:
 
-- If you are searching for a keyword like "config" or "logger", the Agent tool is appropriate
-- If you want to read a specific file path, use the `view` or `glob` tool instead of the `dispatch_agent` tool, to find the match more quickly
-- If you are searching for a specific class definition like "class Foo", use the `glob` tool instead, to find the match more quickly
+- Search for keywords, files, or patterns across the codebase
+- Gather and SYNTHESIZE context while you continue working on other tasks
 
-RULES:
-- Do not ask for more information than necessary. Use the tools provided to accomplish the user's request efficiently and effectively. When you've completed your task, you must use the attempt_completion tool to present the result to the user. The user may provide feedback, which you can use to make improvements and try again.
-- NEVER end attempt_completion result with a question or request to engage in further conversation! Formulate the end of your result in a way that is final and does not require further input from the user.
-
-OBJECTIVE:
-1. Analyze the user's task and set clear, achievable goals to accomplish it. Prioritize these goals in a logical order.
-2. Work through these goals sequentially, utilizing available tools one at a time as necessary. Each goal should correspond to a distinct step in your problem-solving process. You will be informed on the work completed and what's remaining as you go.
-3. Once you've completed the user's task, you must use the attempt_completion tool to present the result of the task to the user. You may also provide a CLI command to showcase the result of your task; this can be particularly useful for web development tasks, where you can run e.g. \`open index.html\` to show the website you've built.
+IMPORTANT RULES:
+- dispatch_agent is ASYNCHRONOUS and FIRE-AND-FORGET. It returns immediately with a dispatch ID.
+- The sub-agent runs in the background. You do NOT wait for results.
+- Results are delivered to you automatically when the dispatch completes (appears as a message in the conversation).
+- You can dispatch MULTIPLE agents concurrently for maximum parallelism.
+- Check the "Active & Recent Dispatches" section in your context for status updates.
+- Continue working on other tasks while dispatches are running.
+- Each dispatch invocation is stateless - provide all context the agent needs in the prompt.
 
 Usage notes:
-1. Launch multiple agents concurrently whenever possible, to maximize performance; to do that, use a single message with multiple tool uses
-2. When the agent is done, it will return a single message back to you. The result returned by the agent is not visible to the user. To show the user the result, you should send a text message back to the user with a concise summary of the result.
-3. Each agent invocation is stateless. You will not be able to send additional messages to the agent, nor will the agent be able to communicate with you outside of its final report. Therefore, your prompt should contain a highly detailed task description for the agent to perform autonomously and you should specify exactly what information the agent should return back to you in its final and only message to you.
-4. The agent's outputs should generally be trusted
-5. IMPORTANT: The agent can not use `bash`, `write`, `str_replace`, so can not modify files. If you want to use these tools, use them directly instead of going through the agent.]]
+1. Launch multiple dispatches concurrently whenever possible for maximum performance.
+2. When a dispatch is done, its result will appear in your conversation context automatically.
+3. If your only remaining work is to wait for dispatch results, DO NOT poll `dispatch_status`
+   in a loop. Instead call `dispatch_await` once — it blocks until the next dispatch finishes,
+   returns its full result inline, and compacts the polling noise out of your context.
+4. Your prompt should ask SPECIFIC QUESTIONS — the agent must return synthesized answers, not raw file dumps.
+5. The agent can NOT use `bash`, `write`, `str_replace` - it can only read/search files.
+6. The agent will use the cheapest available LLM provider that can fit the workload within its context window.
+
+## CRITICAL: The sub-agent's job is to REDUCE context, not amplify it.
+
+BAD prompt (wastes tokens — agent reads a file and dumps it back verbatim):
+  "Read lib/store.ts and return its complete contents"
+  "Read the following files in FULL and return their content verbatim: ..."
+
+GOOD prompt (agent searches, synthesizes, and returns only what matters):
+  "In lib/store.ts, find the VideoEntry type definition — list its field names and types only"
+  "In lib/processing.ts, what function handles face detection? What are its inputs/outputs?"
+  "Search for all callers of updateVideo() across the codebase and list them with file:line"
+
+If you just need to read a file yourself, use the `view` tool directly — do NOT dispatch an agent just to pass file contents back to you.]]
 end
 
 ---@type AvanteLLMToolParam
@@ -46,13 +66,17 @@ M.param = {
   fields = {
     {
       name = "prompt",
-      description = "The task for the agent to perform",
+      description = "A specific question or set of questions for the agent to research and answer. "
+        .. "The agent must SYNTHESIZE and REDUCE information — do NOT ask it to return raw file contents. "
+        .. "Ask targeted questions like 'What fields does the VideoEntry type have?' or "
+        .. "'What function handles face detection in lib/processing.ts and what are its parameters?' "
+        .. "instead of 'Read lib/store.ts and return it verbatim'.",
       type = "string",
     },
   },
   required = { "prompt" },
   usage = {
-    prompt = "The task for the agent to perform",
+    prompt = "Specific question(s) for the agent to research and synthesize (NOT a request to dump raw file contents)",
   },
 }
 
@@ -60,12 +84,12 @@ M.param = {
 M.returns = {
   {
     name = "result",
-    description = "The result of the agent",
+    description = "The dispatch ID and status message (agent runs asynchronously)",
     type = "string",
   },
   {
     name = "error",
-    description = "The error message if the agent fails",
+    description = "The error message if the dispatch could not be started",
     type = "string",
     optional = true,
   },
@@ -81,6 +105,17 @@ local function get_available_tools()
   }
 end
 
+--- Estimate tokens for a string (rough: ~1.3 tokens per word)
+---@param text string
+---@return integer
+local function estimate_tokens(text)
+  local words = 0
+  for _ in text:gmatch("%S+") do
+    words = words + 1
+  end
+  return math.ceil(words * 1.3)
+end
+
 ---@class avante.DispatchAgentInput
 ---@field prompt string
 
@@ -89,6 +124,7 @@ function M.on_render(input, opts)
   local result_message = opts.result_message
   local store = opts.store or {}
   local messages = store.messages or {}
+  local dispatch_id = store.dispatch_id
   local tool_use_summary = {}
   for _, msg in ipairs(messages) do
     local summary
@@ -138,31 +174,32 @@ function M.on_render(input, opts)
           end
         end
       end
-      if summary then summary = "  " .. Utils.icon("🛠️ ") .. summary end
+      if summary then summary = "  " .. Utils.icon("tool ") .. summary end
     else
       summary = History.Helpers.get_text_data(msg)
     end
     if summary then table.insert(tool_use_summary, summary) end
   end
   local state = "running"
-  local icon = Utils.icon("🔄 ")
+  local icon = Utils.icon("running ")
   local hl = Highlights.AVANTE_TASK_RUNNING
   if result_message then
     local result = History.Helpers.get_tool_result_data(result_message)
     if result then
       if result.is_error then
         state = "failed"
-        icon = Utils.icon("❌ ")
+        icon = Utils.icon("failed ")
         hl = Highlights.AVANTE_TASK_FAILED
       else
         state = "completed"
-        icon = Utils.icon("✅ ")
+        icon = Utils.icon("completed ")
         hl = Highlights.AVANTE_TASK_COMPLETED
       end
     end
   end
   local lines = {}
-  table.insert(lines, Line:new({ { icon .. "Subtask " .. state, hl } }))
+  local dispatch_label = dispatch_id and ("Dispatch #" .. dispatch_id) or "Dispatch"
+  table.insert(lines, Line:new({ { icon .. dispatch_label .. " " .. state, hl } }))
   table.insert(lines, Line:new({ { "" } }))
   table.insert(lines, Line:new({ { "  Task:" } }))
   local prompt_lines = vim.split(input.prompt or "", "\n")
@@ -170,11 +207,13 @@ function M.on_render(input, opts)
     table.insert(lines, Line:new({ { "    " .. line } }))
   end
   table.insert(lines, Line:new({ { "" } }))
-  table.insert(lines, Line:new({ { "  Task summary:" } }))
-  for _, summary in ipairs(tool_use_summary) do
-    local summary_lines = vim.split(summary, "\n")
-    for _, line in ipairs(summary_lines) do
-      table.insert(lines, Line:new({ { "    " .. line } }))
+  if #tool_use_summary > 0 then
+    table.insert(lines, Line:new({ { "  Task summary:" } }))
+    for _, summary in ipairs(tool_use_summary) do
+      local summary_lines = vim.split(summary, "\n")
+      for _, line in ipairs(summary_lines) do
+        table.insert(lines, Line:new({ { "    " .. line } }))
+      end
     end
   end
   return lines
@@ -187,22 +226,56 @@ function M.func(input, opts)
   local session_ctx = opts.session_ctx
 
   local Llm = require("avante.llm")
-  if not on_complete then return false, "on_complete not provided" end
 
   local prompt = input.prompt
   local tools = get_available_tools()
-  local start_time = Utils.get_timestamp()
 
   if on_log then on_log("prompt: " .. prompt) end
 
-  local system_prompt = ([[You are a helpful assistant with access to various tools.
-Your task is to help the user with their request: "${prompt}"
-Be thorough and use the tools available to you to find the most relevant information.
-When you're done, provide a clear and concise summary of what you found.]]):gsub("${prompt}", prompt)
+  -- Determine the session_id for the dispatch registry
+  local session_id = session_ctx.dispatch_session_id or "default"
+
+  -- Estimate tokens for the prompt to pick the cheapest provider
+  local prompt_tokens = estimate_tokens(prompt)
+  local dispatch_provider_name, _ = DispatchRegistry.pick_cheapest_provider(prompt_tokens + 2000) -- add headroom
+
+  -- Fall back to default provider if no cheap provider fits
+  if not dispatch_provider_name then dispatch_provider_name = Config.provider end
+
+  local dispatch_provider = Providers[dispatch_provider_name]
+  local dispatch_model = dispatch_provider and dispatch_provider.model or "unknown"
+
+  -- Register the dispatch in the registry
+  local dispatch_id = DispatchRegistry.register(session_id, prompt, dispatch_provider_name, dispatch_model)
+
+  if on_log then
+    on_log(string.format(
+      "Dispatch #%s started (provider: %s, model: %s)",
+      dispatch_id, dispatch_provider_name, dispatch_model
+    ))
+  end
+
+  -- Store the dispatch_id for rendering
+  if opts.set_store then opts.set_store("dispatch_id", dispatch_id) end
+
+  local system_prompt = "You are a focused research assistant with access to file-system tools. "
+    .. "Your ONLY job is to answer this specific request: " .. prompt .. "\n\n"
+    .. "CRITICAL RULES — follow these or you are wasting tokens and defeating the purpose:\n"
+    .. "1. SYNTHESIZE and REDUCE — never return raw file contents or long verbatim excerpts. "
+    .. "Extract exactly the information requested and discard everything else.\n"
+    .. "2. Use grep/glob FIRST to pinpoint the exact lines/symbols you need before opening a file. "
+    .. "Do NOT read an entire file when a targeted search will do.\n"
+    .. "3. Your result in attempt_completion should be COMPACT — only the facts needed to answer "
+    .. "the question. Think: could someone implement code from your answer without needing to ask "
+    .. "follow-up questions? If so, it's complete. Would they need to re-read the source file? "
+    .. "Then you're not synthesizing enough.\n"
+    .. "4. NEVER read a file and return its full contents verbatim — that is strictly forbidden. "
+    .. "If you are tempted to do that, use grep to extract only the relevant section instead.\n"
+    .. "When you have gathered exactly what is needed, call attempt_completion with a concise, "
+    .. "structured answer."
 
   local history_messages = {}
   local tool_use_messages = {}
-
   local total_tokens = 0
   local result = ""
 
@@ -238,6 +311,12 @@ When you're done, provide a clear and concise summary of what you found.]]):gsub
           end
         end
       end
+      -- Update dispatch progress
+      local last_msg = msgs[#msgs]
+      if last_msg then
+        local text = History.Helpers.get_text_data(last_msg)
+        if text and #text > 0 then DispatchRegistry.update_progress(session_id, dispatch_id, text:sub(1, 200)) end
+      end
     end,
     session_ctx = session_ctx,
     on_start = session_ctx.on_start,
@@ -247,31 +326,33 @@ When you're done, provide a clear and concise summary of what you found.]]):gsub
     end,
     on_complete = function(err)
       if err ~= nil then
-        err = string.format("dispatch_agent failed: %s", vim.inspect(err))
-        on_complete(err, nil)
+        DispatchRegistry.fail(session_id, dispatch_id, vim.inspect(err))
         return
       end
-      local end_time = Utils.get_timestamp()
-      local elapsed_time = Utils.datetime_diff(start_time, end_time)
-      local tool_use_count = vim.tbl_count(tool_use_messages)
-      local summary = "dispatch_agent Done ("
-        .. (tool_use_count <= 1 and "1 tool use" or tool_use_count .. " tool uses")
-        .. " · "
-        .. math.ceil(total_tokens)
-        .. " tokens · "
-        .. elapsed_time
-        .. "s)"
-      if session_ctx.on_messages_add then
-        local message = History.Message:new("assistant", "\n\n" .. summary, {
-          just_for_display = true,
-        })
-        session_ctx.on_messages_add({ message })
-      end
-      on_complete(result, nil)
+      DispatchRegistry.complete(session_id, dispatch_id, result)
     end,
   }
 
-  Llm.agent_loop(agent_loop_options)
+  -- Start the agent loop asynchronously (fire-and-forget)
+  -- Use vim.schedule to ensure it runs on the next event loop tick
+  vim.schedule(function() Llm.agent_loop(agent_loop_options) end)
+
+  -- Return IMMEDIATELY with the dispatch ID - do not wait for completion
+  local response = string.format(
+    "Dispatch #%s started. The sub-agent is working on your request in the background using provider '%s' (model: %s). "
+      .. "Results will be delivered to you automatically when the dispatch completes. "
+      .. "You can continue working on other tasks.",
+    dispatch_id,
+    dispatch_provider_name,
+    dispatch_model
+  )
+
+  -- Return synchronously - this makes the tool non-blocking
+  if on_complete then
+    on_complete(response, nil)
+    return
+  end
+  return response, nil
 end
 
 return M

--- a/lua/avante/llm_tools/dispatch_await.lua
+++ b/lua/avante/llm_tools/dispatch_await.lua
@@ -1,0 +1,267 @@
+--- dispatch_await tool: synchronously wait for a pending dispatch to complete,
+--- then return its full result and compact the related polling/dispatch
+--- messages from the chat history.
+---
+--- Use this tool when the primary agent has nothing else to do except wait
+--- for in-flight dispatches. It replaces the noisy "polling dispatch_status
+--- repeatedly" pattern with a single blocking call that picks one dispatch,
+--- waits for it, returns its result, and removes all the intermediate
+--- dispatch_status / dispatch_agent tool calls from the context window so
+--- only the final clean result remains.
+
+local Base = require("avante.llm_tools.base")
+local DispatchRegistry = require("avante.dispatch_registry")
+local History = require("avante.history")
+
+---@class AvanteLLMTool
+local M = setmetatable({}, Base)
+
+M.name = "dispatch_await"
+
+M.description = [[Synchronously wait for a pending dispatch_agent to complete and pull its result into the main chat.
+
+Use this when the only work left to do is waiting on one or more in-flight dispatches.
+Instead of polling `dispatch_status` repeatedly, call `dispatch_await` once:
+
+- If `dispatch_id` is supplied, waits for that specific dispatch.
+- Otherwise, picks the oldest still-running dispatch and waits for it.
+
+When the dispatch completes, this tool:
+1. Returns the dispatch's full result inline (as if you had run the task yourself).
+2. COMPACTS the chat history - all prior `dispatch_status` tool calls and the
+   original `dispatch_agent` tool_use/tool_result for this dispatch are marked
+   as compacted and disappear from your context. Only the final result remains.
+
+This keeps your context window clean and avoids burning tokens on repeated polling.]]
+
+---@type AvanteLLMToolParam
+M.param = {
+  type = "table",
+  fields = {
+    {
+      name = "dispatch_id",
+      description = "Optional: specific dispatch ID to wait for. If omitted, the oldest running dispatch is picked.",
+      type = "string",
+      optional = true,
+    },
+    {
+      name = "timeout_seconds",
+      description = "Optional: max seconds to wait before giving up. Defaults to 600 (10 min).",
+      type = "integer",
+      optional = true,
+    },
+  },
+  usage = {
+    dispatch_id = "Specific dispatch ID to wait for (optional)",
+    timeout_seconds = "Max seconds to wait (optional, default 600)",
+  },
+}
+
+---@type AvanteLLMToolReturn[]
+M.returns = {
+  {
+    name = "result",
+    description = "The completed dispatch's result, ready to use inline.",
+    type = "string",
+  },
+  {
+    name = "error",
+    description = "Error message if the await failed or timed out.",
+    type = "string",
+    optional = true,
+  },
+}
+
+---Format a completed/failed dispatch into a single concise text block.
+---@param dispatch avante.Dispatch
+---@return string
+local function format_result(dispatch)
+  if dispatch.status == "completed" then
+    return string.format(
+      "[Dispatch #%s completed inline] (provider: %s, model: %s)\nTask: %s\n\nResult:\n%s",
+      dispatch.id,
+      dispatch.provider or "unknown",
+      dispatch.model or "unknown",
+      dispatch.prompt:sub(1, 200),
+      dispatch.result or "(no result)"
+    )
+  elseif dispatch.status == "failed" then
+    return string.format(
+      "[Dispatch #%s failed inline] (provider: %s, model: %s)\nTask: %s\n\nError: %s",
+      dispatch.id,
+      dispatch.provider or "unknown",
+      dispatch.model or "unknown",
+      dispatch.prompt:sub(1, 200),
+      dispatch.error or "unknown error"
+    )
+  else
+    return string.format("[Dispatch #%s status: %s]", dispatch.id, dispatch.status or "unknown")
+  end
+end
+
+---Compact all messages related to dispatch_status, the original dispatch_agent
+---for the awaited dispatch, and any prior dispatch_result injections for the
+---same dispatch id. After compaction, only the dispatch_await tool's own
+---result message remains in the LLM context.
+---@param session_ctx table
+---@param awaited_dispatch_id string
+local function compact_dispatch_messages(session_ctx, awaited_dispatch_id)
+  if not session_ctx or not session_ctx.get_history_messages then return end
+  local ok, messages = pcall(session_ctx.get_history_messages)
+  if not ok or type(messages) ~= "table" then return end
+
+  for _, msg in ipairs(messages) do
+    if not msg.is_compacted then
+      local tool_use = History.Helpers.get_tool_use_data(msg)
+      local tool_result = History.Helpers.get_tool_result_data(msg)
+
+      -- 1) All dispatch_status tool calls become obsolete the moment we
+      --    synchronously await a dispatch.
+      if tool_use and tool_use.name == "dispatch_status" then
+        msg.is_compacted = true
+      elseif tool_result then
+        local use_msg = History.Helpers.get_tool_use_message(tool_result.tool_use_id, messages)
+        if use_msg then
+          local use_data = History.Helpers.get_tool_use_data(use_msg)
+          if use_data and use_data.name == "dispatch_status" then msg.is_compacted = true end
+        end
+      end
+
+      -- 2) The original dispatch_agent tool_use that started this dispatch
+      --    and its tool_result (the "Dispatch #N started..." placeholder).
+      if tool_use and tool_use.name == "dispatch_agent" then
+        local store = msg.tool_use_store
+        if store and store.dispatch_id == awaited_dispatch_id then msg.is_compacted = true end
+      elseif tool_result then
+        local use_msg = History.Helpers.get_tool_use_message(tool_result.tool_use_id, messages)
+        if use_msg then
+          local use_data = History.Helpers.get_tool_use_data(use_msg)
+          if use_data and use_data.name == "dispatch_agent" then
+            local store = use_msg.tool_use_store
+            if store and store.dispatch_id == awaited_dispatch_id then msg.is_compacted = true end
+          end
+        end
+      end
+
+      -- 3) Any prior "[Dispatch #X completed/failed]" user messages injected
+      --    by the sidebar's on_complete callback - we are about to deliver a
+      --    cleaner version inline, so drop the duplicate.
+      if msg.is_dispatch_result then
+        local text = History.Helpers.get_text_data(msg)
+        if text and text:match("Dispatch #" .. awaited_dispatch_id .. "[ %]]") then msg.is_compacted = true end
+      end
+    end
+  end
+end
+
+---Pick the dispatch to await. Prefers the oldest currently-running dispatch.
+---Falls back to the most recently-completed dispatch if nothing is running.
+---@param session_id string
+---@param explicit_id? string
+---@return avante.Dispatch | nil dispatch
+---@return string | nil error
+local function pick_target(session_id, explicit_id)
+  if explicit_id then
+    local d = DispatchRegistry.get(session_id, explicit_id)
+    if not d then return nil, "Dispatch #" .. explicit_id .. " not found" end
+    return d, nil
+  end
+
+  local all = DispatchRegistry.get_all(session_id)
+  for _, d in ipairs(all) do
+    if d.status == "running" then return d, nil end
+  end
+  local recent
+  for _, d in ipairs(all) do
+    if d.status == "completed" or d.status == "failed" then recent = d end
+  end
+  if recent then return recent, nil end
+  return nil, "No dispatches available to await"
+end
+
+---@class avante.DispatchAwaitInput
+---@field dispatch_id? string
+---@field timeout_seconds? integer
+
+---@type AvanteLLMToolFunc<avante.DispatchAwaitInput>
+function M.func(input, opts)
+  local on_complete = opts.on_complete
+  local on_log = opts.on_log
+  local session_ctx = opts.session_ctx or {}
+  local session_id = session_ctx.dispatch_session_id or "default"
+
+  local target, err = pick_target(session_id, input.dispatch_id)
+  if err or not target then
+    if on_complete then
+      on_complete(nil, err or "Unknown error")
+      return
+    end
+    return nil, err or "Unknown error"
+  end
+
+  if on_log then on_log("Awaiting dispatch #" .. target.id) end
+
+  -- Already finished? Return immediately + compact.
+  if target.status ~= "running" then
+    local result = format_result(target)
+    compact_dispatch_messages(session_ctx, target.id)
+    if on_complete then
+      on_complete(result, nil)
+      return
+    end
+    return result, nil
+  end
+
+  -- Still running - poll the registry on a timer until it terminates.
+  local timeout_seconds = input.timeout_seconds or 600
+  local poll_interval_ms = 200
+  local max_wait_ms = timeout_seconds * 1000
+  local elapsed = 0
+  local timer = vim.uv.new_timer()
+  if not timer then
+    local msg = "Failed to create timer for dispatch_await"
+    if on_complete then
+      on_complete(nil, msg)
+      return
+    end
+    return nil, msg
+  end
+
+  timer:start(
+    poll_interval_ms,
+    poll_interval_ms,
+    vim.schedule_wrap(function()
+      elapsed = elapsed + poll_interval_ms
+      local d = DispatchRegistry.get(session_id, target.id)
+      if not d then
+        timer:stop()
+        timer:close()
+        if on_complete then on_complete(nil, "Dispatch #" .. target.id .. " disappeared from registry") end
+        return
+      end
+      if d.status ~= "running" then
+        timer:stop()
+        timer:close()
+        local result = format_result(d)
+        compact_dispatch_messages(session_ctx, d.id)
+        if on_complete then on_complete(result, nil) end
+        return
+      end
+      if elapsed >= max_wait_ms then
+        timer:stop()
+        timer:close()
+        if on_complete then
+          on_complete(
+            nil,
+            string.format("Timed out after %ds waiting for dispatch #%s (still running)", timeout_seconds, target.id)
+          )
+        end
+        return
+      end
+    end)
+  )
+
+  -- Async: return nothing - the on_complete callback above will deliver.
+end
+
+return M

--- a/lua/avante/llm_tools/dispatch_await.lua
+++ b/lua/avante/llm_tools/dispatch_await.lua
@@ -227,29 +227,38 @@ function M.func(input, opts)
     return nil, msg
   end
 
+  -- Guard against multiple scheduled callbacks trying to close the same timer.
+  -- vim.schedule_wrap can queue several ticks before any of them runs, so the
+  -- first callback that decides to stop must prevent the rest from closing again.
+  local timer_active = true
+  local function stop_timer()
+    if not timer_active then return end
+    timer_active = false
+    timer:stop()
+    timer:close()
+  end
+
   timer:start(
     poll_interval_ms,
     poll_interval_ms,
     vim.schedule_wrap(function()
+      if not timer_active then return end
       elapsed = elapsed + poll_interval_ms
       local d = DispatchRegistry.get(session_id, target.id)
       if not d then
-        timer:stop()
-        timer:close()
+        stop_timer()
         if on_complete then on_complete(nil, "Dispatch #" .. target.id .. " disappeared from registry") end
         return
       end
       if d.status ~= "running" then
-        timer:stop()
-        timer:close()
+        stop_timer()
         local result = format_result(d)
         compact_dispatch_messages(session_ctx, d.id)
         if on_complete then on_complete(result, nil) end
         return
       end
       if elapsed >= max_wait_ms then
-        timer:stop()
-        timer:close()
+        stop_timer()
         if on_complete then
           on_complete(
             nil,

--- a/lua/avante/llm_tools/dispatch_status.lua
+++ b/lua/avante/llm_tools/dispatch_status.lua
@@ -1,0 +1,70 @@
+local Base = require("avante.llm_tools.base")
+local DispatchRegistry = require("avante.dispatch_registry")
+
+---@class AvanteLLMTool
+local M = setmetatable({}, Base)
+
+M.name = "dispatch_status"
+
+M.description = [[Check the status of dispatched sub-agents. Returns a summary of all running and completed dispatches.
+Use this to check if dispatched work has completed and retrieve their results.]]
+
+---@type AvanteLLMToolParam
+M.param = {
+  type = "table",
+  fields = {
+    {
+      name = "dispatch_id",
+      description = "Optional: specific dispatch ID to check. If omitted, returns all dispatches.",
+      type = "string",
+      optional = true,
+    },
+  },
+  usage = {
+    dispatch_id = "Specific dispatch ID to check (optional)",
+  },
+}
+
+---@type AvanteLLMToolReturn[]
+M.returns = {
+  {
+    name = "status",
+    description = "Status information about dispatches",
+    type = "string",
+  },
+  {
+    name = "error",
+    description = "Error message if the lookup failed",
+    type = "string",
+    optional = true,
+  },
+}
+
+---@type AvanteLLMToolFunc<{ dispatch_id?: string }>
+function M.func(input, opts)
+  local session_ctx = opts.session_ctx or {}
+  local session_id = session_ctx.dispatch_session_id or "default"
+
+  if input.dispatch_id then
+    local dispatch = DispatchRegistry.get(session_id, input.dispatch_id)
+    if not dispatch then return nil, "Dispatch #" .. input.dispatch_id .. " not found" end
+    return vim.json.encode({
+      id = dispatch.id,
+      status = dispatch.status,
+      prompt = dispatch.prompt:sub(1, 200),
+      last_message = dispatch.last_message,
+      result = dispatch.result,
+      error = dispatch.error,
+      provider = dispatch.provider,
+      model = dispatch.model,
+    }),
+      nil
+  end
+
+  -- Return all dispatches
+  local context = DispatchRegistry.get_context(session_id)
+  if context == "" then return "No dispatches have been created yet.", nil end
+  return context, nil
+end
+
+return M

--- a/lua/avante/llm_tools/grep.lua
+++ b/lua/avante/llm_tools/grep.lua
@@ -3,12 +3,26 @@ local Utils = require("avante.utils")
 local Helpers = require("avante.llm_tools.helpers")
 local Base = require("avante.llm_tools.base")
 
+--- Maximum output size in bytes before results are truncated.
+--- Keeps context window usage bounded when searching large codebases.
+local MAX_GREP_OUTPUT_BYTES = 50000
+
+--- Grep tool: search for a pattern across the project using ripgrep (rg), falling
+--- back to ag or grep if rg is unavailable.
+---
+--- Results include file path, line number, and a configurable number of context
+--- lines around each match, so the LLM can understand matches without a separate
+--- file-read step.
+---
+--- Output is capped at MAX_GREP_OUTPUT_BYTES bytes and annotated with a truncation
+--- notice when the limit is hit.
 ---@class AvanteLLMTool
 local M = setmetatable({}, Base)
 
 M.name = "grep"
 
-M.description = "Search for a keyword in a directory using grep in current project scope"
+M.description =
+  "Search for a pattern in files using ripgrep, returning matching lines with surrounding context. Use this to find code, definitions, and usages across the project."
 
 ---@type AvanteLLMToolParam
 M.param = {
@@ -21,8 +35,15 @@ M.param = {
     },
     {
       name = "query",
-      description = "Query to search for",
+      description = "Query to search for (supports regex)",
       type = "string",
+    },
+    {
+      name = "context_lines",
+      description = "Number of lines to show above and below each match (default 3)",
+      type = "integer",
+      default = 3,
+      optional = true,
     },
     {
       name = "case_sensitive",
@@ -47,6 +68,7 @@ M.param = {
   usage = {
     path = "Relative path to the project directory",
     query = "Query to search for",
+    context_lines = "Number of context lines above and below each match (default 3)",
     case_sensitive = "Whether to search case sensitively",
     include_pattern = "Glob pattern to include files",
     exclude_pattern = "Glob pattern to exclude files",
@@ -56,19 +78,19 @@ M.param = {
 ---@type AvanteLLMToolReturn[]
 M.returns = {
   {
-    name = "files",
-    description = "List of files that match the keyword",
+    name = "results",
+    description = "Search results with file paths, line numbers, and matching content with context",
     type = "string",
   },
   {
     name = "error",
-    description = "Error message if the directory was not searched successfully",
+    description = "Error message if the search failed",
     type = "string",
     optional = true,
   },
 }
 
----@type AvanteLLMToolFunc<{ path: string, query: string, case_sensitive?: boolean, include_pattern?: string, exclude_pattern?: string }>
+---@type AvanteLLMToolFunc<{ path: string, query: string, context_lines?: integer, case_sensitive?: boolean, include_pattern?: string, exclude_pattern?: string }>
 function M.func(input, opts)
   local on_log = opts.on_log
 
@@ -76,83 +98,58 @@ function M.func(input, opts)
   if not Helpers.has_permission_to_access(abs_path) then return "", "No permission to access path: " .. abs_path end
   if not Path:new(abs_path):exists() then return "", "No such file or directory: " .. abs_path end
 
-  ---check if any search cmd is available
+  local context_lines = input.context_lines or 3
+
+  -- Prefer ripgrep (rg), fall back to other tools
   local search_cmd = vim.fn.exepath("rg")
   if search_cmd == "" then search_cmd = vim.fn.exepath("ag") end
-  if search_cmd == "" then search_cmd = vim.fn.exepath("ack") end
   if search_cmd == "" then search_cmd = vim.fn.exepath("grep") end
-  if search_cmd == "" then return "", "No search command found" end
+  if search_cmd == "" then return "", "No search command found (rg, ag, or grep required)" end
 
-  ---execute the search command
   local cmd = {}
   if search_cmd:find("rg") then
-    cmd = { search_cmd, "--files-with-matches", "--hidden" }
+    -- ripgrep: return content with line numbers and context
+    cmd = { search_cmd, "-n", "--hidden", "--no-heading" }
+    -- Add context lines
+    if context_lines > 0 then vim.list_extend(cmd, { "-C", tostring(context_lines) }) end
     if input.case_sensitive then
       table.insert(cmd, "--case-sensitive")
     else
       table.insert(cmd, "--ignore-case")
     end
-    if input.include_pattern then
-      table.insert(cmd, "--glob")
-      table.insert(cmd, input.include_pattern)
-    end
-    if input.exclude_pattern then
-      table.insert(cmd, "--glob")
-      table.insert(cmd, "!" .. input.exclude_pattern)
-    end
-    table.insert(cmd, input.query)
-    table.insert(cmd, abs_path)
+    if input.include_pattern then vim.list_extend(cmd, { "--glob", input.include_pattern }) end
+    if input.exclude_pattern then vim.list_extend(cmd, { "--glob", "!" .. input.exclude_pattern }) end
+    -- Limit output to avoid overwhelming context
+    vim.list_extend(cmd, { "--max-count", "50", input.query, abs_path })
   elseif search_cmd:find("ag") then
     cmd = { search_cmd, "--nocolor", "--nogroup", "--hidden" }
+    if context_lines > 0 then vim.list_extend(cmd, { "-C", tostring(context_lines) }) end
     if input.case_sensitive then table.insert(cmd, "--case-sensitive") end
-    if input.include_pattern then
-      table.insert(cmd, "--ignore")
-      table.insert(cmd, "!" .. input.include_pattern)
-    end
-    if input.exclude_pattern then
-      table.insert(cmd, "--ignore")
-      table.insert(cmd, input.exclude_pattern)
-    end
-    table.insert(cmd, input.query)
-    table.insert(cmd, abs_path)
-  elseif search_cmd:find("ack") then
-    cmd = { search_cmd, "--nocolor", "--nogroup", "--hidden" }
-    if input.case_sensitive then table.insert(cmd, "--smart-case") end
-    if input.exclude_pattern then
-      table.insert(cmd, "--ignore-dir")
-      table.insert(cmd, input.exclude_pattern)
-    end
-    table.insert(cmd, input.query)
-    table.insert(cmd, abs_path)
+    if input.include_pattern then vim.list_extend(cmd, { "--ignore", "!" .. input.include_pattern }) end
+    if input.exclude_pattern then vim.list_extend(cmd, { "--ignore", input.exclude_pattern }) end
+    vim.list_extend(cmd, { input.query, abs_path })
   elseif search_cmd:find("grep") then
-    local files =
-      vim.system({ "git", "-C", abs_path, "ls-files", "-co", "--exclude-standard" }, { text = true }):wait().stdout
-    cmd = { "grep", "-rH" }
+    cmd = { "grep", "-rnH" }
+    if context_lines > 0 then vim.list_extend(cmd, { "-C", tostring(context_lines) }) end
     if not input.case_sensitive then table.insert(cmd, "-i") end
-    if input.include_pattern then
-      table.insert(cmd, "--include")
-      table.insert(cmd, input.include_pattern)
-    end
-    if input.exclude_pattern then
-      table.insert(cmd, "--exclude")
-      table.insert(cmd, input.exclude_pattern)
-    end
-    table.insert(cmd, input.query)
-    if files ~= "" then
-      for _, path in ipairs(vim.split(files, "\n")) do
-        if not path:match("^%s*$") then table.insert(cmd, vim.fs.joinpath(abs_path, path)) end
-      end
-    else
-      table.insert(cmd, abs_path)
-    end
+    if input.include_pattern then vim.list_extend(cmd, { "--include", input.include_pattern }) end
+    if input.exclude_pattern then vim.list_extend(cmd, { "--exclude", input.exclude_pattern }) end
+    vim.list_extend(cmd, { input.query, abs_path })
   end
 
   Utils.debug("cmd", table.concat(cmd, " "))
   if on_log then on_log("Running command: " .. table.concat(cmd, " ")) end
-  local result = vim.system(cmd, { text = true }):wait().stdout or ""
-  local filepaths = vim.split(result, "\n")
+  local result = vim.system(cmd, { text = true }):wait()
+  local output = result.stdout or ""
 
-  return vim.json.encode(filepaths), nil
+  -- Truncate if too large (avoid blowing up context)
+  if #output > MAX_GREP_OUTPUT_BYTES then
+    output = output:sub(1, MAX_GREP_OUTPUT_BYTES) .. "\n\n...[output truncated, " .. #output .. " total bytes]"
+  end
+
+  if output == "" then return vim.json.encode({ matches = {}, total = 0 }), nil end
+
+  return output, nil
 end
 
 return M

--- a/lua/avante/llm_tools/grep.lua
+++ b/lua/avante/llm_tools/grep.lua
@@ -8,7 +8,8 @@ local M = setmetatable({}, Base)
 
 M.name = "grep"
 
-M.description = "Search for a keyword in a directory using grep in current project scope"
+M.description =
+  "Search for a pattern in files using ripgrep, returning matching lines with surrounding context. Use this to find code, definitions, and usages across the project."
 
 ---@type AvanteLLMToolParam
 M.param = {
@@ -21,8 +22,15 @@ M.param = {
     },
     {
       name = "query",
-      description = "Query to search for",
+      description = "Query to search for (supports regex)",
       type = "string",
+    },
+    {
+      name = "context_lines",
+      description = "Number of lines to show above and below each match (default 3)",
+      type = "integer",
+      default = 3,
+      optional = true,
     },
     {
       name = "case_sensitive",
@@ -47,6 +55,7 @@ M.param = {
   usage = {
     path = "Relative path to the project directory",
     query = "Query to search for",
+    context_lines = "Number of context lines above and below each match (default 3)",
     case_sensitive = "Whether to search case sensitively",
     include_pattern = "Glob pattern to include files",
     exclude_pattern = "Glob pattern to exclude files",
@@ -56,19 +65,19 @@ M.param = {
 ---@type AvanteLLMToolReturn[]
 M.returns = {
   {
-    name = "files",
-    description = "List of files that match the keyword",
+    name = "results",
+    description = "Search results with file paths, line numbers, and matching content with context",
     type = "string",
   },
   {
     name = "error",
-    description = "Error message if the directory was not searched successfully",
+    description = "Error message if the search failed",
     type = "string",
     optional = true,
   },
 }
 
----@type AvanteLLMToolFunc<{ path: string, query: string, case_sensitive?: boolean, include_pattern?: string, exclude_pattern?: string }>
+---@type AvanteLLMToolFunc<{ path: string, query: string, context_lines?: integer, case_sensitive?: boolean, include_pattern?: string, exclude_pattern?: string }>
 function M.func(input, opts)
   local on_log = opts.on_log
 
@@ -76,17 +85,23 @@ function M.func(input, opts)
   if not Helpers.has_permission_to_access(abs_path) then return "", "No permission to access path: " .. abs_path end
   if not Path:new(abs_path):exists() then return "", "No such file or directory: " .. abs_path end
 
-  ---check if any search cmd is available
+  local context_lines = input.context_lines or 3
+
+  -- Prefer ripgrep (rg), fall back to other tools
   local search_cmd = vim.fn.exepath("rg")
   if search_cmd == "" then search_cmd = vim.fn.exepath("ag") end
-  if search_cmd == "" then search_cmd = vim.fn.exepath("ack") end
   if search_cmd == "" then search_cmd = vim.fn.exepath("grep") end
-  if search_cmd == "" then return "", "No search command found" end
+  if search_cmd == "" then return "", "No search command found (rg, ag, or grep required)" end
 
-  ---execute the search command
   local cmd = {}
   if search_cmd:find("rg") then
-    cmd = { search_cmd, "--files-with-matches", "--hidden" }
+    -- ripgrep: return content with line numbers and context
+    cmd = { search_cmd, "-n", "--hidden", "--no-heading" }
+    -- Add context lines
+    if context_lines > 0 then
+      table.insert(cmd, "-C")
+      table.insert(cmd, tostring(context_lines))
+    end
     if input.case_sensitive then
       table.insert(cmd, "--case-sensitive")
     else
@@ -100,10 +115,17 @@ function M.func(input, opts)
       table.insert(cmd, "--glob")
       table.insert(cmd, "!" .. input.exclude_pattern)
     end
+    -- Limit output to avoid overwhelming context
+    table.insert(cmd, "--max-count")
+    table.insert(cmd, "50")
     table.insert(cmd, input.query)
     table.insert(cmd, abs_path)
   elseif search_cmd:find("ag") then
     cmd = { search_cmd, "--nocolor", "--nogroup", "--hidden" }
+    if context_lines > 0 then
+      table.insert(cmd, "-C")
+      table.insert(cmd, tostring(context_lines))
+    end
     if input.case_sensitive then table.insert(cmd, "--case-sensitive") end
     if input.include_pattern then
       table.insert(cmd, "--ignore")
@@ -115,19 +137,12 @@ function M.func(input, opts)
     end
     table.insert(cmd, input.query)
     table.insert(cmd, abs_path)
-  elseif search_cmd:find("ack") then
-    cmd = { search_cmd, "--nocolor", "--nogroup", "--hidden" }
-    if input.case_sensitive then table.insert(cmd, "--smart-case") end
-    if input.exclude_pattern then
-      table.insert(cmd, "--ignore-dir")
-      table.insert(cmd, input.exclude_pattern)
-    end
-    table.insert(cmd, input.query)
-    table.insert(cmd, abs_path)
   elseif search_cmd:find("grep") then
-    local files =
-      vim.system({ "git", "-C", abs_path, "ls-files", "-co", "--exclude-standard" }, { text = true }):wait().stdout
-    cmd = { "grep", "-rH" }
+    cmd = { "grep", "-rnH" }
+    if context_lines > 0 then
+      table.insert(cmd, "-C")
+      table.insert(cmd, tostring(context_lines))
+    end
     if not input.case_sensitive then table.insert(cmd, "-i") end
     if input.include_pattern then
       table.insert(cmd, "--include")
@@ -138,21 +153,23 @@ function M.func(input, opts)
       table.insert(cmd, input.exclude_pattern)
     end
     table.insert(cmd, input.query)
-    if files ~= "" then
-      for _, path in ipairs(vim.split(files, "\n")) do
-        if not path:match("^%s*$") then table.insert(cmd, vim.fs.joinpath(abs_path, path)) end
-      end
-    else
-      table.insert(cmd, abs_path)
-    end
+    table.insert(cmd, abs_path)
   end
 
   Utils.debug("cmd", table.concat(cmd, " "))
   if on_log then on_log("Running command: " .. table.concat(cmd, " ")) end
-  local result = vim.system(cmd, { text = true }):wait().stdout or ""
-  local filepaths = vim.split(result, "\n")
+  local result = vim.system(cmd, { text = true }):wait()
+  local output = result.stdout or ""
 
-  return vim.json.encode(filepaths), nil
+  -- Truncate if too large (avoid blowing up context)
+  local max_output_size = 50000
+  if #output > max_output_size then
+    output = output:sub(1, max_output_size) .. "\n\n...[output truncated, " .. #output .. " total bytes]"
+  end
+
+  if output == "" then return vim.json.encode({ matches = {}, total = 0 }), nil end
+
+  return output, nil
 end
 
 return M

--- a/lua/avante/llm_tools/helpers.lua
+++ b/lua/avante/llm_tools/helpers.lua
@@ -7,14 +7,33 @@ local M = {}
 
 M.CANCEL_TOKEN = "__CANCELLED__"
 
--- Track cancellation state
+-- Track cancellation state (legacy global — prefer session_ctx.is_cancelled for new code).
+-- This flag is kept for backward compatibility with external callers but is no longer the
+-- primary cancellation signal; per-stream session_ctx._cancel_state is used instead.
 M.is_cancelled = false
 ---@type avante.ui.Confirm
 M.confirm_popup = nil
 
+--- Check whether the current execution has been cancelled.
+--- Prefers per-stream session_ctx (set via session_ctx.is_cancelled) over the legacy global.
+---@param session_ctx? table
+---@return boolean
+function M.check_cancelled(session_ctx)
+  if session_ctx then return session_ctx.is_cancelled == true end
+  return M.is_cancelled
+end
+
+--- Clear the cancellation flag for a session without touching the global.
+---@param session_ctx? table
+function M.reset_cancelled(session_ctx)
+  if session_ctx then session_ctx.is_cancelled = false end
+  -- Intentionally does NOT reset M.is_cancelled — the global is only reset at stream start.
+end
+
 ---@param rel_path string
 ---@return string
 function M.get_abs_path(rel_path)
+  if not rel_path then error("get_abs_path: path argument is nil", 2) end
   local project_root = Utils.get_project_root()
   local p = Utils.is_absolute_path(rel_path) and rel_path or vim.fs.normalize(vim.fs.joinpath(project_root, rel_path))
   if p:sub(-2) == "/." then p = p:sub(1, -3) end

--- a/lua/avante/llm_tools/init.lua
+++ b/lua/avante/llm_tools/init.lua
@@ -71,6 +71,7 @@ local Path = require("plenary.path")
 local Config = require("avante.config")
 local RagService = require("avante.rag_service")
 local Helpers = require("avante.llm_tools.helpers")
+local DispatchRegistry = require("avante.dispatch_registry")
 
 local M = {}
 
@@ -714,6 +715,8 @@ end
 ---@type AvanteLLMTool[]
 M._tools = {
   require("avante.llm_tools.dispatch_agent"),
+  require("avante.llm_tools.dispatch_status"),
+  require("avante.llm_tools.dispatch_await"),
   require("avante.llm_tools.glob"),
   {
     name = "rag_search",
@@ -917,7 +920,182 @@ Then you can use the "read_definitions" tool to retrieve the source code definit
     },
   },
   require("avante.llm_tools.str_replace"),
-  require("avante.llm_tools.view"),
+  {
+    name = "view",
+    description = [[Reads the content of a file by dispatching a sub-agent with a cheap LLM.
+The sub-agent reads the file and returns analyzed content relevant to your task.
+This is ASYNCHRONOUS - it returns immediately with a dispatch ID. The result
+will be delivered to you automatically when the dispatch completes.
+
+For quick searches, prefer the grep tool with context_lines instead.
+Use view when you need to understand the full structure or content of a file.
+
+IMPORTANT: If you just need a few lines around a known pattern, use grep with context_lines instead - it's synchronous and faster.]],
+    param = {
+      type = "table",
+      fields = {
+        {
+          name = "path",
+          description = "The relative path of the file to read",
+          type = "string",
+        },
+        {
+          name = "purpose",
+          description = "What you're looking for or trying to understand in this file. This helps the sub-agent provide more relevant analysis.",
+          type = "string",
+          optional = true,
+        },
+        {
+          name = "start_line",
+          description = "Optional line number to start reading on (1-based index)",
+          type = "integer",
+          optional = true,
+        },
+        {
+          name = "end_line",
+          description = "Optional line number to end reading on (1-based index, inclusive)",
+          type = "integer",
+          optional = true,
+        },
+      },
+      usage = {
+        path = "The path to the file in the current project scope",
+        purpose = "What you're looking for in this file",
+        start_line = "The start line of the view range, 1-indexed",
+        end_line = "The end line of the view range, 1-indexed",
+      },
+    },
+    returns = {
+      {
+        name = "result",
+        description = "Dispatch ID and status (async - result delivered later)",
+        type = "string",
+      },
+      {
+        name = "error",
+        description = "Error message if the dispatch could not be started",
+        type = "string",
+        optional = true,
+      },
+    },
+    func = function(input, opts)
+      local on_log = opts.on_log
+      local on_complete = opts.on_complete
+      local session_ctx = opts.session_ctx or {}
+
+      if not input.path then return nil, "path is required" end
+
+      -- Read the file content using the raw view tool
+      local raw_view = require("avante.llm_tools.view")
+      local file_result, file_err = raw_view.func(input, {
+        on_log = on_log,
+        session_ctx = session_ctx,
+      })
+
+      if file_err then
+        if on_complete then
+          on_complete(nil, file_err)
+          return
+        end
+        return nil, file_err
+      end
+
+      -- Estimate file tokens
+      local file_content = file_result or ""
+      local words = 0
+      for _ in file_content:gmatch("%S+") do
+        words = words + 1
+      end
+      local estimated_file_tokens = math.ceil(words * 1.3)
+
+      -- Build the dispatch prompt
+      local purpose = input.purpose or "Read and summarize the file content"
+      local dispatch_prompt = "Read the file '" .. input.path .. "' and provide a thorough analysis."
+        .. " Focus on: " .. purpose
+        .. "\n\nFile content:\n" .. file_content
+
+      -- Pick cheapest provider that fits
+      local total_tokens = estimated_file_tokens + 500 -- headroom for prompt overhead
+      local dispatch_provider_name, _ = DispatchRegistry.pick_cheapest_provider(total_tokens)
+
+      -- Fall back to default provider
+      if not dispatch_provider_name then dispatch_provider_name = Config.provider end
+
+      local Llm = require("avante.llm")
+      local Providers_ = require("avante.providers")
+      local dispatch_provider = Providers_[dispatch_provider_name]
+      local dispatch_model = dispatch_provider and dispatch_provider.model or "unknown"
+
+      local session_id = session_ctx.dispatch_session_id or "default"
+      local dispatch_id = DispatchRegistry.register(session_id, "view: " .. input.path, dispatch_provider_name, dispatch_model)
+
+      if on_log then
+        on_log(string.format("Dispatching file read #%s for '%s' (provider: %s)", dispatch_id, input.path, dispatch_provider_name))
+      end
+
+      local system_prompt = "You are a file analysis assistant. Read the provided file content and answer questions about it. Be thorough and precise."
+      local history_messages = {}
+      local result = ""
+
+      local agent_loop_options = {
+        system_prompt = system_prompt,
+        user_input = dispatch_prompt,
+        tools = {
+          require("avante.llm_tools.attempt_completion"),
+        },
+        on_tool_log = session_ctx.on_tool_log,
+        on_messages_add = function(msgs)
+          msgs = vim.islist(msgs) and msgs or { msgs }
+          for _, msg in ipairs(msgs) do
+            local idx = nil
+            for i, m in ipairs(history_messages) do
+              if m.uuid == msg.uuid then
+                idx = i
+                break
+              end
+            end
+            if idx ~= nil then
+              history_messages[idx] = msg
+            else
+              table.insert(history_messages, msg)
+            end
+          end
+          for _, msg in ipairs(msgs) do
+            local History_ = require("avante.history")
+            local tool_use = History_.Helpers.get_tool_use_data(msg)
+            if tool_use and tool_use.name == "attempt_completion" and tool_use.input and tool_use.input.result then
+              result = tool_use.input.result
+            end
+          end
+        end,
+        session_ctx = session_ctx,
+        on_chunk = function() end,
+        on_complete = function(err)
+          if err ~= nil then
+            DispatchRegistry.fail(session_id, dispatch_id, vim.inspect(err))
+            return
+          end
+          DispatchRegistry.complete(session_id, dispatch_id, result)
+        end,
+      }
+
+      -- Fire-and-forget
+      vim.schedule(function()
+        Llm.agent_loop(agent_loop_options)
+      end)
+
+      local response = string.format(
+        "Dispatch #%s started - reading '%s' via provider '%s' (model: %s). Result will be delivered automatically.",
+        dispatch_id, input.path, dispatch_provider_name, dispatch_model
+      )
+
+      if on_complete then
+        on_complete(response, nil)
+        return
+      end
+      return response, nil
+    end,
+  },
   require("avante.llm_tools.write_to_file"),
   require("avante.llm_tools.insert"),
   require("avante.llm_tools.undo_edit"),

--- a/lua/avante/llm_tools/init.lua
+++ b/lua/avante/llm_tools/init.lua
@@ -105,6 +105,7 @@ function M.str_replace_based_edit_tool(input, opts)
   if not input.command then return false, "command not provided" end
   if on_log then on_log("command: " .. input.command) end
   if not on_complete then return false, "on_complete not provided" end
+  if not input.path then return false, "path not provided" end
   local abs_path = Helpers.get_abs_path(input.path)
   if not Helpers.has_permission_to_access(abs_path) then return false, "No permission to access path: " .. abs_path end
   if input.command == "view" then
@@ -1331,8 +1332,12 @@ M.run_python = M.python
 function M.process_tool_use(tools, tool_use, opts)
   local on_log = opts.on_log
   local on_complete = opts.on_complete
+  -- session_ctx carries the per-stream cancellation state (session_ctx.is_cancelled).
+  -- Helpers.check_cancelled() prefers session_ctx over the legacy global flag so that
+  -- cancelling one avante instance does not accidentally abort tool execution in another.
+  local session_ctx = opts.session_ctx or {}
   -- Check if execution is already cancelled
-  if Helpers.is_cancelled then
+  if Helpers.check_cancelled(session_ctx) then
     Utils.debug("Tool execution cancelled before starting: " .. tool_use.name)
     if on_complete then
       on_complete(nil, Helpers.CANCEL_TOKEN)
@@ -1365,13 +1370,13 @@ function M.process_tool_use(tools, tool_use, opts)
         100,
         100,
         vim.schedule_wrap(function()
-          if Helpers.is_cancelled then
+          if Helpers.check_cancelled(session_ctx) then
             Utils.debug("Tool execution cancelled during execution: " .. tool_use.name)
             if cancel_timer and not cancel_timer:is_closing() then
               cancel_timer:stop()
               cancel_timer:close()
             end
-            Helpers.is_cancelled = false
+            Helpers.reset_cancelled(session_ctx)
             on_complete(nil, Helpers.CANCEL_TOKEN)
           end
         end)
@@ -1389,7 +1394,7 @@ function M.process_tool_use(tools, tool_use, opts)
     end
 
     -- Check for cancellation one more time before processing result
-    if Helpers.is_cancelled then
+    if Helpers.check_cancelled(session_ctx) then
       if on_log then on_log(tool_use.id, tool_use.name, "cancelled during result handling", "failed") end
       return nil, Helpers.CANCEL_TOKEN
     end
@@ -1408,11 +1413,16 @@ function M.process_tool_use(tools, tool_use, opts)
     return result_str, err
   end
 
-  local result, err = func(input_json, {
-    session_ctx = opts.session_ctx or {},
+  -- Wrap the tool call in pcall so that any unhandled error is converted into a
+  -- proper tool_result error instead of crashing the stream callback.  Without
+  -- this, a crash would leave an orphaned tool_use message in history with no
+  -- matching tool_result, causing every subsequent API request to fail with an
+  -- "ids were found without tool_result blocks" error.
+  local ok, result, err = pcall(func, input_json, {
+    session_ctx = session_ctx,
     on_log = function(log)
       -- Check for cancellation during logging
-      if Helpers.is_cancelled then return end
+      if Helpers.check_cancelled(session_ctx) then return end
       if on_log then on_log(tool_use.id, tool_use.name, log, "running") end
     end,
     set_store = function(key, value)
@@ -1420,8 +1430,8 @@ function M.process_tool_use(tools, tool_use, opts)
     end,
     on_complete = function(result, err)
       -- Check for cancellation before completing
-      if Helpers.is_cancelled then
-        Helpers.is_cancelled = false
+      if Helpers.check_cancelled(session_ctx) then
+        Helpers.reset_cancelled(session_ctx)
         if on_complete then on_complete(nil, Helpers.CANCEL_TOKEN) end
         return
       end
@@ -1436,6 +1446,23 @@ function M.process_tool_use(tools, tool_use, opts)
     streaming = opts.streaming,
     tool_use_id = opts.tool_use_id,
   })
+
+  if not ok then
+    -- func threw an unhandled error; stop the cancel timer and surface the error
+    -- as a normal tool failure so the caller can record a tool_result and keep
+    -- the message history consistent.
+    local error_msg = tostring(result) -- pcall puts the error in the first return slot
+    if cancel_timer and not cancel_timer:is_closing() then
+      cancel_timer:stop()
+      cancel_timer:close()
+    end
+    if on_log then on_log(tool_use.id, tool_use.name, "Unexpected error: " .. error_msg, "failed") end
+    if on_complete then
+      on_complete(nil, "Unexpected error: " .. error_msg)
+      return
+    end
+    return nil, "Unexpected error: " .. error_msg
+  end
 
   -- Result and error being nil means that the tool was executed asynchronously
   if result == nil and err == nil and on_complete then return end

--- a/lua/avante/llm_tools/init.lua
+++ b/lua/avante/llm_tools/init.lua
@@ -105,6 +105,7 @@ function M.str_replace_based_edit_tool(input, opts)
   if not input.command then return false, "command not provided" end
   if on_log then on_log("command: " .. input.command) end
   if not on_complete then return false, "on_complete not provided" end
+  if not input.path then return false, "path not provided" end
   local abs_path = Helpers.get_abs_path(input.path)
   if not Helpers.has_permission_to_access(abs_path) then return false, "No permission to access path: " .. abs_path end
   if input.command == "view" then
@@ -1408,7 +1409,12 @@ function M.process_tool_use(tools, tool_use, opts)
     return result_str, err
   end
 
-  local result, err = func(input_json, {
+  -- Wrap the tool call in pcall so that any unhandled error is converted into a
+  -- proper tool_result error instead of crashing the stream callback.  Without
+  -- this, a crash would leave an orphaned tool_use message in history with no
+  -- matching tool_result, causing every subsequent API request to fail with an
+  -- "ids were found without tool_result blocks" error.
+  local ok, result, err = pcall(func, input_json, {
     session_ctx = opts.session_ctx or {},
     on_log = function(log)
       -- Check for cancellation during logging
@@ -1436,6 +1442,23 @@ function M.process_tool_use(tools, tool_use, opts)
     streaming = opts.streaming,
     tool_use_id = opts.tool_use_id,
   })
+
+  if not ok then
+    -- func threw an unhandled error; stop the cancel timer and surface the error
+    -- as a normal tool failure so the caller can record a tool_result and keep
+    -- the message history consistent.
+    local error_msg = tostring(result) -- pcall puts the error in the first return slot
+    if cancel_timer and not cancel_timer:is_closing() then
+      cancel_timer:stop()
+      cancel_timer:close()
+    end
+    if on_log then on_log(tool_use.id, tool_use.name, "Unexpected error: " .. error_msg, "failed") end
+    if on_complete then
+      on_complete(nil, "Unexpected error: " .. error_msg)
+      return
+    end
+    return nil, "Unexpected error: " .. error_msg
+  end
 
   -- Result and error being nil means that the tool was executed asynchronously
   if result == nil and err == nil and on_complete then return end

--- a/lua/avante/llm_tools/init.lua
+++ b/lua/avante/llm_tools/init.lua
@@ -71,6 +71,7 @@ local Path = require("plenary.path")
 local Config = require("avante.config")
 local RagService = require("avante.rag_service")
 local Helpers = require("avante.llm_tools.helpers")
+local DispatchRegistry = require("avante.dispatch_registry")
 
 local M = {}
 
@@ -105,6 +106,7 @@ function M.str_replace_based_edit_tool(input, opts)
   if not input.command then return false, "command not provided" end
   if on_log then on_log("command: " .. input.command) end
   if not on_complete then return false, "on_complete not provided" end
+  if not input.path then return false, "path not provided" end
   local abs_path = Helpers.get_abs_path(input.path)
   if not Helpers.has_permission_to_access(abs_path) then return false, "No permission to access path: " .. abs_path end
   if input.command == "view" then
@@ -713,6 +715,8 @@ end
 ---@type AvanteLLMTool[]
 M._tools = {
   require("avante.llm_tools.dispatch_agent"),
+  require("avante.llm_tools.dispatch_status"),
+  require("avante.llm_tools.dispatch_await"),
   require("avante.llm_tools.glob"),
   {
     name = "rag_search",
@@ -916,7 +920,182 @@ Then you can use the "read_definitions" tool to retrieve the source code definit
     },
   },
   require("avante.llm_tools.str_replace"),
-  require("avante.llm_tools.view"),
+  {
+    name = "view",
+    description = [[Reads the content of a file by dispatching a sub-agent with a cheap LLM.
+The sub-agent reads the file and returns analyzed content relevant to your task.
+This is ASYNCHRONOUS - it returns immediately with a dispatch ID. The result
+will be delivered to you automatically when the dispatch completes.
+
+For quick searches, prefer the grep tool with context_lines instead.
+Use view when you need to understand the full structure or content of a file.
+
+IMPORTANT: If you just need a few lines around a known pattern, use grep with context_lines instead - it's synchronous and faster.]],
+    param = {
+      type = "table",
+      fields = {
+        {
+          name = "path",
+          description = "The relative path of the file to read",
+          type = "string",
+        },
+        {
+          name = "purpose",
+          description = "What you're looking for or trying to understand in this file. This helps the sub-agent provide more relevant analysis.",
+          type = "string",
+          optional = true,
+        },
+        {
+          name = "start_line",
+          description = "Optional line number to start reading on (1-based index)",
+          type = "integer",
+          optional = true,
+        },
+        {
+          name = "end_line",
+          description = "Optional line number to end reading on (1-based index, inclusive)",
+          type = "integer",
+          optional = true,
+        },
+      },
+      usage = {
+        path = "The path to the file in the current project scope",
+        purpose = "What you're looking for in this file",
+        start_line = "The start line of the view range, 1-indexed",
+        end_line = "The end line of the view range, 1-indexed",
+      },
+    },
+    returns = {
+      {
+        name = "result",
+        description = "Dispatch ID and status (async - result delivered later)",
+        type = "string",
+      },
+      {
+        name = "error",
+        description = "Error message if the dispatch could not be started",
+        type = "string",
+        optional = true,
+      },
+    },
+    func = function(input, opts)
+      local on_log = opts.on_log
+      local on_complete = opts.on_complete
+      local session_ctx = opts.session_ctx or {}
+
+      if not input.path then return nil, "path is required" end
+
+      -- Read the file content using the raw view tool
+      local raw_view = require("avante.llm_tools.view")
+      local file_result, file_err = raw_view.func(input, {
+        on_log = on_log,
+        session_ctx = session_ctx,
+      })
+
+      if file_err then
+        if on_complete then
+          on_complete(nil, file_err)
+          return
+        end
+        return nil, file_err
+      end
+
+      -- Estimate file tokens
+      local file_content = file_result or ""
+      local words = 0
+      for _ in file_content:gmatch("%S+") do
+        words = words + 1
+      end
+      local estimated_file_tokens = math.ceil(words * 1.3)
+
+      -- Build the dispatch prompt
+      local purpose = input.purpose or "Read and summarize the file content"
+      local dispatch_prompt = "Read the file '" .. input.path .. "' and provide a thorough analysis."
+        .. " Focus on: " .. purpose
+        .. "\n\nFile content:\n" .. file_content
+
+      -- Pick cheapest provider that fits
+      local total_tokens = estimated_file_tokens + 500 -- headroom for prompt overhead
+      local dispatch_provider_name, _ = DispatchRegistry.pick_cheapest_provider(total_tokens)
+
+      -- Fall back to default provider
+      if not dispatch_provider_name then dispatch_provider_name = Config.provider end
+
+      local Llm = require("avante.llm")
+      local Providers_ = require("avante.providers")
+      local dispatch_provider = Providers_[dispatch_provider_name]
+      local dispatch_model = dispatch_provider and dispatch_provider.model or "unknown"
+
+      local session_id = session_ctx.dispatch_session_id or "default"
+      local dispatch_id = DispatchRegistry.register(session_id, "view: " .. input.path, dispatch_provider_name, dispatch_model)
+
+      if on_log then
+        on_log(string.format("Dispatching file read #%s for '%s' (provider: %s)", dispatch_id, input.path, dispatch_provider_name))
+      end
+
+      local system_prompt = "You are a file analysis assistant. Read the provided file content and answer questions about it. Be thorough and precise."
+      local history_messages = {}
+      local result = ""
+
+      local agent_loop_options = {
+        system_prompt = system_prompt,
+        user_input = dispatch_prompt,
+        tools = {
+          require("avante.llm_tools.attempt_completion"),
+        },
+        on_tool_log = session_ctx.on_tool_log,
+        on_messages_add = function(msgs)
+          msgs = vim.islist(msgs) and msgs or { msgs }
+          for _, msg in ipairs(msgs) do
+            local idx = nil
+            for i, m in ipairs(history_messages) do
+              if m.uuid == msg.uuid then
+                idx = i
+                break
+              end
+            end
+            if idx ~= nil then
+              history_messages[idx] = msg
+            else
+              table.insert(history_messages, msg)
+            end
+          end
+          for _, msg in ipairs(msgs) do
+            local History_ = require("avante.history")
+            local tool_use = History_.Helpers.get_tool_use_data(msg)
+            if tool_use and tool_use.name == "attempt_completion" and tool_use.input and tool_use.input.result then
+              result = tool_use.input.result
+            end
+          end
+        end,
+        session_ctx = session_ctx,
+        on_chunk = function() end,
+        on_complete = function(err)
+          if err ~= nil then
+            DispatchRegistry.fail(session_id, dispatch_id, vim.inspect(err))
+            return
+          end
+          DispatchRegistry.complete(session_id, dispatch_id, result)
+        end,
+      }
+
+      -- Fire-and-forget
+      vim.schedule(function()
+        Llm.agent_loop(agent_loop_options)
+      end)
+
+      local response = string.format(
+        "Dispatch #%s started - reading '%s' via provider '%s' (model: %s). Result will be delivered automatically.",
+        dispatch_id, input.path, dispatch_provider_name, dispatch_model
+      )
+
+      if on_complete then
+        on_complete(response, nil)
+        return
+      end
+      return response, nil
+    end,
+  },
   require("avante.llm_tools.write_to_file"),
   require("avante.llm_tools.insert"),
   require("avante.llm_tools.undo_edit"),

--- a/lua/avante/path.lua
+++ b/lua/avante/path.lua
@@ -3,6 +3,7 @@ local Utils = require("avante.utils")
 local Path = require("plenary.path")
 local Scan = require("plenary.scandir")
 local Config = require("avante.config")
+local Names = require("avante.utils.names")
 
 ---@class avante.Path
 ---@field history_path string
@@ -128,6 +129,7 @@ end
 ---@param bufnr integer
 function History.new(bufnr)
   local filepath = History.get_latest_filepath(bufnr, true)
+  local instance_name = Names.generate()
   ---@type avante.ChatHistory
   local history = {
     title = "untitled",
@@ -136,6 +138,8 @@ function History.new(bufnr)
     messages = {},
     todos = {},
     filename = filepath_to_filename(filepath),
+    instance_id = Utils.uuid(),
+    instance_name = instance_name,
   }
   return history
 end
@@ -157,6 +161,14 @@ function History.from_file(filepath)
         if not vim.islist(history.todos) then history.todos = {} end
         ---@cast history avante.ChatHistory
         history.filename = filepath_to_filename(filepath)
+        -- Backfill instance_id / instance_name for histories created before this feature.
+        if not history.instance_id or history.instance_id == "" then history.instance_id = Utils.uuid() end
+        if not history.instance_name or history.instance_name == "" then
+          history.instance_name = Names.generate()
+        else
+          -- Register the persisted name so the collision table stays accurate.
+          Names.register(history.instance_name)
+        end
         return history
       end
     end

--- a/lua/avante/path.lua
+++ b/lua/avante/path.lua
@@ -173,12 +173,43 @@ function History.load(bufnr, filename)
   return History.from_file(history_filepath) or History.new(bufnr)
 end
 
+--- Recursively strip UTF-8 surrogate code points (CESU-8: 0xED [0xA0-0xBF] [0x80-0xBF])
+--- from all string values in `value`, replacing each 3-byte sequence with U+FFFD.
+--- This prevents cjson from rejecting the JSON with "surrogates not allowed" when
+--- file content or tool results contain characters encoded in modified UTF-8.
+---@param value any
+---@return any
+local function deep_sanitize_utf8(value)
+  local t = type(value)
+  if t == "string" then
+    return (value:gsub("\xED[\xA0-\xBF][\x80-\xBF]", "\xEF\xBF\xBD"))
+  elseif t == "table" then
+    local out = {}
+    for k, v in pairs(value) do
+      out[deep_sanitize_utf8(k)] = deep_sanitize_utf8(v)
+    end
+    if vim.islist(value) then return vim.list_slice(out, 1) end
+    return out
+  else
+    return value
+  end
+end
+
 -- Saves the chat history for the given buffer.
 ---@param bufnr integer
 ---@param history avante.ChatHistory
 function History.save(bufnr, history)
   local history_filepath = History.get_filepath(bufnr, history.filename)
-  history_filepath:write(vim.json.encode(history), "w")
+  -- Sanitize surrogate code points before encoding so that history files
+  -- remain valid UTF-8 JSON even when tool results or file contents contain
+  -- CESU-8 / modified-UTF-8 surrogate bytes.
+  local ok, json_content = pcall(vim.json.encode, deep_sanitize_utf8(history))
+  if not ok then
+    -- Fallback: encode without sanitization (better to save something than nothing)
+    ok, json_content = pcall(vim.json.encode, history)
+    if not ok then return end
+  end
+  history_filepath:write(json_content, "w")
   History.save_latest_filename(bufnr, history.filename)
 end
 
@@ -295,8 +326,7 @@ function Prompt.get_templates_dir(project_root)
   -- get root directory of given bufnr
   local directory = Path:new(project_root)
   if Utils.get_os_name() == "windows" then
-    local win_path = vim.fs.abspath(tostring(directory)):gsub("^%a:", ""):gsub("^[/\\]+", "")
-    directory = Path:new(vim.fs.normalize(win_path))
+    directory = Path:new(vim.fs.abspath(tostring(directory)):gsub("^%a:", ""))
   end
   local cache_prompt_dir = Path:new(P.cache_path):joinpath(directory)
   if not cache_prompt_dir:exists() then cache_prompt_dir:mkdir({ parents = true }) end

--- a/lua/avante/path.lua
+++ b/lua/avante/path.lua
@@ -29,6 +29,19 @@ local function filepath_to_filename(filepath) return tostring(filepath):sub(tost
 -- History path
 local History = {}
 
+-- Hard cap per JSON file. Beyond this we transparently split into 0.json,
+-- 1.json, 2.json, ... inside the instance directory.  Load reassembles them.
+local MAX_FILE_SIZE_BYTES = 4 * 1024 * 1024
+
+-- Sentinel filename written inside an instance dir to mark it as deleted by
+-- /clear.  We never actually remove the directory so the user can recover
+-- by deleting this sentinel manually.
+local DELETED_SENTINEL = ".deleted"
+
+-- Per-process memo of project history dirs whose legacy flat <n>.json files
+-- have already been migrated into per-instance folders during this session.
+local _migrated_dirs = {}
+
 function History.get_history_dir(bufnr)
   local dirname = generate_project_dirname_in_storage(bufnr)
   local history_dir = Path:new(Config.history.storage_path):joinpath(dirname):joinpath("history")
@@ -46,43 +59,120 @@ function History.get_history_dir(bufnr)
   return history_dir
 end
 
+---Return true if the given instance directory has been marked as deleted by /clear.
+---@param instance_dir_path Path
+---@return boolean
+function History.is_instance_deleted(instance_dir_path)
+  return instance_dir_path:joinpath(DELETED_SENTINEL):exists()
+end
+
+---Mark an instance as deleted (writes a sentinel file).  Keeps all JSON files
+---intact so the user can restore manually.  Does NOT release the instance_name.
+---@param bufnr integer
+---@param instance_dirname string  e.g. "swift-fox"
+function History.mark_instance_deleted(bufnr, instance_dirname)
+  local history_dir = History.get_history_dir(bufnr)
+  local instance_dir = history_dir:joinpath(instance_dirname)
+  if not instance_dir:exists() then return end
+  local sentinel = instance_dir:joinpath(DELETED_SENTINEL)
+  sentinel:write(tostring(os.time()), "w")
+  Utils.debug("History.mark_instance_deleted", instance_dirname)
+end
+
+---Remove the deleted sentinel from an instance directory.
+---@param bufnr integer
+---@param instance_dirname string
+function History.restore_instance(bufnr, instance_dirname)
+  local history_dir = History.get_history_dir(bufnr)
+  local sentinel = history_dir:joinpath(instance_dirname):joinpath(DELETED_SENTINEL)
+  if sentinel:exists() then pcall(vim.fs.rm, tostring(sentinel)) end
+end
+
+---One-shot migration: move any legacy flat <n>.json (and named *.json) files
+---directly inside history_dir into per-instance folders so they show up in
+---the new picker.  Runs at most once per directory per process.
+---@param history_dir Path
+local function migrate_legacy_files(history_dir)
+  local key = tostring(history_dir)
+  if _migrated_dirs[key] then return end
+  _migrated_dirs[key] = true
+
+  local files = vim.fn.glob(tostring(history_dir:joinpath("*.json")), true, true)
+  for _, file_path in ipairs(files) do
+    if not file_path:match("metadata%.json$") then
+      local stem = vim.fn.fnamemodify(file_path, ":t:r")
+      -- Prefer the existing instance_name inside the file when available;
+      -- otherwise label the legacy file by its numeric stem.
+      local target_dirname
+      local ok, content = pcall(function() return Path:new(file_path):read() end)
+      if ok and content then
+        local decode_ok, parsed = pcall(vim.json.decode, content)
+        if decode_ok and type(parsed) == "table" and type(parsed.instance_name) == "string" and parsed.instance_name ~= "" then
+          target_dirname = parsed.instance_name
+        end
+      end
+      if not target_dirname then target_dirname = "legacy-" .. stem end
+
+      local target_dir = history_dir:joinpath(target_dirname)
+      if not target_dir:exists() then target_dir:mkdir({ parents = true }) end
+      local dest = target_dir:joinpath("0.json")
+      if not dest:exists() then
+        -- Fix up filename field inside the JSON before moving.
+        if ok and content then
+          local decode_ok, parsed = pcall(vim.json.decode, content)
+          if decode_ok and type(parsed) == "table" then
+            parsed.filename = target_dirname .. "/0.json"
+            if not parsed.instance_name or parsed.instance_name == "" then
+              parsed.instance_name = target_dirname
+            end
+            if not parsed.instance_id or parsed.instance_id == "" then
+              parsed.instance_id = Utils.uuid()
+            end
+            local enc_ok, enc = pcall(vim.json.encode, parsed)
+            if enc_ok then
+              dest:write(enc, "w")
+              pcall(vim.fs.rm, file_path)
+              Utils.debug("History.migrate_legacy moved", file_path, "→", tostring(dest))
+              goto continue
+            end
+          end
+        end
+        -- Fallback: byte copy + remove
+        pcall(function()
+          Path:new(file_path):copy({ destination = dest })
+          vim.fs.rm(file_path)
+        end)
+      end
+      ::continue::
+    end
+  end
+end
+
+---@param bufnr integer
+---@param opts? { include_deleted?: boolean }
 ---@return avante.ChatHistory[]
-function History.list(bufnr)
+function History.list(bufnr, opts)
+  opts = opts or {}
   local history_dir = History.get_history_dir(bufnr)
   local latest_filename = History.get_latest_filename(bufnr, false)
   local res = {}
 
+  -- Migrate legacy flat files into per-instance folders (idempotent, one-shot per session).
+  migrate_legacy_files(history_dir)
+
   Utils.debug("History.list scanning", tostring(history_dir))
 
-  -- New format: per-instance subdirectories (<instance_name>/*.json)
+  -- Per-instance subdirectories (<instance_name>/*.json).  After migration this
+  -- is the ONLY layout we have to deal with.
   local subdirs = Scan.scan_dir(tostring(history_dir), { depth = 1, only_dirs = true, add_dirs = true })
   for _, subdir_path in ipairs(subdirs) do
     local subdir = Path:new(subdir_path)
-    local instance_dirname = filepath_to_filename(subdir)
-    local json_files = vim.fn.glob(tostring(subdir:joinpath("*.json")), true, true)
-    table.sort(json_files) -- 0.json first for consistency
-    for _, json_file in ipairs(json_files) do
-      local filepath = Path:new(json_file)
-      local history = History.from_file(filepath)
+    if opts.include_deleted or not History.is_instance_deleted(subdir) then
+      local instance_dirname = filepath_to_filename(subdir)
+      -- Load the merged instance history (handles multi-part 0.json / 1.json / …).
+      local history = History.load(bufnr, instance_dirname .. "/0.json")
       if history then
-        -- Override filename with path relative to history_dir so callers use
-        -- the correct relative key (e.g. "swift-fox/0.json").
-        history.filename = instance_dirname .. "/" .. filepath_to_filename(filepath)
-        Utils.debug("History.list found (new)", history.filename, history.instance_name)
-        table.insert(res, history)
-      end
-    end
-  end
-
-  -- Legacy format: flat *.json files directly inside history_dir
-  local flat_files = vim.fn.glob(tostring(history_dir:joinpath("*.json")), true, true)
-  for _, file_path in ipairs(flat_files) do
-    if not file_path:match("metadata.json") then
-      local filepath = Path:new(file_path)
-      local history = History.from_file(filepath)
-      if history then
-        history.filename = filepath_to_filename(filepath) -- just basename for legacy
-        Utils.debug("History.list found (legacy)", history.filename, history.instance_name)
+        Utils.debug("History.list found", history.filename, history.instance_name)
         table.insert(res, history)
       end
     end
@@ -99,6 +189,173 @@ function History.list(bufnr)
     local timestamp_b = #b_messages > 0 and b_messages[#b_messages].timestamp or b.timestamp
     return timestamp_a > timestamp_b
   end)
+  return res
+end
+
+---Lightweight per-instance summary used by the :AvanteHistory picker.  Avoids
+---loading multi-megabyte JSON files when only mtime/title/first-message are
+---needed for the picker.  Sorted by mtime descending.
+---@class avante.HistoryInstanceSummary
+---@field instance_name string
+---@field instance_dirname string
+---@field filename string             relative path: "<instance>/0.json"
+---@field project_root string
+---@field project_dirname string      filesystem-safe encoded form (the storage key)
+---@field title string
+---@field first_message_text string
+---@field last_message_text string
+---@field mtime integer               seconds since epoch (latest mtime in instance dir)
+---@field timestamp string|nil
+---@field is_legacy boolean
+
+---@param history_dir Path
+---@param instance_dirname string
+---@param project_root string
+---@param project_dirname string
+---@return avante.HistoryInstanceSummary | nil
+local function build_instance_summary(history_dir, instance_dirname, project_root, project_dirname)
+  local instance_dir = history_dir:joinpath(instance_dirname)
+  if not instance_dir:exists() then return nil end
+  if History.is_instance_deleted(instance_dir) then return nil end
+
+  -- Latest mtime across all *.json parts so growing instances bubble to the top.
+  local json_files = vim.fn.glob(tostring(instance_dir:joinpath("*.json")), true, true)
+  if #json_files == 0 then return nil end
+  local latest_mtime = 0
+  for _, fp in ipairs(json_files) do
+    local stat = vim.uv.fs_stat(fp)
+    if stat and stat.mtime and stat.mtime.sec and stat.mtime.sec > latest_mtime then
+      latest_mtime = stat.mtime.sec
+    end
+  end
+
+  -- Load merged history to extract title + first/last message previews.  This
+  -- DOES read every part file, which can be expensive for very large
+  -- instances; callers that want raw mtime sort should defer this.
+  local history = History.from_file(instance_dir:joinpath("0.json"))
+  if not history then return nil end
+  -- Merge subsequent parts to make first/last message previews accurate.
+  table.sort(json_files)
+  for i = 2, #json_files do
+    local part = History.from_file(Path:new(json_files[i]))
+    if part then
+      if part.messages then vim.list_extend(history.messages, part.messages) end
+      if part.entries then vim.list_extend(history.entries, part.entries) end
+    end
+  end
+
+  local H = require("avante.history")
+  local messages = H.get_history_messages(history)
+
+  local function extract_text(content)
+    if type(content) == "string" then return content end
+    if type(content) == "table" then
+      for _, block in ipairs(content) do
+        if type(block) == "table" and block.type == "text" and type(block.text) == "string" then
+          return block.text
+        end
+      end
+    end
+    return ""
+  end
+  local function msg_role(m) return m.role or (type(m.message) == "table" and m.message.role) or "" end
+  local function msg_content(m) return m.content or (type(m.message) == "table" and m.message.content) or "" end
+
+  local first_text = ""
+  for _, m in ipairs(messages) do
+    if msg_role(m) == "user" then
+      local t = extract_text(msg_content(m))
+      if t ~= "" then
+        first_text = t
+        break
+      end
+    end
+  end
+  local last_text = ""
+  for i = #messages, 1, -1 do
+    local t = extract_text(msg_content(messages[i]))
+    if t ~= "" then
+      last_text = t
+      break
+    end
+  end
+
+  return {
+    instance_name = history.instance_name or instance_dirname,
+    instance_dirname = instance_dirname,
+    filename = instance_dirname .. "/0.json",
+    project_root = project_root,
+    project_dirname = project_dirname,
+    title = history.title or "untitled",
+    first_message_text = first_text,
+    last_message_text = last_text,
+    mtime = latest_mtime,
+    timestamp = history.timestamp,
+    is_legacy = instance_dirname:match("^legacy%-") ~= nil,
+  }
+end
+
+---List instance summaries for the buffer's project, sorted by mtime descending.
+---Excludes /clear-deleted instances.
+---@param bufnr integer
+---@return avante.HistoryInstanceSummary[]
+function History.list_instances(bufnr)
+  local history_dir = History.get_history_dir(bufnr)
+  migrate_legacy_files(history_dir)
+
+  local project_root = Utils.root.get({ buf = bufnr }) or ""
+  local project_dirname = generate_project_dirname_in_storage(bufnr):match("[^/]+$") or ""
+
+  local res = {}
+  local subdirs = Scan.scan_dir(tostring(history_dir), { depth = 1, only_dirs = true, add_dirs = true })
+  for _, subdir_path in ipairs(subdirs) do
+    local subdir = Path:new(subdir_path)
+    local instance_dirname = filepath_to_filename(subdir)
+    local summary = build_instance_summary(history_dir, instance_dirname, project_root, project_dirname)
+    if summary then table.insert(res, summary) end
+  end
+  table.sort(res, function(a, b) return a.mtime > b.mtime end)
+  return res
+end
+
+---List instance summaries across ALL projects, sorted by mtime descending.
+---Excludes the current project (callers should concat them onto the
+---current-project list themselves).
+---@param exclude_project_root? string
+---@return avante.HistoryInstanceSummary[]
+function History.list_all_instances(exclude_project_root)
+  local projects_dir = Path:new(Config.history.storage_path):joinpath("projects")
+  if not projects_dir:exists() then return {} end
+
+  local res = {}
+  local project_dirs = Scan.scan_dir(tostring(projects_dir), { depth = 1, only_dirs = true, add_dirs = true })
+  for _, project_dir_path in ipairs(project_dirs) do
+    local project_dir = Path:new(project_dir_path)
+    local history_dir = project_dir:joinpath("history")
+    if history_dir:exists() then
+      migrate_legacy_files(history_dir)
+      local metadata_file = history_dir:joinpath("metadata.json")
+      local project_root = ""
+      if metadata_file:exists() then
+        local ok, content = pcall(function() return metadata_file:read() end)
+        if ok and content then
+          local dok, metadata = pcall(vim.json.decode, content)
+          if dok and metadata and metadata.project_root then project_root = metadata.project_root end
+        end
+      end
+      if project_root ~= "" and project_root ~= exclude_project_root then
+        local project_dirname = filepath_to_filename(project_dir)
+        local subdirs = Scan.scan_dir(tostring(history_dir), { depth = 1, only_dirs = true, add_dirs = true })
+        for _, subdir_path in ipairs(subdirs) do
+          local subdir = Path:new(subdir_path)
+          local instance_dirname = filepath_to_filename(subdir)
+          local summary = build_instance_summary(history_dir, instance_dirname, project_root, project_dirname)
+          if summary then table.insert(res, summary) end
+        end
+      end
+    end
+  end
+  table.sort(res, function(a, b) return a.mtime > b.mtime end)
   return res
 end
 
@@ -206,20 +463,59 @@ function History.from_file(filepath)
   end
 end
 
--- Loads the chat history for the given buffer.
+-- Loads the chat history for the given buffer.  Transparently merges
+-- multi-part instance directories (0.json + 1.json + …) produced by the
+-- 4 MB split logic in History.save.
 ---@param bufnr integer
 ---@param filename string?
 ---@return avante.ChatHistory
 function History.load(bufnr, filename)
+  local history_dir = History.get_history_dir(bufnr)
+  local instance_dirname = filename and filename:match("^(.-)/[^/]+%.json$") or nil
+
+  if instance_dirname then
+    local instance_dir = history_dir:joinpath(instance_dirname)
+    if instance_dir:exists() then
+      local json_files = vim.fn.glob(tostring(instance_dir:joinpath("*.json")), true, true)
+      table.sort(json_files, function(a, b)
+        local na = tonumber(vim.fn.fnamemodify(a, ":t:r")) or 0
+        local nb = tonumber(vim.fn.fnamemodify(b, ":t:r")) or 0
+        return na < nb
+      end)
+      if #json_files > 0 then
+        local base = History.from_file(Path:new(json_files[1]))
+        if base then
+          -- Canonical filename always points at 0.json regardless of how many
+          -- parts there are on disk; subsequent saves go through the same
+          -- canonical entry point.
+          base.filename = instance_dirname .. "/0.json"
+          for i = 2, #json_files do
+            local part = History.from_file(Path:new(json_files[i]))
+            if part then
+              if part.messages then vim.list_extend(base.messages, part.messages) end
+              if part.entries then vim.list_extend(base.entries, part.entries) end
+            end
+          end
+          Utils.debug(
+            "History.load merged",
+            base.filename,
+            base.instance_name,
+            string.format("(%d parts, %d messages)", #json_files, #base.messages)
+          )
+          return base
+        end
+      end
+    end
+  end
+
+  -- Fall back to legacy single-file path (e.g. metadata.json points at a
+  -- flat <n>.json that hasn't been migrated yet).
   local history_filepath = filename and History.get_filepath(bufnr, filename)
     or History.get_latest_filepath(bufnr, false)
   local h = History.from_file(history_filepath)
   if h then
-    -- Ensure the filename stored in the history object uses the relative path
-    -- passed by the caller (e.g. "swift-fox/0.json") rather than just the
-    -- basename that from_file() sets.
     if filename then h.filename = filename end
-    Utils.debug("History.load loaded", h.filename, h.instance_name)
+    Utils.debug("History.load loaded (legacy single-file)", h.filename, h.instance_name)
     return h
   end
   Utils.debug("History.load creating new (file missing or unreadable)", tostring(history_filepath))
@@ -248,26 +544,135 @@ local function deep_sanitize_utf8(value)
   end
 end
 
--- Saves the chat history for the given buffer.
+-- Saves the chat history for the given buffer.  When the encoded history
+-- exceeds MAX_FILE_SIZE_BYTES, transparently splits messages and entries
+-- across <instance>/0.json, <instance>/1.json, ... so each file stays under
+-- the cap.  The first part holds all metadata (title, todos, memory, etc.)
+-- plus as many messages/entries as fit; subsequent parts hold only the
+-- overflow `{ messages = [...], entries = [...] }`.
 ---@param bufnr integer
 ---@param history avante.ChatHistory
 function History.save(bufnr, history)
-  local history_filepath = History.get_filepath(bufnr, history.filename)
-  -- Ensure parent directory exists (needed for per-instance subfolders like
-  -- <history_dir>/swift-fox/0.json — the swift-fox dir might not exist yet).
-  local parent = history_filepath:parent()
-  if not parent:exists() then parent:mkdir({ parents = true }) end
+  if not history or not history.filename then return end
+
   -- Sanitize surrogate code points before encoding so that history files
   -- remain valid UTF-8 JSON even when tool results or file contents contain
   -- CESU-8 / modified-UTF-8 surrogate bytes.
-  local ok, json_content = pcall(vim.json.encode, deep_sanitize_utf8(history))
-  if not ok then
-    -- Fallback: encode without sanitization (better to save something than nothing)
-    ok, json_content = pcall(vim.json.encode, history)
-    if not ok then return end
+  local sanitized = deep_sanitize_utf8(history)
+
+  local instance_dirname = type(history.filename) == "string" and history.filename:match("^(.-)/[^/]+%.json$") or nil
+  local history_dir = History.get_history_dir(bufnr)
+
+  -- Legacy: filename has no slash → behave exactly like the old single-file save.
+  if not instance_dirname then
+    local history_filepath = History.get_filepath(bufnr, history.filename)
+    local parent = history_filepath:parent()
+    if not parent:exists() then parent:mkdir({ parents = true }) end
+    local ok, json_content = pcall(vim.json.encode, sanitized)
+    if not ok then
+      ok, json_content = pcall(vim.json.encode, history)
+      if not ok then return end
+    end
+    Utils.debug("History.save writing (legacy)", history.filename)
+    history_filepath:write(json_content, "w")
+    History.save_latest_filename(bufnr, history.filename)
+    return
   end
-  Utils.debug("History.save writing", history.filename)
-  history_filepath:write(json_content, "w")
+
+  -- New (per-instance) layout: always canonicalize filename to <instance>/0.json
+  -- regardless of how many parts there end up being.
+  history.filename = instance_dirname .. "/0.json"
+  local instance_dir = history_dir:joinpath(instance_dirname)
+  if not instance_dir:exists() then instance_dir:mkdir({ parents = true }) end
+
+  -- Fast path: does the whole thing fit in a single file?
+  local ok_full, full_json = pcall(vim.json.encode, sanitized)
+  if not ok_full then
+    -- Last-ditch: encode raw
+    ok_full, full_json = pcall(vim.json.encode, history)
+    if not ok_full then return end
+  end
+
+  if #full_json <= MAX_FILE_SIZE_BYTES then
+    instance_dir:joinpath("0.json"):write(full_json, "w")
+    -- Clean up any leftover part files from a previously-larger state.
+    local existing = vim.fn.glob(tostring(instance_dir:joinpath("*.json")), true, true)
+    for _, fp in ipairs(existing) do
+      local n = tonumber(vim.fn.fnamemodify(fp, ":t:r"))
+      if n and n > 0 then pcall(function() vim.fs.rm(fp) end) end
+    end
+    Utils.debug("History.save wrote single-part", history.filename, "bytes=" .. #full_json)
+    History.save_latest_filename(bufnr, history.filename)
+    return
+  end
+
+  -- Need to split.  Strategy: greedy bin-packing of messages + entries.
+  -- Part 0 carries the full metadata table.  Subsequent parts are just
+  -- `{ messages = [...], entries = [...] }`.
+  Utils.debug("History.save splitting (size " .. #full_json .. " > cap)", history.filename)
+
+  local base = vim.deepcopy(sanitized)
+  base.messages = {}
+  base.entries = {}
+  local base_size = #vim.json.encode(base)
+  -- Use the base size as the floor for part 0.  Reserve a small safety margin.
+  local SAFETY = 1024
+  local budget_for_part0 = MAX_FILE_SIZE_BYTES - base_size - SAFETY
+  if budget_for_part0 < 0 then budget_for_part0 = 0 end
+  local budget_for_part_n = MAX_FILE_SIZE_BYTES - SAFETY
+
+  ---@type { messages: any[], entries: any[] }[]
+  local parts = { { messages = {}, entries = {} } }
+  local sizes = { 0 }
+  local function current_budget(i) return i == 1 and budget_for_part0 or budget_for_part_n end
+
+  local function fit(field, item)
+    -- Encoded size: item plus a comma overhead.
+    local ok_e, enc = pcall(vim.json.encode, item)
+    if not ok_e then return end
+    local cost = #enc + 2 -- comma + space-ish overhead
+
+    local idx = #parts
+    -- If item alone is larger than even a fresh part, drop it onto its own
+    -- oversized part (better to exceed than to silently lose data).
+    if cost > current_budget(idx) and (#parts[idx].messages + #parts[idx].entries) > 0 then
+      table.insert(parts, { messages = {}, entries = {} })
+      sizes[#parts] = 0
+      idx = #parts
+    end
+    table.insert(parts[idx][field], item)
+    sizes[idx] = sizes[idx] + cost
+  end
+
+  for _, msg in ipairs(sanitized.messages or {}) do
+    fit("messages", msg)
+  end
+  for _, entry in ipairs(sanitized.entries or {}) do
+    fit("entries", entry)
+  end
+
+  -- Materialise part 0 as base ∪ parts[1]
+  local part0 = vim.deepcopy(base)
+  part0.messages = parts[1].messages
+  part0.entries = parts[1].entries
+  local p0_ok, p0_json = pcall(vim.json.encode, part0)
+  if not p0_ok then return end
+  instance_dir:joinpath("0.json"):write(p0_json, "w")
+
+  for i = 2, #parts do
+    local part = { messages = parts[i].messages, entries = parts[i].entries }
+    local pe_ok, pe_json = pcall(vim.json.encode, part)
+    if pe_ok then instance_dir:joinpath((i - 1) .. ".json"):write(pe_json, "w") end
+  end
+
+  -- Trim any leftover files from a previously-larger state.
+  local existing = vim.fn.glob(tostring(instance_dir:joinpath("*.json")), true, true)
+  for _, fp in ipairs(existing) do
+    local n = tonumber(vim.fn.fnamemodify(fp, ":t:r"))
+    if n and n >= #parts then pcall(function() vim.fs.rm(fp) end) end
+  end
+
+  Utils.debug("History.save wrote " .. #parts .. " parts for " .. history.filename)
   History.save_latest_filename(bufnr, history.filename)
 end
 

--- a/lua/avante/path.lua
+++ b/lua/avante/path.lua
@@ -3,6 +3,7 @@ local Utils = require("avante.utils")
 local Path = require("plenary.path")
 local Scan = require("plenary.scandir")
 local Config = require("avante.config")
+local Names = require("avante.utils.names")
 
 ---@class avante.Path
 ---@field history_path string
@@ -128,6 +129,7 @@ end
 ---@param bufnr integer
 function History.new(bufnr)
   local filepath = History.get_latest_filepath(bufnr, true)
+  local instance_name = Names.generate()
   ---@type avante.ChatHistory
   local history = {
     title = "untitled",
@@ -136,6 +138,8 @@ function History.new(bufnr)
     messages = {},
     todos = {},
     filename = filepath_to_filename(filepath),
+    instance_id = Utils.uuid(),
+    instance_name = instance_name,
   }
   return history
 end
@@ -157,6 +161,14 @@ function History.from_file(filepath)
         if not vim.islist(history.todos) then history.todos = {} end
         ---@cast history avante.ChatHistory
         history.filename = filepath_to_filename(filepath)
+        -- Backfill instance_id / instance_name for histories created before this feature.
+        if not history.instance_id or history.instance_id == "" then history.instance_id = Utils.uuid() end
+        if not history.instance_name or history.instance_name == "" then
+          history.instance_name = Names.generate()
+        else
+          -- Register the persisted name so the collision table stays accurate.
+          Names.register(history.instance_name)
+        end
         return history
       end
     end
@@ -173,12 +185,43 @@ function History.load(bufnr, filename)
   return History.from_file(history_filepath) or History.new(bufnr)
 end
 
+--- Recursively strip UTF-8 surrogate code points (CESU-8: 0xED [0xA0-0xBF] [0x80-0xBF])
+--- from all string values in `value`, replacing each 3-byte sequence with U+FFFD.
+--- This prevents cjson from rejecting the JSON with "surrogates not allowed" when
+--- file content or tool results contain characters encoded in modified UTF-8.
+---@param value any
+---@return any
+local function deep_sanitize_utf8(value)
+  local t = type(value)
+  if t == "string" then
+    return (value:gsub("\xED[\xA0-\xBF][\x80-\xBF]", "\xEF\xBF\xBD"))
+  elseif t == "table" then
+    local out = {}
+    for k, v in pairs(value) do
+      out[deep_sanitize_utf8(k)] = deep_sanitize_utf8(v)
+    end
+    if vim.islist(value) then return vim.list_slice(out, 1) end
+    return out
+  else
+    return value
+  end
+end
+
 -- Saves the chat history for the given buffer.
 ---@param bufnr integer
 ---@param history avante.ChatHistory
 function History.save(bufnr, history)
   local history_filepath = History.get_filepath(bufnr, history.filename)
-  history_filepath:write(vim.json.encode(history), "w")
+  -- Sanitize surrogate code points before encoding so that history files
+  -- remain valid UTF-8 JSON even when tool results or file contents contain
+  -- CESU-8 / modified-UTF-8 surrogate bytes.
+  local ok, json_content = pcall(vim.json.encode, deep_sanitize_utf8(history))
+  if not ok then
+    -- Fallback: encode without sanitization (better to save something than nothing)
+    ok, json_content = pcall(vim.json.encode, history)
+    if not ok then return end
+  end
+  history_filepath:write(json_content, "w")
   History.save_latest_filename(bufnr, history.filename)
 end
 
@@ -295,8 +338,7 @@ function Prompt.get_templates_dir(project_root)
   -- get root directory of given bufnr
   local directory = Path:new(project_root)
   if Utils.get_os_name() == "windows" then
-    local win_path = vim.fs.abspath(tostring(directory)):gsub("^%a:", ""):gsub("^[/\\]+", "")
-    directory = Path:new(vim.fs.normalize(win_path))
+    directory = Path:new(vim.fs.abspath(tostring(directory)):gsub("^%a:", ""))
   end
   local cache_prompt_dir = Path:new(P.cache_path):joinpath(directory)
   if not cache_prompt_dir:exists() then cache_prompt_dir:mkdir({ parents = true }) end

--- a/lua/avante/path.lua
+++ b/lua/avante/path.lua
@@ -3,6 +3,7 @@ local Utils = require("avante.utils")
 local Path = require("plenary.path")
 local Scan = require("plenary.scandir")
 local Config = require("avante.config")
+local Names = require("avante.utils.names")
 
 ---@class avante.Path
 ---@field history_path string
@@ -128,6 +129,7 @@ end
 ---@param bufnr integer
 function History.new(bufnr)
   local filepath = History.get_latest_filepath(bufnr, true)
+  local instance_name = Names.generate()
   ---@type avante.ChatHistory
   local history = {
     title = "untitled",
@@ -136,6 +138,8 @@ function History.new(bufnr)
     messages = {},
     todos = {},
     filename = filepath_to_filename(filepath),
+    instance_id = Utils.uuid(),
+    instance_name = instance_name,
   }
   return history
 end
@@ -157,6 +161,12 @@ function History.from_file(filepath)
         if not vim.islist(history.todos) then history.todos = {} end
         ---@cast history avante.ChatHistory
         history.filename = filepath_to_filename(filepath)
+        if not history.instance_id or history.instance_id == "" then history.instance_id = Utils.uuid() end
+        if not history.instance_name or history.instance_name == "" then
+          history.instance_name = Names.generate()
+        else
+          Names.register(history.instance_name)
+        end
         return history
       end
     end

--- a/lua/avante/path.lua
+++ b/lua/avante/path.lua
@@ -49,18 +49,46 @@ end
 ---@return avante.ChatHistory[]
 function History.list(bufnr)
   local history_dir = History.get_history_dir(bufnr)
-  local files = vim.fn.glob(tostring(history_dir:joinpath("*.json")), true, true)
   local latest_filename = History.get_latest_filename(bufnr, false)
   local res = {}
-  for _, filename in ipairs(files) do
-    if not filename:match("metadata.json") then
-      local filepath = Path:new(filename)
+
+  Utils.debug("History.list scanning", tostring(history_dir))
+
+  -- New format: per-instance subdirectories (<instance_name>/*.json)
+  local subdirs = Scan.scan_dir(tostring(history_dir), { depth = 1, only_dirs = true, add_dirs = true })
+  for _, subdir_path in ipairs(subdirs) do
+    local subdir = Path:new(subdir_path)
+    local instance_dirname = filepath_to_filename(subdir)
+    local json_files = vim.fn.glob(tostring(subdir:joinpath("*.json")), true, true)
+    table.sort(json_files) -- 0.json first for consistency
+    for _, json_file in ipairs(json_files) do
+      local filepath = Path:new(json_file)
       local history = History.from_file(filepath)
-      if history then table.insert(res, history) end
+      if history then
+        -- Override filename with path relative to history_dir so callers use
+        -- the correct relative key (e.g. "swift-fox/0.json").
+        history.filename = instance_dirname .. "/" .. filepath_to_filename(filepath)
+        Utils.debug("History.list found (new)", history.filename, history.instance_name)
+        table.insert(res, history)
+      end
     end
   end
-  --- sort by timestamp
-  --- sort by latest_filename
+
+  -- Legacy format: flat *.json files directly inside history_dir
+  local flat_files = vim.fn.glob(tostring(history_dir:joinpath("*.json")), true, true)
+  for _, file_path in ipairs(flat_files) do
+    if not file_path:match("metadata.json") then
+      local filepath = Path:new(file_path)
+      local history = History.from_file(filepath)
+      if history then
+        history.filename = filepath_to_filename(filepath) -- just basename for legacy
+        Utils.debug("History.list found (legacy)", history.filename, history.instance_name)
+        table.insert(res, history)
+      end
+    end
+  end
+
+  -- Sort: latest_filename pinned first, then descending by last-message timestamp
   table.sort(res, function(a, b)
     local H = require("avante.history")
     if a.filename == latest_filename then return true end
@@ -128,8 +156,11 @@ end
 
 ---@param bufnr integer
 function History.new(bufnr)
-  local filepath = History.get_latest_filepath(bufnr, true)
   local instance_name = Names.generate()
+  -- New layout: one subfolder per instance, history stored as 0.json inside it.
+  -- e.g.  <history_dir>/swift-fox/0.json
+  local filename = instance_name .. "/0.json"
+  Utils.debug("History.new creating", filename, instance_name)
   ---@type avante.ChatHistory
   local history = {
     title = "untitled",
@@ -137,7 +168,7 @@ function History.new(bufnr)
     entries = {},
     messages = {},
     todos = {},
-    filename = filepath_to_filename(filepath),
+    filename = filename,
     instance_id = Utils.uuid(),
     instance_name = instance_name,
   }
@@ -182,7 +213,17 @@ end
 function History.load(bufnr, filename)
   local history_filepath = filename and History.get_filepath(bufnr, filename)
     or History.get_latest_filepath(bufnr, false)
-  return History.from_file(history_filepath) or History.new(bufnr)
+  local h = History.from_file(history_filepath)
+  if h then
+    -- Ensure the filename stored in the history object uses the relative path
+    -- passed by the caller (e.g. "swift-fox/0.json") rather than just the
+    -- basename that from_file() sets.
+    if filename then h.filename = filename end
+    Utils.debug("History.load loaded", h.filename, h.instance_name)
+    return h
+  end
+  Utils.debug("History.load creating new (file missing or unreadable)", tostring(history_filepath))
+  return History.new(bufnr)
 end
 
 --- Recursively strip UTF-8 surrogate code points (CESU-8: 0xED [0xA0-0xBF] [0x80-0xBF])
@@ -212,6 +253,10 @@ end
 ---@param history avante.ChatHistory
 function History.save(bufnr, history)
   local history_filepath = History.get_filepath(bufnr, history.filename)
+  -- Ensure parent directory exists (needed for per-instance subfolders like
+  -- <history_dir>/swift-fox/0.json — the swift-fox dir might not exist yet).
+  local parent = history_filepath:parent()
+  if not parent:exists() then parent:mkdir({ parents = true }) end
   -- Sanitize surrogate code points before encoding so that history files
   -- remain valid UTF-8 JSON even when tool results or file contents contain
   -- CESU-8 / modified-UTF-8 surrogate bytes.
@@ -221,6 +266,7 @@ function History.save(bufnr, history)
     ok, json_content = pcall(vim.json.encode, history)
     if not ok then return end
   end
+  Utils.debug("History.save writing", history.filename)
   history_filepath:write(json_content, "w")
   History.save_latest_filename(bufnr, history.filename)
 end
@@ -233,6 +279,17 @@ function History.delete(bufnr, filename)
   if history_filepath:exists() then
     local was_latest = (filename == History.get_latest_filename(bufnr, false))
     vim.fs.rm(tostring(history_filepath))
+
+    -- Clean up the per-instance subdirectory if it's now empty.
+    -- Only remove direct subdirectories of history_dir (not history_dir itself).
+    local history_dir = History.get_history_dir(bufnr)
+    local parent = history_filepath:parent()
+    if tostring(parent) ~= tostring(history_dir) then
+      local remaining = vim.fn.glob(tostring(parent:joinpath("*")), true, true)
+      if #remaining == 0 then
+        pcall(vim.fs.rm, tostring(parent), { recursive = true })
+      end
+    end
 
     if was_latest then
       local remaining_histories = History.list(bufnr) -- This list is sorted by recency

--- a/lua/avante/providers/claude.lua
+++ b/lua/avante/providers/claude.lua
@@ -236,8 +236,12 @@ function M:get_rate_limit_sleep_time(headers)
 end
 
 -- Models that do not support the temperature parameter.
--- Claude 4+ generation models (new naming: claude-{tier}-{version}) deprecate temperature entirely.
-local function is_temperature_unsupported(model)
+-- Claude 4+ generation models (new naming: claude-{tier}-{version}) use always-on extended thinking,
+-- which is incompatible with the temperature parameter (API hard error if sent).
+-- See: https://docs.anthropic.com/en/docs/build-with-claude/extended-thinking#important-considerations
+---@param model string|nil
+---@return boolean
+function M.is_temperature_unsupported(model)
   if not model then return false end
   -- Claude 4+ models use new naming convention: claude-{tier}-{major}[-{minor}]-{date}
   -- e.g. claude-opus-4-20250514, claude-sonnet-4-5-20250929, claude-sonnet-4-20250514
@@ -265,10 +269,6 @@ function M:transform_tool(tool, use_prefix)
   local input_schema_properties, required = Utils.llm_tool_param_fields_to_json_schema(tool.param.fields)
   local tool_name = tool.name
   if use_prefix then tool_name = OAUTH_TOOL_PREFIX .. tool.name end
-  -- Ensure properties is always a JSON object (not array) even when empty
-  if not input_schema_properties or vim.tbl_isempty(input_schema_properties) then
-    input_schema_properties = vim.empty_dict()
-  end
   local tool_def = {
     name = tool_name,
     description = tool.get_description and tool.get_description() or tool.description,
@@ -277,9 +277,9 @@ function M:transform_tool(tool, use_prefix)
       properties = input_schema_properties,
       required = required,
     },
+    -- OAuth/claude-code beta requires discriminated tool type
+    type = use_prefix and "custom" or nil,
   }
-  -- OAuth/claude-code beta requires discriminated tool type
-  if use_prefix then tool_def.type = "custom" end
   return tool_def
 end
 
@@ -689,7 +689,7 @@ function M:parse_curl_args(prompt_opts)
   }, request_body)
 
   -- Strip temperature for models that don't support it (e.g. Opus 4 with always-on thinking)
-  if is_temperature_unsupported(provider_conf.model) then body.temperature = nil end
+  if M.is_temperature_unsupported(provider_conf.model) then body.temperature = nil end
 
   return {
     url = Utils.url_join(provider_conf.endpoint, api_path),
@@ -718,7 +718,9 @@ function M.on_error(result)
     error_msg = "You don't have any credits or have exceeded your quota. Please check your plan and billing details."
   elseif error_type == "invalid_request_error" and error_msg:match("temperature") then
     error_msg = error_msg
-      .. " Try removing 'temperature' from your provider's extra_request_body config."
+      .. "\nPossible fixes:"
+      .. "\n  - Remove 'temperature' from your provider's extra_request_body config"
+      .. "\n  - Ensure the temperature value is between 0 and 1"
   end
 
   Utils.error(error_msg, { once = true, title = "Avante" })

--- a/lua/avante/providers/claude.lua
+++ b/lua/avante/providers/claude.lua
@@ -235,6 +235,19 @@ function M:get_rate_limit_sleep_time(headers)
   return Utils.datetime_diff(tostring(now), tostring(reset_dt))
 end
 
+-- Models that do not support the temperature parameter.
+-- Claude 4+ generation models (new naming: claude-{tier}-{version}) deprecate temperature entirely.
+local function is_temperature_unsupported(model)
+  if not model then return false end
+  -- Claude 4+ models use new naming convention: claude-{tier}-{major}[-{minor}]-{date}
+  -- e.g. claude-opus-4-20250514, claude-sonnet-4-5-20250929, claude-sonnet-4-20250514
+  -- Also handles bedrock/vertex prefixed names like us.anthropic.claude-opus-4-*
+  if model:match("claude%-opus%-[4-9]") then return true end
+  if model:match("claude%-sonnet%-[4-9]") then return true end
+  if model:match("claude%-haiku%-[4-9]") then return true end
+  return false
+end
+
 -- Prefix for tool names when using OAuth to avoid Anthropic's tool name validation
 local OAUTH_TOOL_PREFIX = "av_"
 
@@ -252,7 +265,11 @@ function M:transform_tool(tool, use_prefix)
   local input_schema_properties, required = Utils.llm_tool_param_fields_to_json_schema(tool.param.fields)
   local tool_name = tool.name
   if use_prefix then tool_name = OAUTH_TOOL_PREFIX .. tool.name end
-  return {
+  -- Ensure properties is always a JSON object (not array) even when empty
+  if not input_schema_properties or vim.tbl_isempty(input_schema_properties) then
+    input_schema_properties = vim.empty_dict()
+  end
+  local tool_def = {
     name = tool_name,
     description = tool.get_description and tool.get_description() or tool.description,
     input_schema = {
@@ -261,6 +278,9 @@ function M:transform_tool(tool, use_prefix)
       required = required,
     },
   }
+  -- OAuth/claude-code beta requires discriminated tool type
+  if use_prefix then tool_def.type = "custom" end
+  return tool_def
 end
 
 function M:is_disable_stream() return false end
@@ -660,18 +680,23 @@ function M:parse_curl_args(prompt_opts)
   local api_path = "/v1/messages"
   if provider_conf.auth_type == "max" then api_path = "/v1/messages?beta=true" end
 
+  local body = vim.tbl_deep_extend("force", {
+    model = provider_conf.model,
+    system = system,
+    messages = messages,
+    tools = tools,
+    stream = true,
+  }, request_body)
+
+  -- Strip temperature for models that don't support it (e.g. Opus 4 with always-on thinking)
+  if is_temperature_unsupported(provider_conf.model) then body.temperature = nil end
+
   return {
     url = Utils.url_join(provider_conf.endpoint, api_path),
     proxy = provider_conf.proxy,
     insecure = provider_conf.allow_insecure,
     headers = Utils.tbl_override(headers, self.extra_headers),
-    body = vim.tbl_deep_extend("force", {
-      model = provider_conf.model,
-      system = system,
-      messages = messages,
-      tools = tools,
-      stream = true,
-    }, request_body),
+    body = body,
   }
 end
 
@@ -692,7 +717,8 @@ function M.on_error(result)
   if error_type == "insufficient_quota" then
     error_msg = "You don't have any credits or have exceeded your quota. Please check your plan and billing details."
   elseif error_type == "invalid_request_error" and error_msg:match("temperature") then
-    error_msg = "Invalid temperature value. Please ensure it's between 0 and 1."
+    error_msg = error_msg
+      .. " Try removing 'temperature' from your provider's extra_request_body config."
   end
 
   Utils.error(error_msg, { once = true, title = "Avante" })
@@ -930,6 +956,7 @@ function M.cleanup_claude()
   if M._file_watcher then
     ---@diagnostic disable-next-line: param-type-mismatch
     M._file_watcher:stop()
+    pcall(function() M._file_watcher:close() end)
     M._file_watcher = nil
   end
 end

--- a/lua/avante/providers/openai.lua
+++ b/lua/avante/providers/openai.lua
@@ -24,10 +24,6 @@ function M:is_disable_stream() return false end
 ---@return AvanteOpenAITool
 function M:transform_tool(tool)
   local input_schema_properties, required = Utils.llm_tool_param_fields_to_json_schema(tool.param.fields)
-  -- Ensure properties is always a JSON object (not array) even when empty
-  if not input_schema_properties or vim.tbl_isempty(input_schema_properties) then
-    input_schema_properties = vim.empty_dict()
-  end
   ---@type AvanteOpenAIToolFunctionParameters
   local parameters = {
     type = "object",

--- a/lua/avante/providers/openai.lua
+++ b/lua/avante/providers/openai.lua
@@ -24,6 +24,10 @@ function M:is_disable_stream() return false end
 ---@return AvanteOpenAITool
 function M:transform_tool(tool)
   local input_schema_properties, required = Utils.llm_tool_param_fields_to_json_schema(tool.param.fields)
+  -- Ensure properties is always a JSON object (not array) even when empty
+  if not input_schema_properties or vim.tbl_isempty(input_schema_properties) then
+    input_schema_properties = vim.empty_dict()
+  end
   ---@type AvanteOpenAIToolFunctionParameters
   local parameters = {
     type = "object",

--- a/lua/avante/providers/vertex_claude.lua
+++ b/lua/avante/providers/vertex_claude.lua
@@ -64,6 +64,12 @@ function M:parse_curl_args(prompt_opts)
     tools = tools,
   })
 
+  -- Strip temperature for models that don't support it (e.g. Claude 4+ with always-on thinking)
+  local model = provider_conf.model or ""
+  if model:match("claude%-opus%-[4-9]") or model:match("claude%-sonnet%-[4-9]") or model:match("claude%-haiku%-[4-9]") then
+    request_body.temperature = nil
+  end
+
   return {
     url = url,
     headers = Utils.tbl_override({

--- a/lua/avante/providers/vertex_claude.lua
+++ b/lua/avante/providers/vertex_claude.lua
@@ -65,10 +65,7 @@ function M:parse_curl_args(prompt_opts)
   })
 
   -- Strip temperature for models that don't support it (e.g. Claude 4+ with always-on thinking)
-  local model = provider_conf.model or ""
-  if model:match("claude%-opus%-[4-9]") or model:match("claude%-sonnet%-[4-9]") or model:match("claude%-haiku%-[4-9]") then
-    request_body.temperature = nil
-  end
+  if P.claude.is_temperature_unsupported(provider_conf.model) then request_body.temperature = nil end
 
   return {
     url = url,

--- a/lua/avante/rag_service.lua
+++ b/lua/avante/rag_service.lua
@@ -290,12 +290,11 @@ function M.to_local_uri(uri)
 end
 
 function M.is_ready()
-  return vim
-    .system(
-      { "curl", "-s", "-o", "/dev/null", "-w", "%{http_code}", M.get_rag_service_url() .. "/api/health" },
-      { text = true }
-    )
-    :wait().code == 0
+  local result = vim.system(
+    { "curl", "-s", "-o", "/dev/null", "-w", "%{http_code}", M.get_rag_service_url() .. "/api/health" },
+    { text = true }
+  ):wait()
+  return result.code == 0 and vim.trim(result.stdout or "") == "200"
 end
 
 ---@class AvanteRagServiceAddResourceResponse
@@ -468,9 +467,10 @@ function M.get_resources()
     headers = {
       ["Content-Type"] = "application/json",
     },
+    timeout = 10000, -- 10 seconds; the RAG service can be slow to respond on startup
   })
-  if resp.status ~= 200 then
-    Utils.error("Failed to get resources: " .. resp.body)
+  if not resp or resp.status ~= 200 then
+    Utils.error("Failed to get resources: " .. (resp and resp.body or "no response"))
     return
   end
   local jsn = vim.json.decode(resp.body)

--- a/lua/avante/sidebar.lua
+++ b/lua/avante/sidebar.lua
@@ -85,6 +85,7 @@ local Highlights = require("avante.highlights")
 local RepoMap = require("avante.repo_map")
 local FileSelector = require("avante.file_selector")
 local LLMTools = require("avante.llm_tools")
+local DispatchRegistry = require("avante.dispatch_registry")
 local History = require("avante.history")
 local Render = require("avante.history.render")
 local Line = require("avante.ui.line")
@@ -3342,7 +3343,9 @@ function Sidebar:handle_submit(request)
       -- Avante instance and return a different session's todos.
       get_todos = function() return self.chat_history and self.chat_history.todos or {} end,
       update_todos = function(todos) self:update_todos(todos) end,
-      session_ctx = {},
+      session_ctx = {
+        dispatch_session_id = tostring(self.code.bufnr or "default"),
+      },
       ---@param usage avante.LLMTokenUsage
       update_tokens_usage = function(usage)
         if not usage then return end
@@ -3373,6 +3376,43 @@ function Sidebar:handle_submit(request)
     end
 
     stream_options.on_memory_summarize = on_memory_summarize
+
+    -- Register dispatch completion callback so results are injected into chat history
+    local dispatch_session_id = tostring(self.code.bufnr or "default")
+    DispatchRegistry.set_on_complete(dispatch_session_id, function(dispatch)
+      -- Inject the dispatch result as a visible user message into the chat history
+      local content_text
+      if dispatch.status == "completed" then
+        content_text = string.format(
+          "[Dispatch #%s completed] (provider: %s, model: %s)\nTask: %s\n\nResult:\n%s",
+          dispatch.id,
+          dispatch.provider or "unknown",
+          dispatch.model or "unknown",
+          dispatch.prompt:sub(1, 200),
+          dispatch.result or "(no result)"
+        )
+      else
+        content_text = string.format(
+          "[Dispatch #%s failed] (provider: %s, model: %s)\nTask: %s\n\nError: %s",
+          dispatch.id,
+          dispatch.provider or "unknown",
+          dispatch.model or "unknown",
+          dispatch.prompt:sub(1, 200),
+          dispatch.error or "unknown error"
+        )
+      end
+      local message = History.Message:new("user", content_text, {
+        visible = true,
+        is_dispatch_result = true,
+      })
+      self:add_history_messages({ message })
+      self:save_history()
+      -- Re-render the chat to show the dispatch result.
+      -- Guard against missing/closed sidebar containers.
+      if Utils.is_valid_container(self.containers.result, true) then
+        pcall(function() self:update_content_with_history() end)
+      end
+    end)
 
     if request ~= "" then on_state_change("generating") end
     Llm.stream(stream_options)

--- a/lua/avante/sidebar.lua
+++ b/lua/avante/sidebar.lua
@@ -124,6 +124,8 @@ local SIDEBAR_CONTAINERS = {
 ---@field containers { result?: NuiSplit, todos?: NuiSplit, selected_code?: NuiSplit, selected_files?: NuiSplit, input?: NuiSplit }
 ---@field file_selector FileSelector
 ---@field chat_history avante.ChatHistory | nil
+---@field current_history_filename string | nil Tracks which history file this sidebar is using; prevents concurrent instances from hijacking each other's session via the shared metadata.json pointer.
+---@field _chat_history_mtime integer | nil Disk mtime (seconds) of the history file at the last load/save; used to detect concurrent writes from other Avante instances.
 ---@field current_state avante.GenerateState | nil
 ---@field state_timer table | nil
 ---@field state_spinner_chars string[]
@@ -170,6 +172,13 @@ function Sidebar:new(id)
     file_selector = FileSelector:new(id),
     is_generating = false,
     chat_history = nil,
+    -- Tracks which history file THIS sidebar instance is using so that two
+    -- Avante instances open on the same project do not steal each other's
+    -- session when one of them saves or creates a new chat.
+    current_history_filename = nil,
+    -- mtime (seconds) of the history file as it was when last loaded or saved
+    -- by THIS instance. Used to detect concurrent writes from other instances.
+    _chat_history_mtime = nil,
     current_state = nil,
     state_timer = nil,
     state_spinner_chars = Config.windows.spinner.generating,
@@ -229,6 +238,9 @@ function Sidebar:reset()
   self.current_tool_use_extmark_id = nil
   self.win_size_store = {}
   self.is_in_full_view = false
+  -- Clear the pinned history filename so that initialize() -> reload_chat_history()
+  -- reads from metadata.json for whatever project/buffer is opened next.
+  self.current_history_filename = nil
 end
 
 ---@class SidebarOpenOptions: AskOptions
@@ -1120,7 +1132,9 @@ end
 
 function Sidebar:render_result()
   if not Utils.is_valid_container(self.containers.result) then return end
+  local instance_name = self.chat_history and self.chat_history.instance_name
   local header_text = Utils.icon("󰭻 ") .. "Avante"
+  if instance_name then header_text = header_text .. " [" .. instance_name .. "]" end
   self:render_header(
     self.containers.result.winid,
     self.containers.result.bufnr,
@@ -2352,6 +2366,16 @@ end
 
 function Sidebar:new_chat(args, cb)
   local history = Path.history.new(self.code.bufnr)
+  local Avante = require("avante")
+  -- Eagerly update the instance registry so other sidebars can find the new
+  -- name immediately, before the save -> reload cycle completes.
+  if self.chat_history and self.chat_history.instance_name then
+    Avante.instance_registry[self.chat_history.instance_name] = nil
+  end
+  if history.instance_name then Avante.instance_registry[history.instance_name] = self end
+  -- Pin this sidebar to the new file BEFORE saving so reload_chat_history()
+  -- uses the correct file and doesn't read a stale metadata.json value.
+  self.current_history_filename = history.filename
   Path.history.save(self.code.bufnr, history)
   self:reload_chat_history()
   self.current_state = nil
@@ -2368,7 +2392,7 @@ function Sidebar:new_chat(args, cb)
 end
 
 local debounced_save_history = Utils.debounce(
-  function(self) Path.history.save(self.code.bufnr, self.chat_history) end,
+  function(self) self:_save_chat_history() end,
   1000
 )
 
@@ -2605,8 +2629,87 @@ end
 function Sidebar:reload_chat_history()
   self.token_count = nil
   if not self.code.bufnr or not api.nvim_buf_is_valid(self.code.bufnr) then return end
-  self.chat_history = Path.history.load(self.code.bufnr)
+
+  local Avante = require("avante")
+  -- Deregister the old instance name before loading the new history so that
+  -- stale entries don't accumulate across /new cycles.
+  if self.chat_history and self.chat_history.instance_name then
+    Avante.instance_registry[self.chat_history.instance_name] = nil
+  end
+
+  -- Load the specific file this sidebar is pinned to (if any), so that a
+  -- concurrent Avante instance saving to the shared metadata.json cannot
+  -- hijack this sidebar's history.
+  self.chat_history = Path.history.load(self.code.bufnr, self.current_history_filename)
+
+  -- Isolation guard: if the history we just loaded is already owned by a
+  -- *different* live sidebar, fork to a fresh independent history.  This
+  -- prevents two Avante windows that share the same source buffer from
+  -- inheriting the same chat timeline, and guarantees each window gets a
+  -- unique instance_name for cross-instance messaging.
+  if self.chat_history and self.chat_history.instance_name then
+    local existing_owner = Avante.instance_registry[self.chat_history.instance_name]
+    if existing_owner ~= nil and existing_owner ~= self then
+      -- The loaded history is already in use -- branch off to a fresh session.
+      local fresh = Path.history.new(self.code.bufnr)
+      self.chat_history = fresh
+      self.current_history_filename = fresh.filename
+      self._chat_history_mtime = nil -- no disk file yet; suppress false conflicts
+    end
+  end
+
+  if self.chat_history then self.current_history_filename = self.chat_history.filename end
+  -- Record the disk mtime so _save_chat_history() can detect concurrent writes.
+  if self._chat_history_mtime == nil and self.current_history_filename then
+    local fp = Path.history.get_filepath(self.code.bufnr, self.current_history_filename)
+    local stat = vim.uv.fs_stat(tostring(fp))
+    self._chat_history_mtime = stat and stat.mtime.sec or nil
+  end
+  -- Register this sidebar under its (now-unique) instance name.
+  if self.chat_history and self.chat_history.instance_name then
+    Avante.instance_registry[self.chat_history.instance_name] = self
+  end
   self._history_cache_invalidated = true
+  -- Update the result header to reflect the (possibly new) instance name.
+  vim.schedule(function() self:render_result() end)
+end
+
+--- Save self.chat_history to disk, forking to a new file first when a
+--- concurrent Avante instance has modified the file since we last loaded it.
+function Sidebar:_save_chat_history()
+  if not self.chat_history or not self.code.bufnr then return end
+
+  -- Conflict detection: if the file on disk has a newer mtime, someone else wrote to it.
+  if self.current_history_filename and self._chat_history_mtime then
+    local fp = Path.history.get_filepath(self.code.bufnr, self.current_history_filename)
+    local stat = vim.uv.fs_stat(tostring(fp))
+    local disk_mtime = stat and stat.mtime.sec or nil
+    if disk_mtime and disk_mtime ~= self._chat_history_mtime then
+      -- Another instance wrote to our file. Branch to a new file.
+      local new_stub = Path.history.new(self.code.bufnr)
+      new_stub.title = self.chat_history.title
+      new_stub.timestamp = self.chat_history.timestamp
+      new_stub.entries = self.chat_history.entries
+      new_stub.messages = self.chat_history.messages
+      new_stub.todos = self.chat_history.todos
+      if self.chat_history.memory then new_stub.memory = self.chat_history.memory end
+      if self.chat_history.system_prompt then new_stub.system_prompt = self.chat_history.system_prompt end
+      if self.chat_history.tokens_usage then new_stub.tokens_usage = self.chat_history.tokens_usage end
+      if self.chat_history.acp_session_id then new_stub.acp_session_id = self.chat_history.acp_session_id end
+      self.chat_history = new_stub
+      self.current_history_filename = new_stub.filename
+      self._chat_history_mtime = nil
+    end
+  end
+
+  Path.history.save(self.code.bufnr, self.chat_history)
+
+  -- Update the stored mtime for the next conflict check.
+  if self.current_history_filename then
+    local fp = Path.history.get_filepath(self.code.bufnr, self.current_history_filename)
+    local stat = vim.uv.fs_stat(tostring(fp))
+    self._chat_history_mtime = stat and stat.mtime.sec or nil
+  end
 end
 
 ---@param opts? {all?: boolean}
@@ -2982,10 +3085,9 @@ function Sidebar:handle_submit(request)
       end,
       set_tool_use_store = set_tool_use_store,
       get_history_messages = function(opts) return self:get_history_messages_for_api(opts) end,
-      get_todos = function()
-        local history = Path.history.load(self.code.bufnr)
-        return history.todos
-      end,
+      -- Use in-memory todos to avoid a disk read that could race with another
+      -- Avante instance and return a different session's todos.
+      get_todos = function() return self.chat_history and self.chat_history.todos or {} end,
       update_todos = function(todos) self:update_todos(todos) end,
       session_ctx = {},
       ---@param usage avante.LLMTokenUsage
@@ -3230,8 +3332,10 @@ function Sidebar:get_selected_code_container_height()
 end
 
 function Sidebar:get_todos_container_height()
-  local history = Path.history.load(self.code.bufnr)
-  if #history.todos == 0 then return 0 end
+  -- Use the in-memory chat_history to avoid a disk read that could return a
+  -- different instance's file via the shared metadata.json pointer.
+  local todos = self.chat_history and self.chat_history.todos or {}
+  if #todos == 0 then return 0 end
   return 3
 end
 
@@ -3338,6 +3442,10 @@ function Sidebar:render(opts)
           if not self.code.winid or not api.nvim_win_is_valid(self.code.winid) then return end
           local bufnr = api.nvim_win_get_buf(self.code.winid)
           self.code.bufnr = bufnr
+          -- The code buffer changed (different project/root), so let
+          -- reload_chat_history() pick up the correct file from metadata.json
+          -- for the new buffer rather than staying pinned to the old file.
+          self.current_history_filename = nil
           self:reload_chat_history()
         end)
       end,
@@ -3531,7 +3639,9 @@ function Sidebar:create_selected_files_container()
 end
 
 function Sidebar:create_todos_container()
-  local history = Path.history.load(self.code.bufnr)
+  -- Use in-memory history to avoid loading from disk (which would follow
+  -- the shared metadata.json and could pull in another instance's file).
+  local history = self.chat_history or Path.history.load(self.code.bufnr, self.current_history_filename)
   if #history.todos == 0 then
     if self.containers.todos and Utils.is_valid_container(self.containers.todos) then
       self.containers.todos:unmount()

--- a/lua/avante/sidebar.lua
+++ b/lua/avante/sidebar.lua
@@ -3026,6 +3026,42 @@ function Sidebar:handle_submit(request)
 
     stream_options.on_memory_summarize = on_memory_summarize
 
+    -- Register dispatch completion callback so results are injected into chat history
+    local dispatch_session_id = tostring(self.code.bufnr or "default")
+    DispatchRegistry.set_on_complete(dispatch_session_id, function(dispatch)
+      -- Inject the dispatch result as a visible user message into the chat history
+      local content_text
+      if dispatch.status == "completed" then
+        content_text = string.format(
+          "[Dispatch #%s completed] (provider: %s, model: %s)\nTask: %s\n\nResult:\n%s",
+          dispatch.id,
+          dispatch.provider or "unknown",
+          dispatch.model or "unknown",
+          dispatch.prompt:sub(1, 200),
+          dispatch.result or "(no result)"
+        )
+      else
+        content_text = string.format(
+          "[Dispatch #%s failed] (provider: %s, model: %s)\nTask: %s\n\nError: %s",
+          dispatch.id,
+          dispatch.provider or "unknown",
+          dispatch.model or "unknown",
+          dispatch.prompt:sub(1, 200),
+          dispatch.error or "unknown error"
+        )
+      end
+      local message = History.Message:new("user", content_text, {
+        visible = true,
+        is_dispatch_result = true,
+      })
+      self:add_history_messages({ message })
+      self:save_history()
+      -- Re-render the chat to show the dispatch result.
+      if Utils.is_valid_container(self.containers.result, true) then
+        pcall(function() self:update_content_with_history() end)
+      end
+    end)
+
     if request ~= "" then on_state_change("generating") end
     Llm.stream(stream_options)
   end)

--- a/lua/avante/sidebar.lua
+++ b/lua/avante/sidebar.lua
@@ -1808,6 +1808,7 @@ end
 --- Initialize the sidebar instance.
 --- @return avante.Sidebar The Sidebar instance.
 function Sidebar:initialize()
+  Utils.debug("Sidebar:initialize bufnr=" .. tostring(api.nvim_get_current_buf()))
   self.code.winid = api.nvim_get_current_win()
   self.code.bufnr = api.nvim_get_current_buf()
   self.code.selection = Utils.get_visual_selection_and_range()
@@ -3003,13 +3004,18 @@ When action="send":
 end
 
 function Sidebar:reload_chat_history()
+  Utils.debug("Sidebar:reload_chat_history called, pinned_file=" .. tostring(self.current_history_filename))
   self.token_count = nil
-  if not self.code.bufnr or not api.nvim_buf_is_valid(self.code.bufnr) then return end
+  if not self.code.bufnr or not api.nvim_buf_is_valid(self.code.bufnr) then
+    Utils.debug("Sidebar:reload_chat_history aborted: invalid bufnr")
+    return
+  end
 
   local Avante = require("avante")
   -- Deregister the old instance name before loading the new history so that
   -- stale entries don't accumulate across /new cycles.
   if self.chat_history and self.chat_history.instance_name then
+    Utils.debug("Sidebar:reload_chat_history deregistering", self.chat_history.instance_name)
     Avante.instance_registry[self.chat_history.instance_name] = nil
   end
 
@@ -3017,6 +3023,7 @@ function Sidebar:reload_chat_history()
   -- concurrent Avante instance saving to the shared metadata.json cannot
   -- hijack this sidebar's history.
   self.chat_history = Path.history.load(self.code.bufnr, self.current_history_filename)
+  Utils.debug("Sidebar:reload_chat_history loaded", tostring(self.chat_history and self.chat_history.filename), tostring(self.chat_history and self.chat_history.instance_name))
 
   -- Isolation guard: if the history we just loaded is already owned by a
   -- *different* live sidebar, fork to a fresh independent history.  This
@@ -3029,6 +3036,7 @@ function Sidebar:reload_chat_history()
       -- The loaded history is already in use — branch off to a fresh session.
       -- The fresh history is intentionally not saved here; it will be written
       -- to disk the first time the user sends a message (via save_history()).
+      Utils.debug("Sidebar:reload_chat_history isolation guard triggered for", self.chat_history.instance_name, "— forking fresh history")
       local fresh = Path.history.new(self.code.bufnr)
       self.chat_history = fresh
       self.current_history_filename = fresh.filename
@@ -3049,6 +3057,7 @@ function Sidebar:reload_chat_history()
   -- Register this sidebar under its (now-unique) instance name.
   if self.chat_history and self.chat_history.instance_name then
     Avante.instance_registry[self.chat_history.instance_name] = self
+    Utils.debug("Sidebar:reload_chat_history registered", self.chat_history.instance_name)
   end
   self._history_cache_invalidated = true
   -- Update the result header to reflect the (possibly new) instance name.
@@ -3058,6 +3067,55 @@ function Sidebar:reload_chat_history()
   if Config.ipc_service and Config.ipc_service.enabled then
     vim.schedule(function() self:ipc_register() end)
   end
+end
+
+--- Explicitly switch this sidebar to a selected history file.
+--- Unlike reload_chat_history(), this does NOT apply the isolation guard — the
+--- user intentionally chose this history, so we allow it even if another sidebar
+--- in the same session also holds that instance_name.  The "other" sidebar will
+--- naturally receive a fresh identity on its next reload.
+---@param filename string  Relative filename as returned by Path.history.list()
+function Sidebar:switch_to_history(filename)
+  Utils.debug("Sidebar:switch_to_history", filename)
+  local Avante = require("avante")
+
+  -- Release the current instance from the registry.
+  if self.chat_history and self.chat_history.instance_name then
+    Avante.instance_registry[self.chat_history.instance_name] = nil
+  end
+
+  -- Load the requested history directly — no isolation guard.
+  local history = Path.history.load(self.code.bufnr, filename)
+  if not history then
+    Utils.debug("Sidebar:switch_to_history load returned nil, aborting")
+    return
+  end
+
+  -- If another sidebar currently owns this instance_name, evict it so it will
+  -- pick up a fresh identity on its next reload cycle.
+  if history.instance_name then
+    local prev_owner = Avante.instance_registry[history.instance_name]
+    if prev_owner and prev_owner ~= self then
+      Utils.debug("Sidebar:switch_to_history evicting previous owner of", history.instance_name)
+      prev_owner.current_history_filename = nil
+      prev_owner._history_cache_invalidated = true
+    end
+  end
+
+  self.chat_history = history
+  self.current_history_filename = filename
+  self._chat_history_mtime = nil -- mtime will be refreshed on next explicit save
+  self.token_count = nil
+  self._history_cache_invalidated = true
+
+  -- Register under the new identity.
+  if history.instance_name then Avante.instance_registry[history.instance_name] = self end
+
+  vim.schedule(function() self:render_result() end)
+  if Config.ipc_service and Config.ipc_service.enabled then
+    vim.schedule(function() self:ipc_register() end)
+  end
+  Utils.debug("Sidebar:switch_to_history done", filename, history.instance_name)
 end
 
 --- Register this sidebar with the cross-process IPC service.

--- a/lua/avante/sidebar.lua
+++ b/lua/avante/sidebar.lua
@@ -259,8 +259,16 @@ function Sidebar:open(opts)
     self:focus()
   else
     if in_visual_mode or opts.selection then
+      -- Preserve the history pin across the close/reset cycle so that this
+      -- sidebar does not lose its identity and fall back to reading
+      -- metadata.json (a shared last-writer-wins pointer that races between
+      -- all concurrent instances).  reset() was designed to clear the pin
+      -- only when the sidebar is truly starting from scratch (first open);
+      -- for visual-mode re-renders we are staying in the same session.
+      local saved_filename = self.current_history_filename
       self:close()
       self:reset()
+      self.current_history_filename = saved_filename
       self:initialize()
       if opts.selection then self.code.selection = opts.selection end
       self:render(opts)
@@ -3448,12 +3456,20 @@ function Sidebar:render(opts)
       on_detach = function(_, _)
         vim.schedule(function()
           if not self.code.winid or not api.nvim_win_is_valid(self.code.winid) then return end
-          local bufnr = api.nvim_win_get_buf(self.code.winid)
-          self.code.bufnr = bufnr
-          -- The code buffer changed (different project/root), so let
-          -- reload_chat_history() pick up the correct file from metadata.json
-          -- for the new buffer rather than staying pinned to the old file.
-          self.current_history_filename = nil
+          local old_root = Utils.root.get({ buf = self.code.bufnr })
+          local new_bufnr = api.nvim_win_get_buf(self.code.winid)
+          local new_root = Utils.root.get({ buf = new_bufnr })
+          self.code.bufnr = new_bufnr
+          -- Only drop the history pin when the buffer genuinely moved to a
+          -- different project root.  Within the same project the pin MUST be
+          -- kept so that reload_chat_history() continues to load *this*
+          -- instance's own file instead of reading metadata.json — which is a
+          -- shared, last-writer-wins pointer that races between all concurrent
+          -- instances saving their histories.  Without this guard, any buffer
+          -- detach (e.g. :bdelete of a file in the same project) would clear
+          -- the pin and cause the sidebar to converge onto whichever instance
+          -- wrote metadata.json most recently.
+          if old_root ~= new_root then self.current_history_filename = nil end
           self:reload_chat_history()
         end)
       end,

--- a/lua/avante/sidebar.lua
+++ b/lua/avante/sidebar.lua
@@ -2802,6 +2802,86 @@ function Sidebar:reload_chat_history()
   self._history_cache_invalidated = true
   -- Update the result header to reflect the (possibly new) instance name.
   vim.schedule(function() self:render_result() end)
+  -- Register with the IPC service if it is enabled (non-blocking).
+  local Config = require("avante.config")
+  if Config.ipc_service and Config.ipc_service.enabled then
+    vim.schedule(function() self:ipc_register() end)
+  end
+end
+
+--- Register this sidebar with the cross-process IPC service.
+--- Safe to call multiple times; the service treats it as idempotent.
+function Sidebar:ipc_register()
+  if not (self.chat_history and self.chat_history.instance_name and self.chat_history.instance_id) then
+    return
+  end
+  local IpcService = require("avante.ipc_service")
+  local name = self.chat_history.instance_name
+  local id = self.chat_history.instance_id
+  local project = Utils.get_project_root() or ""
+  IpcService.register(name, id, self._ipc_description or "", project)
+  -- Start timers (idempotent — stops any previous set first).
+  IpcService.start_timers(function(from_name, message)
+    self:_on_ipc_message(from_name, message)
+  end)
+end
+
+--- Unregister this sidebar from the IPC service and stop timers.
+function Sidebar:ipc_unregister()
+  if not (self.chat_history and self.chat_history.instance_id) then return end
+  local IpcService = require("avante.ipc_service")
+  IpcService.unregister()
+end
+
+--- Update the responsibility description that other instances see in the IPC listing.
+---@param description string
+function Sidebar:ipc_update_description(description)
+  self._ipc_description = description
+  local Config = require("avante.config")
+  if not (Config.ipc_service and Config.ipc_service.enabled) then return end
+  local IpcService = require("avante.ipc_service")
+  IpcService.update_description(description)
+end
+
+--- Handle an incoming message delivered via the IPC service.
+--- Adds it to chat history as a user-role message (so the API always receives
+--- valid turn order) and triggers the LLM to generate a response.
+--- The "← From [name]" attribution is driven by the from_instance field so
+--- it appears in the UI without being part of the raw message content.
+---@param from_name string
+---@param message string
+function Sidebar:_on_ipc_message(from_name, message)
+  local History = require("avante.history")
+
+  -- Store the raw message as a user message with from_instance metadata.
+  -- The renderer uses from_instance to show the special "← From [name]" header;
+  -- the content itself stays clean so the API sees normal user-role text.
+  local msg = History.Message:new("user", message, {
+    is_user_submission = true, -- enables <task> wrapper in agentic mode
+    from_instance = from_name,
+  })
+  self:add_history_messages({ msg })
+
+  -- Persist immediately (bypass the 1-second debounce) so that the message
+  -- is on disk before any subsequent reload_chat_history() call reads the file.
+  -- Without this the debounced write loses the IPC message when the reload
+  -- overwrites self.chat_history with the stale on-disk state.
+  self:_save_chat_history()
+
+  -- Re-render the chat panel using the current in-memory history.
+  -- Do NOT call update_content_with_history() here — that calls
+  -- reload_chat_history() which would overwrite our just-added message with
+  -- the old on-disk state (even though we saved above, there is a race).
+  self._history_cache_invalidated = true
+  vim.schedule(function()
+    if Utils.is_valid_container(self.containers.result, true) then
+      pcall(function() self:update_content("") end)
+    end
+
+    -- Trigger the LLM to generate a response to the incoming message.
+    -- Guard against the sidebar already being mid-generation.
+    if not self.is_generating then self:handle_submit("") end
+  end)
 end
 
 --- Save self.chat_history to disk, forking to a new file first when a
@@ -2970,46 +3050,169 @@ function Sidebar:get_generate_prompts_options(request, cb)
     returns = {},
   })
 
-  -- Build the sender name now so the closure captures the current value.
+  -- Build sender identity now so closures capture the current values.
   local sender_name = self.chat_history and self.chat_history.instance_name or "unknown"
+  local sender_id = self.chat_history and self.chat_history.instance_id or nil
+
+  -- Determine IPC mode: cross-process IPC service, or fallback in-process registry.
+  local Config = require("avante.config")
+  local ipc_enabled = Config.ipc_service and Config.ipc_service.enabled
+
+  -- Build sub-agent dispatch IDs owned by this sidebar so we can label them
+  -- correctly in the listing (they are employees/dispatched workers, not peers).
+  local session_id = tostring(self.code.bufnr or "default")
+  local DispatchRegistry = require("avante.dispatch_registry")
 
   table.insert(tools, {
     name = "send_message",
     description = string.format(
-      [[Send a message to another active Avante instance.
+      [[Send a message to another root-level Avante co-agent instance.
 
-⚠️  IMPORTANT: Only use this tool when:
-1. The user EXPLICITLY asks you to send a message to another instance, OR
-2. You have received a message FROM another instance (shown with a "← From [name]" header) and the user wants you to reply.
+This tool connects peer Avante instances (co-workers with equal standing).
+It does NOT target dispatch_agent sub-agents — those are background workers
+you already control directly via dispatch_agent / dispatch_await.
 
-Do NOT proactively contact other instances on your own initiative.
+⚠️  Use this tool ONLY when:
+1. The user EXPLICITLY asks you to contact another instance, OR
+2. You received a message from another co-agent (shown with "← From [name]") and need to reply.
+
+Do NOT contact peers proactively on your own initiative.
 
 YOUR instance name: [%s]
 
-To see available target instances call this tool with action="list". Then call it again with action="send" to deliver the message.
+⚠️  IDENTITY RULES — read carefully:
+- You are a co-agent instance named [%s], NOT a human user.
+- When you send a message, the receiver has NO idea who you are unless you tell them.
+- ALWAYS open your message with an identity line so the receiver knows they are
+  talking to another AI instance, not a human.  Use this exact format:
+    "← From [%s] (Avante co-agent, not a user): <your message here>"
+- If you omit this header, the receiving instance will assume they are talking to
+  a human user and will behave incorrectly.
+
+Relationship guide:
+  • Co-agents (peers / co-workers): other root Avante instances — use THIS tool.
+  • Sub-agents (employees): dispatched via dispatch_agent — they report back to you,
+    you do not message them; monitor them with dispatch_status / dispatch_await instead.
+
+Steps:
+  1. Call with action="list" to see live co-agents and what they are working on.
+  2. Call with action="send" to deliver your message.
 
 When action="send":
-- "target_instance": the exact name of the destination instance (e.g. "swift-fox")
-- "message": the fully-composed text to deliver — be concise and contextual]],
+  - "target_instance": exact name of the peer (e.g. "swift-fox")
+  - "message": the text to deliver — be concise and contextual, and ALWAYS begin
+    with the identity header described above]],
+      sender_name,
+      sender_name,
       sender_name
     ),
     ---@type AvanteLLMToolFunc<{ action: "list"|"send", target_instance?: string, message?: string }>
     func = function(input, opts)
       local Avante = require("avante")
+
+      -- ----------------------------------------------------------------
+      -- LIST
+      -- ----------------------------------------------------------------
       if input.action == "list" then
-        local names = vim.tbl_keys(Avante.instance_registry)
-        -- Exclude self from the list so the model doesn't try to message itself.
-        names = vim.iter(names):filter(function(n) return n ~= sender_name end):totable()
-        if #names == 0 then return "No other active Avante instances found.", nil end
-        return "Active instances: " .. table.concat(names, ", "), nil
+        if ipc_enabled then
+          -- Cross-process listing via IPC service.
+          local IpcService = require("avante.ipc_service")
+          local peers = IpcService.list_instances() -- synchronous
+          -- Also include in-process siblings (same nvim, different tabs/buffers).
+          local in_proc = vim.tbl_keys(Avante.instance_registry)
+          local in_proc_names = vim.iter(in_proc):filter(function(n) return n ~= sender_name end):totable()
+
+          -- Merge: IPC peers already exclude self (by instance_id); de-dup with in-proc list.
+          local seen = {}
+          local lines = {}
+          for _, peer in ipairs(peers) do
+            if not seen[peer.name] then
+              seen[peer.name] = true
+              local desc = (peer.description and peer.description ~= "") and peer.description or "(no description)"
+              local project = (peer.project and peer.project ~= "") and (" | project: " .. peer.project) or ""
+              table.insert(lines, string.format("  • %s — %s%s", peer.name, desc, project))
+            end
+          end
+          for _, n in ipairs(in_proc_names) do
+            if not seen[n] then
+              seen[n] = true
+              table.insert(lines, string.format("  • %s — (same nvim process, no description available)", n))
+            end
+          end
+
+          if #lines == 0 then return "No other active co-agent instances found.", nil end
+          return "Active co-agent instances:\n" .. table.concat(lines, "\n"), nil
+        else
+          -- In-process only listing.
+          local Avante2 = require("avante")
+          local names = vim.iter(vim.tbl_keys(Avante2.instance_registry))
+            :filter(function(n) return n ~= sender_name end)
+            :totable()
+          if #names == 0 then
+            return "No other active co-agent instances found in this Neovim session.\n"
+              .. "Tip: enable ipc_service to discover instances in other Neovim processes.",
+              nil
+          end
+          return "Active co-agent instances (this nvim session only):\n  • "
+            .. table.concat(names, "\n  • "),
+            nil
+        end
       end
 
+      -- ----------------------------------------------------------------
+      -- SEND
+      -- ----------------------------------------------------------------
       if input.action == "send" then
         local target_name = input.target_instance
         local message_text = input.message
         if not target_name or target_name == "" then return nil, "target_instance is required" end
         if not message_text or message_text == "" then return nil, "message is required" end
 
+        local on_log = opts and opts.on_log
+        if on_log then on_log(string.format("→ [%s]: %s", target_name, message_text:sub(1, 80))) end
+
+        -- Try IPC delivery first (cross-process) when enabled.
+        if ipc_enabled then
+          local IpcService = require("avante.ipc_service")
+          local ok, err = IpcService.send_message(target_name, message_text)
+          if ok then
+            -- Also attempt in-process delivery in case the target is in the same nvim.
+            local in_proc_target = Avante.instance_registry[target_name]
+            if in_proc_target and in_proc_target ~= self then
+              local injected = History.Message:new("user", message_text, {
+                from_instance = sender_name,
+                is_user_submission = false,
+                visible = true,
+              })
+              injected.is_coagent_message = true
+              in_proc_target:add_history_messages({ injected })
+              in_proc_target:save_history()
+              if Utils.is_valid_container(in_proc_target.containers.result, true) then
+                pcall(function() in_proc_target:update_content_with_history() end)
+              end
+            end
+            return string.format("Message queued for co-agent [%s].", target_name), nil
+          end
+          -- If IPC failed, try in-process as last resort.
+          local in_proc_target = Avante.instance_registry[target_name]
+          if in_proc_target and in_proc_target ~= self then
+            local injected = History.Message:new("user", message_text, {
+              from_instance = sender_name,
+              is_user_submission = false,
+              visible = true,
+            })
+            injected.is_coagent_message = true
+            in_proc_target:add_history_messages({ injected })
+            in_proc_target:save_history()
+            if Utils.is_valid_container(in_proc_target.containers.result, true) then
+              pcall(function() in_proc_target:update_content_with_history() end)
+            end
+            return string.format("Message delivered (in-process) to co-agent [%s].", target_name), nil
+          end
+          return nil, string.format("Co-agent '%s' not found: %s", target_name, err or "unknown error")
+        end
+
+        -- In-process only delivery.
         local target_sidebar = Avante.instance_registry[target_name]
         if not target_sidebar then
           local available = table.concat(
@@ -3020,29 +3223,25 @@ When action="send":
           )
           return nil,
             string.format(
-              "Instance '%s' not found. Available: %s",
+              "Co-agent '%s' not found in this nvim session. Available: %s\nTip: enable ipc_service to reach instances in other Neovim processes.",
               target_name,
               available ~= "" and available or "(none)"
             )
         end
-
         if target_sidebar == self then return nil, "Cannot send a message to yourself" end
-
-        local on_log = opts.on_log
-        if on_log then on_log(string.format("sending to [%s]: %s", target_name, message_text:sub(1, 80))) end
 
         local injected = History.Message:new("user", message_text, {
           from_instance = sender_name,
           is_user_submission = false,
           visible = true,
         })
+        injected.is_coagent_message = true
         target_sidebar:add_history_messages({ injected })
         target_sidebar:save_history()
         if Utils.is_valid_container(target_sidebar.containers.result, true) then
           pcall(function() target_sidebar:update_content_with_history() end)
         end
-
-        return string.format("Message delivered to [%s].", target_name), nil
+        return string.format("Message delivered to co-agent [%s].", target_name), nil
       end
 
       return nil, "Unknown action '" .. tostring(input.action) .. "'. Use 'list' or 'send'."
@@ -3052,12 +3251,12 @@ When action="send":
       fields = {
         {
           name = "action",
-          description = "'list' to see available instances, 'send' to deliver a message",
+          description = "'list' to see available co-agent instances with their current responsibilities, 'send' to deliver a message",
           type = "string",
         },
         {
           name = "target_instance",
-          description = "The name of the destination instance (required when action='send')",
+          description = "The name of the destination co-agent instance (required when action='send')",
           type = "string",
           optional = true,
         },
@@ -3075,12 +3274,12 @@ When action="send":
     returns = {
       {
         name = "result",
-        description = "Confirmation or list of available instances",
+        description = "Confirmation message or formatted list of co-agent instances with their responsibilities",
         type = "string",
       },
       {
         name = "error",
-        description = "Error message if the send failed",
+        description = "Error message if the operation failed",
         type = "string",
         optional = true,
       },

--- a/lua/avante/sidebar.lua
+++ b/lua/avante/sidebar.lua
@@ -2282,26 +2282,33 @@ function Sidebar:get_content_between_separators(position)
   return content, start_line
 end
 
+--- /clear command.
+--- Marks the current instance directory as "deleted" via a sentinel file
+--- (so it stops appearing in the :AvanteHistory picker), but DOES NOT remove
+--- any JSON files from disk and DOES NOT release the instance_name from the
+--- Names registry — both are kept around so the user can recover the chat
+--- by manually removing the sentinel.
+--- Then immediately starts a brand-new chat in the same sidebar (new
+--- instance_name + new instance dir), the same way /new behaves.
 function Sidebar:clear_history(args, cb)
   self.current_state = nil
-  if next(self.chat_history) ~= nil then
-    self.chat_history.messages = {}
-    self.chat_history.entries = {}
-    Path.history.save(self.code.bufnr, self.chat_history)
-    self._history_cache_invalidated = true
-    self:reload_chat_history()
-    self:update_content_with_history()
-    self:update_content(
-      "Chat history cleared",
-      { focus = false, scroll = false, callback = function() self:focus_input() end }
-    )
-    if cb then cb(args) end
-  else
-    self:update_content(
-      "Chat history is already empty",
-      { focus = false, scroll = false, callback = function() self:focus_input() end }
-    )
+  if self.chat_history and self.chat_history.instance_name and self.chat_history.instance_name ~= "" then
+    local prev_instance_name = self.chat_history.instance_name
+    -- Best-effort persist of the current state so the sentinel marks a known
+    -- on-disk snapshot rather than a stale one.
+    pcall(function() Path.history.save(self.code.bufnr, self.chat_history) end)
+    Path.history.mark_instance_deleted(self.code.bufnr, prev_instance_name)
+    Utils.debug("Sidebar:clear_history marked deleted", prev_instance_name)
+    -- NOTE: we deliberately do NOT release the instance_name from
+    -- avante.utils.names so the user can restore later.
   end
+
+  -- Start a brand-new chat in this same sidebar so it stays usable.
+  self:new_chat(args, cb)
+  self:update_content(
+    "Previous chat marked as deleted; started a new chat.",
+    { focus = false, scroll = false, callback = function() self:focus_input() end }
+  )
 end
 
 function Sidebar:clear_state()

--- a/lua/avante/sidebar.lua
+++ b/lua/avante/sidebar.lua
@@ -2579,6 +2579,242 @@ function Sidebar:show_selected_files_hint()
   local line_number = cursor_pos[1]
   local col_number = cursor_pos[2]
 
+  -- Build sender identity now so closures capture the current values.
+  local sender_name = self.chat_history and self.chat_history.instance_name or "unknown"
+  local sender_id = self.chat_history and self.chat_history.instance_id or nil
+
+  -- Determine IPC mode: cross-process IPC service, or fallback in-process registry.
+  local Config = require("avante.config")
+  local ipc_enabled = Config.ipc_service and Config.ipc_service.enabled
+
+  -- Build sub-agent dispatch IDs owned by this sidebar so we can label them
+  -- correctly in the listing (they are employees/dispatched workers, not peers).
+  local session_id = tostring(self.code.bufnr or "default")
+  local DispatchRegistry = require("avante.dispatch_registry")
+
+  table.insert(tools, {
+    name = "send_message",
+    description = string.format(
+      [[Send a message to another root-level Avante co-agent instance.
+
+This tool connects peer Avante instances (co-workers with equal standing).
+It does NOT target dispatch_agent sub-agents — those are background workers
+you already control directly via dispatch_agent / dispatch_await.
+
+⚠️  Use this tool ONLY when:
+1. The user EXPLICITLY asks you to contact another instance, OR
+2. You received a message from another co-agent (shown with "← From [name]") and need to reply.
+
+Do NOT contact peers proactively on your own initiative.
+
+YOUR instance name: [%s]
+
+⚠️  IDENTITY RULES — read carefully:
+- You are a co-agent instance named [%s], NOT a human user.
+- When you send a message, the receiver has NO idea who you are unless you tell them.
+- ALWAYS open your message with an identity line so the receiver knows they are
+  talking to another AI instance, not a human.  Use this exact format:
+    "← From [%s] (Avante co-agent, not a user): <your message here>"
+- If you omit this header, the receiving instance will assume they are talking to
+  a human user and will behave incorrectly.
+
+Relationship guide:
+  • Co-agents (peers / co-workers): other root Avante instances — use THIS tool.
+  • Sub-agents (employees): dispatched via dispatch_agent — they report back to you,
+    you do not message them; monitor them with dispatch_status / dispatch_await instead.
+
+Steps:
+  1. Call with action="list" to see live co-agents and what they are working on.
+  2. Call with action="send" to deliver your message.
+
+When action="send":
+  - "target_instance": exact name of the peer (e.g. "swift-fox")
+  - "message": the text to deliver — be concise and contextual, and ALWAYS begin
+    with the identity header described above]],
+      sender_name,
+      sender_name,
+      sender_name
+    ),
+    ---@type AvanteLLMToolFunc<{ action: "list"|"send", target_instance?: string, message?: string }>
+    func = function(input, opts)
+      local Avante = require("avante")
+
+      -- ----------------------------------------------------------------
+      -- LIST
+      -- ----------------------------------------------------------------
+      if input.action == "list" then
+        if ipc_enabled then
+          -- Cross-process listing via IPC service.
+          local IpcService = require("avante.ipc_service")
+          local peers = IpcService.list_instances() -- synchronous
+          -- Also include in-process siblings (same nvim, different tabs/buffers).
+          local in_proc = vim.tbl_keys(Avante.instance_registry)
+          local in_proc_names = vim.iter(in_proc):filter(function(n) return n ~= sender_name end):totable()
+
+          -- Merge: IPC peers already exclude self (by instance_id); de-dup with in-proc list.
+          local seen = {}
+          local lines = {}
+          for _, peer in ipairs(peers) do
+            if not seen[peer.name] then
+              seen[peer.name] = true
+              local desc = (peer.description and peer.description ~= "") and peer.description or "(no description)"
+              local project = (peer.project and peer.project ~= "") and (" | project: " .. peer.project) or ""
+              table.insert(lines, string.format("  • %s — %s%s", peer.name, desc, project))
+            end
+          end
+          for _, n in ipairs(in_proc_names) do
+            if not seen[n] then
+              seen[n] = true
+              table.insert(lines, string.format("  • %s — (same nvim process, no description available)", n))
+            end
+          end
+
+          if #lines == 0 then return "No other active co-agent instances found.", nil end
+          return "Active co-agent instances:\n" .. table.concat(lines, "\n"), nil
+        else
+          -- In-process only listing.
+          local Avante2 = require("avante")
+          local names = vim.iter(vim.tbl_keys(Avante2.instance_registry))
+            :filter(function(n) return n ~= sender_name end)
+            :totable()
+          if #names == 0 then
+            return "No other active co-agent instances found in this Neovim session.\n"
+              .. "Tip: enable ipc_service to discover instances in other Neovim processes.",
+              nil
+          end
+          return "Active co-agent instances (this nvim session only):\n  • "
+            .. table.concat(names, "\n  • "),
+            nil
+        end
+      end
+
+      -- ----------------------------------------------------------------
+      -- SEND
+      -- ----------------------------------------------------------------
+      if input.action == "send" then
+        local target_name = input.target_instance
+        local message_text = input.message
+        if not target_name or target_name == "" then return nil, "target_instance is required" end
+        if not message_text or message_text == "" then return nil, "message is required" end
+
+        local on_log = opts and opts.on_log
+        if on_log then on_log(string.format("→ [%s]: %s", target_name, message_text:sub(1, 80))) end
+
+        -- Try IPC delivery first (cross-process) when enabled.
+        if ipc_enabled then
+          local IpcService = require("avante.ipc_service")
+          local ok, err = IpcService.send_message(target_name, message_text)
+          if ok then
+            -- Also attempt in-process delivery in case the target is in the same nvim.
+            local in_proc_target = Avante.instance_registry[target_name]
+            if in_proc_target and in_proc_target ~= self then
+              local injected = History.Message:new("user", message_text, {
+                from_instance = sender_name,
+                is_user_submission = false,
+                visible = true,
+              })
+              injected.is_coagent_message = true
+              in_proc_target:add_history_messages({ injected })
+              in_proc_target:save_history()
+              if Utils.is_valid_container(in_proc_target.containers.result, true) then
+                pcall(function() in_proc_target:update_content_with_history() end)
+              end
+            end
+            return string.format("Message queued for co-agent [%s].", target_name), nil
+          end
+          -- If IPC failed, try in-process as last resort.
+          local in_proc_target = Avante.instance_registry[target_name]
+          if in_proc_target and in_proc_target ~= self then
+            local injected = History.Message:new("user", message_text, {
+              from_instance = sender_name,
+              is_user_submission = false,
+              visible = true,
+            })
+            injected.is_coagent_message = true
+            in_proc_target:add_history_messages({ injected })
+            in_proc_target:save_history()
+            if Utils.is_valid_container(in_proc_target.containers.result, true) then
+              pcall(function() in_proc_target:update_content_with_history() end)
+            end
+            return string.format("Message delivered (in-process) to co-agent [%s].", target_name), nil
+          end
+          return nil, string.format("Co-agent '%s' not found: %s", target_name, err or "unknown error")
+        end
+
+        -- In-process only delivery.
+        local target_sidebar = Avante.instance_registry[target_name]
+        if not target_sidebar then
+          local available = table.concat(
+            vim.iter(vim.tbl_keys(Avante.instance_registry))
+              :filter(function(n) return n ~= sender_name end)
+              :totable(),
+            ", "
+          )
+          return nil,
+            string.format(
+              "Co-agent '%s' not found in this nvim session. Available: %s\nTip: enable ipc_service to reach instances in other Neovim processes.",
+              target_name,
+              available ~= "" and available or "(none)"
+            )
+        end
+        if target_sidebar == self then return nil, "Cannot send a message to yourself" end
+
+        local injected = History.Message:new("user", message_text, {
+          from_instance = sender_name,
+          is_user_submission = false,
+          visible = true,
+        })
+        injected.is_coagent_message = true
+        target_sidebar:add_history_messages({ injected })
+        target_sidebar:save_history()
+        if Utils.is_valid_container(target_sidebar.containers.result, true) then
+          pcall(function() target_sidebar:update_content_with_history() end)
+        end
+        return string.format("Message delivered to co-agent [%s].", target_name), nil
+      end
+
+      return nil, "Unknown action '" .. tostring(input.action) .. "'. Use 'list' or 'send'."
+    end,
+    param = {
+      type = "table",
+      fields = {
+        {
+          name = "action",
+          description = "'list' to see available co-agent instances with their current responsibilities, 'send' to deliver a message",
+          type = "string",
+        },
+        {
+          name = "target_instance",
+          description = "The name of the destination co-agent instance (required when action='send')",
+          type = "string",
+          optional = true,
+        },
+        {
+          name = "message",
+          description = "The message text to deliver (required when action='send')",
+          type = "string",
+          optional = true,
+        },
+      },
+      usage = {
+        action = "list",
+      },
+    },
+    returns = {
+      {
+        name = "result",
+        description = "Confirmation message or formatted list of co-agent instances with their responsibilities",
+        type = "string",
+      },
+      {
+        name = "error",
+        description = "Error message if the operation failed",
+        type = "string",
+        optional = true,
+      },
+    },
+  })
+
   local selected_filepaths_ = self.file_selector:get_selected_filepaths()
   local hint
   if #selected_filepaths_ == 0 then

--- a/lua/avante/sidebar.lua
+++ b/lua/avante/sidebar.lua
@@ -124,6 +124,8 @@ local SIDEBAR_CONTAINERS = {
 ---@field containers { result?: NuiSplit, todos?: NuiSplit, selected_code?: NuiSplit, selected_files?: NuiSplit, input?: NuiSplit }
 ---@field file_selector FileSelector
 ---@field chat_history avante.ChatHistory | nil
+---@field current_history_filename string | nil Tracks which history file this sidebar is using; prevents concurrent instances from hijacking each other's session via the shared metadata.json pointer.
+---@field _chat_history_mtime integer | nil Disk mtime (seconds) of the history file at the last load/save; used to detect concurrent writes from other Avante instances.
 ---@field current_state avante.GenerateState | nil
 ---@field state_timer table | nil
 ---@field state_spinner_chars string[]
@@ -170,6 +172,13 @@ function Sidebar:new(id)
     file_selector = FileSelector:new(id),
     is_generating = false,
     chat_history = nil,
+    -- Tracks which history file THIS sidebar instance is using so that two
+    -- Avante instances open on the same project do not steal each other's
+    -- session when one of them saves or creates a new chat.
+    current_history_filename = nil,
+    -- mtime (seconds) of the history file as it was when last loaded or saved
+    -- by THIS instance. Used to detect concurrent writes from other instances.
+    _chat_history_mtime = nil,
     current_state = nil,
     state_timer = nil,
     state_spinner_chars = Config.windows.spinner.generating,
@@ -229,6 +238,12 @@ function Sidebar:reset()
   self.current_tool_use_extmark_id = nil
   self.win_size_store = {}
   self.is_in_full_view = false
+  -- Clear the pinned history filename so that initialize() → reload_chat_history()
+  -- reads from metadata.json for whatever project/buffer is opened next.
+  -- The per-session isolation guarantee (two tabs on the same project not
+  -- stealing each other's history) is preserved because each tab has its own
+  -- Sidebar instance and reset() is never called on another tab's sidebar.
+  self.current_history_filename = nil
 end
 
 ---@class SidebarOpenOptions: AskOptions
@@ -1120,7 +1135,9 @@ end
 
 function Sidebar:render_result()
   if not Utils.is_valid_container(self.containers.result) then return end
+  local instance_name = self.chat_history and self.chat_history.instance_name
   local header_text = Utils.icon("󰭻 ") .. "Avante"
+  if instance_name then header_text = header_text .. " [" .. instance_name .. "]" end
   self:render_header(
     self.containers.result.winid,
     self.containers.result.bufnr,
@@ -2014,6 +2031,18 @@ function Sidebar:_get_message_lines(ctx, message, messages, ignore_record_prefix
     return res
   end
   if message.message.role == "user" then
+    -- Cross-instance messages are rendered with a special "← From <name>" header
+    -- instead of the standard "> " user prefix.
+    if message.from_instance then
+      local from_label = "← From [" .. message.from_instance .. "]"
+      local res = { Line:new({ { from_label } }) }
+      for _, line_ in ipairs(lines) do
+        local sections = { { "> " } }
+        sections = vim.list_extend(sections, line_.sections)
+        table.insert(res, Line:new(sections))
+      end
+      return res
+    end
     local res = {}
     for _, line_ in ipairs(lines) do
       local sections = { { "> " } }
@@ -2350,8 +2379,127 @@ function Sidebar:compact_history_messages(args, cb)
   end)
 end
 
+--- /simplify command: run all history messages through the model with an
+--- aggressive prompt that distils only the information an engineer needs to
+--- continue the work.  The result replaces the chat memory so that old
+--- messages are hidden from subsequent API calls.
+function Sidebar:simplify_history_messages(args, cb)
+  local history_memory = self.chat_history.memory
+  local messages = History.get_history_messages(self.chat_history)
+  self.current_state = "compacting"
+  self:render_state()
+  self:update_content(
+    "simplifying history …",
+    { focus = false, scroll = true, callback = function() self:focus_input() end }
+  )
+  Llm.simplify_history(history_memory and history_memory.content, messages, function(memory)
+    if memory then
+      self.chat_history.memory = memory
+      Path.history.save(self.code.bufnr, self.chat_history)
+    end
+    self:update_content(
+      "simplified!",
+      { focus = false, scroll = true, callback = function() self:focus_input() end }
+    )
+    self.current_state = "compacted"
+    self:clear_state()
+    if cb then cb(args) end
+  end)
+end
+
+--- /send <instance_name> <intent> command: ask the current conversation's model
+--- to draft a message for another active Avante instance based on the user's
+--- intent and the current conversation context, then deliver that drafted
+--- message to the target instance.  The message appears in the receiver's chat
+--- with a "← From [name]" header, but is stored as a plain user message so
+--- the API receives valid turn order.
+---@param args string   e.g. "swift-fox tell them about the auth bug we found"
+---@param cb? fun(args: string): nil
+function Sidebar:send_message_to_instance(args, cb)
+  local target_name, user_intent = args:match("^(%S+)%s+(.*)")
+  if not target_name or not user_intent or user_intent == "" then
+    self:update_content(
+      "Usage: /send <instance-name> <message intent>\n"
+        .. "The current chat will draft the message based on conversation context.",
+      { focus = false, scroll = false, callback = function() self:focus_input() end }
+    )
+    if cb then cb(args) end
+    return
+  end
+
+  local Avante = require("avante")
+  local target_sidebar = Avante.instance_registry[target_name]
+  if not target_sidebar then
+    self:update_content(
+      "Instance not found: " .. target_name .. "\nAvailable: " .. table.concat(
+        vim.tbl_keys(Avante.instance_registry),
+        ", "
+      ),
+      { focus = false, scroll = false, callback = function() self:focus_input() end }
+    )
+    if cb then cb(args) end
+    return
+  end
+
+  local sender_name = self.chat_history and self.chat_history.instance_name or "unknown"
+  local history_messages = History.get_history_messages(self.chat_history)
+
+  -- Show drafting status in the current instance.
+  self.current_state = "generating"
+  self:render_state()
+  self:update_content(
+    "drafting message to [" .. target_name .. "] …",
+    { focus = false, scroll = false, callback = function() self:focus_input() end }
+  )
+
+  -- Ask the current conversation's model to draft the message.
+  Llm.draft_inter_instance_message(history_messages, user_intent, sender_name, target_name, function(drafted)
+    self.current_state = nil
+    self:clear_state()
+
+    if not drafted or drafted == "" then
+      self:update_content(
+        "Failed to draft message to [" .. target_name .. "]",
+        { focus = false, scroll = false, callback = function() self:focus_input() end }
+      )
+      if cb then cb(args) end
+      return
+    end
+
+    -- Inject the LLM-drafted message into the target sidebar as a user message
+    -- tagged with `from_instance` so the renderer shows the special header.
+    local injected = History.Message:new("user", drafted, {
+      from_instance = sender_name,
+      is_user_submission = false,
+      visible = true,
+    })
+    target_sidebar:add_history_messages({ injected })
+    target_sidebar:save_history()
+    -- Force the target sidebar to re-render so the new message is visible.
+    if Utils.is_valid_container(target_sidebar.containers.result, true) then
+      pcall(function() target_sidebar:update_content_with_history() end)
+    end
+
+    self:update_content(
+      "Message sent to [" .. target_name .. "]",
+      { focus = false, scroll = false, callback = function() self:focus_input() end }
+    )
+    if cb then cb(args) end
+  end)
+end
+
 function Sidebar:new_chat(args, cb)
   local history = Path.history.new(self.code.bufnr)
+  local Avante = require("avante")
+  -- Eagerly update the instance registry so other sidebars can find the new
+  -- name immediately, before the save → reload cycle completes.
+  if self.chat_history and self.chat_history.instance_name then
+    Avante.instance_registry[self.chat_history.instance_name] = nil
+  end
+  if history.instance_name then Avante.instance_registry[history.instance_name] = self end
+  -- Pin this sidebar to the new file BEFORE saving so reload_chat_history()
+  -- uses the correct file and doesn't read a stale metadata.json value.
+  self.current_history_filename = history.filename
   Path.history.save(self.code.bufnr, history)
   self:reload_chat_history()
   self.current_state = nil
@@ -2368,7 +2516,7 @@ function Sidebar:new_chat(args, cb)
 end
 
 local debounced_save_history = Utils.debounce(
-  function(self) Path.history.save(self.code.bufnr, self.chat_history) end,
+  function(self) self:_save_chat_history() end,
   1000
 )
 
@@ -2605,8 +2753,99 @@ end
 function Sidebar:reload_chat_history()
   self.token_count = nil
   if not self.code.bufnr or not api.nvim_buf_is_valid(self.code.bufnr) then return end
-  self.chat_history = Path.history.load(self.code.bufnr)
+
+  local Avante = require("avante")
+  -- Deregister the old instance name before loading the new history so that
+  -- stale entries don't accumulate across /new cycles.
+  if self.chat_history and self.chat_history.instance_name then
+    Avante.instance_registry[self.chat_history.instance_name] = nil
+  end
+
+  -- Load the specific file this sidebar is pinned to (if any), so that a
+  -- concurrent Avante instance saving to the shared metadata.json cannot
+  -- hijack this sidebar's history.
+  self.chat_history = Path.history.load(self.code.bufnr, self.current_history_filename)
+
+  -- Isolation guard: if the history we just loaded is already owned by a
+  -- *different* live sidebar, fork to a fresh independent history.  This
+  -- prevents two Avante windows that share the same source buffer from
+  -- inheriting the same chat timeline, and guarantees each window gets a
+  -- unique instance_name for cross-instance messaging.
+  if self.chat_history and self.chat_history.instance_name then
+    local existing_owner = Avante.instance_registry[self.chat_history.instance_name]
+    if existing_owner ~= nil and existing_owner ~= self then
+      -- The loaded history is already in use — branch off to a fresh session.
+      -- The fresh history is intentionally not saved here; it will be written
+      -- to disk the first time the user sends a message (via save_history()).
+      local fresh = Path.history.new(self.code.bufnr)
+      self.chat_history = fresh
+      self.current_history_filename = fresh.filename
+      self._chat_history_mtime = nil -- no disk file yet; suppress false conflicts
+    end
+  end
+
+  -- Pin ourselves to whatever file we now hold so future reloads stay on the
+  -- same file even if another instance updates metadata.json.
+  if self.chat_history then self.current_history_filename = self.chat_history.filename end
+  -- Record the disk mtime so _save_chat_history() can detect concurrent writes.
+  -- Skip if mtime was already cleared above (fresh-history branch).
+  if self._chat_history_mtime == nil and self.current_history_filename then
+    local fp = Path.history.get_filepath(self.code.bufnr, self.current_history_filename)
+    local stat = vim.uv.fs_stat(tostring(fp))
+    self._chat_history_mtime = stat and stat.mtime.sec or nil
+  end
+  -- Register this sidebar under its (now-unique) instance name.
+  if self.chat_history and self.chat_history.instance_name then
+    Avante.instance_registry[self.chat_history.instance_name] = self
+  end
   self._history_cache_invalidated = true
+  -- Update the result header to reflect the (possibly new) instance name.
+  vim.schedule(function() self:render_result() end)
+end
+
+--- Save self.chat_history to disk, forking to a new file first when a
+--- concurrent Avante instance (in another Neovim process) has modified the
+--- file since we last loaded or saved it.  This prevents two instances that
+--- both open the same "latest" history file from overwriting each other's
+--- messages.
+function Sidebar:_save_chat_history()
+  if not self.chat_history or not self.code.bufnr then return end
+
+  -- Conflict detection: if the file on disk has a newer mtime than the one
+  -- we recorded, someone else wrote to it.  Fork to a fresh file so our
+  -- session is independent going forward.
+  if self.current_history_filename and self._chat_history_mtime then
+    local fp = Path.history.get_filepath(self.code.bufnr, self.current_history_filename)
+    local stat = vim.uv.fs_stat(tostring(fp))
+    local disk_mtime = stat and stat.mtime.sec or nil
+    if disk_mtime and disk_mtime ~= self._chat_history_mtime then
+      -- Another instance wrote to our file.  Branch to a new file that carries
+      -- our in-memory messages so both sessions stay independent.
+      local new_stub = Path.history.new(self.code.bufnr)
+      -- Copy all relevant fields from the current in-memory history.
+      new_stub.title = self.chat_history.title
+      new_stub.timestamp = self.chat_history.timestamp
+      new_stub.entries = self.chat_history.entries
+      new_stub.messages = self.chat_history.messages
+      new_stub.todos = self.chat_history.todos
+      if self.chat_history.memory then new_stub.memory = self.chat_history.memory end
+      if self.chat_history.system_prompt then new_stub.system_prompt = self.chat_history.system_prompt end
+      if self.chat_history.tokens_usage then new_stub.tokens_usage = self.chat_history.tokens_usage end
+      if self.chat_history.acp_session_id then new_stub.acp_session_id = self.chat_history.acp_session_id end
+      self.chat_history = new_stub
+      self.current_history_filename = new_stub.filename
+      self._chat_history_mtime = nil -- will be set after the save below
+    end
+  end
+
+  Path.history.save(self.code.bufnr, self.chat_history)
+
+  -- Update the stored mtime so the NEXT conflict check has a fresh baseline.
+  if self.current_history_filename then
+    local fp = Path.history.get_filepath(self.code.bufnr, self.current_history_filename)
+    local stat = vim.uv.fs_stat(tostring(fp))
+    self._chat_history_mtime = stat and stat.mtime.sec or nil
+  end
 end
 
 ---@param opts? {all?: boolean}
@@ -2728,6 +2967,123 @@ function Sidebar:get_generate_prompts_options(request, cb)
       fields = { { name = "rel_path", description = "Relative path to the file", type = "string" } },
     },
     returns = {},
+  })
+
+  -- Build the sender name now so the closure captures the current value.
+  local sender_name = self.chat_history and self.chat_history.instance_name or "unknown"
+
+  table.insert(tools, {
+    name = "send_message",
+    description = string.format(
+      [[Send a message to another active Avante instance.
+
+⚠️  IMPORTANT: Only use this tool when:
+1. The user EXPLICITLY asks you to send a message to another instance, OR
+2. You have received a message FROM another instance (shown with a "← From [name]" header) and the user wants you to reply.
+
+Do NOT proactively contact other instances on your own initiative.
+
+YOUR instance name: [%s]
+
+To see available target instances call this tool with action="list". Then call it again with action="send" to deliver the message.
+
+When action="send":
+- "target_instance": the exact name of the destination instance (e.g. "swift-fox")
+- "message": the fully-composed text to deliver — be concise and contextual]],
+      sender_name
+    ),
+    ---@type AvanteLLMToolFunc<{ action: "list"|"send", target_instance?: string, message?: string }>
+    func = function(input, opts)
+      local Avante = require("avante")
+      if input.action == "list" then
+        local names = vim.tbl_keys(Avante.instance_registry)
+        -- Exclude self from the list so the model doesn't try to message itself.
+        names = vim.iter(names):filter(function(n) return n ~= sender_name end):totable()
+        if #names == 0 then return "No other active Avante instances found.", nil end
+        return "Active instances: " .. table.concat(names, ", "), nil
+      end
+
+      if input.action == "send" then
+        local target_name = input.target_instance
+        local message_text = input.message
+        if not target_name or target_name == "" then return nil, "target_instance is required" end
+        if not message_text or message_text == "" then return nil, "message is required" end
+
+        local target_sidebar = Avante.instance_registry[target_name]
+        if not target_sidebar then
+          local available = table.concat(
+            vim.iter(vim.tbl_keys(Avante.instance_registry))
+              :filter(function(n) return n ~= sender_name end)
+              :totable(),
+            ", "
+          )
+          return nil,
+            string.format(
+              "Instance '%s' not found. Available: %s",
+              target_name,
+              available ~= "" and available or "(none)"
+            )
+        end
+
+        if target_sidebar == self then return nil, "Cannot send a message to yourself" end
+
+        local on_log = opts.on_log
+        if on_log then on_log(string.format("sending to [%s]: %s", target_name, message_text:sub(1, 80))) end
+
+        local injected = History.Message:new("user", message_text, {
+          from_instance = sender_name,
+          is_user_submission = false,
+          visible = true,
+        })
+        target_sidebar:add_history_messages({ injected })
+        target_sidebar:save_history()
+        if Utils.is_valid_container(target_sidebar.containers.result, true) then
+          pcall(function() target_sidebar:update_content_with_history() end)
+        end
+
+        return string.format("Message delivered to [%s].", target_name), nil
+      end
+
+      return nil, "Unknown action '" .. tostring(input.action) .. "'. Use 'list' or 'send'."
+    end,
+    param = {
+      type = "table",
+      fields = {
+        {
+          name = "action",
+          description = "'list' to see available instances, 'send' to deliver a message",
+          type = "string",
+        },
+        {
+          name = "target_instance",
+          description = "The name of the destination instance (required when action='send')",
+          type = "string",
+          optional = true,
+        },
+        {
+          name = "message",
+          description = "The message text to deliver (required when action='send')",
+          type = "string",
+          optional = true,
+        },
+      },
+      usage = {
+        action = "list",
+      },
+    },
+    returns = {
+      {
+        name = "result",
+        description = "Confirmation or list of available instances",
+        type = "string",
+      },
+      {
+        name = "error",
+        description = "Error message if the send failed",
+        type = "string",
+        optional = true,
+      },
+    },
   })
 
   local selected_filepaths = self.file_selector.selected_filepaths or {}
@@ -2982,10 +3338,9 @@ function Sidebar:handle_submit(request)
       end,
       set_tool_use_store = set_tool_use_store,
       get_history_messages = function(opts) return self:get_history_messages_for_api(opts) end,
-      get_todos = function()
-        local history = Path.history.load(self.code.bufnr)
-        return history.todos
-      end,
+      -- Use in-memory todos to avoid a disk read that could race with another
+      -- Avante instance and return a different session's todos.
+      get_todos = function() return self.chat_history and self.chat_history.todos or {} end,
       update_todos = function(todos) self:update_todos(todos) end,
       session_ctx = {},
       ---@param usage avante.LLMTokenUsage
@@ -3230,8 +3585,10 @@ function Sidebar:get_selected_code_container_height()
 end
 
 function Sidebar:get_todos_container_height()
-  local history = Path.history.load(self.code.bufnr)
-  if #history.todos == 0 then return 0 end
+  -- Use the in-memory chat_history to avoid a disk read that could return a
+  -- different instance's file via the shared metadata.json pointer.
+  local todos = self.chat_history and self.chat_history.todos or {}
+  if #todos == 0 then return 0 end
   return 3
 end
 
@@ -3338,6 +3695,10 @@ function Sidebar:render(opts)
           if not self.code.winid or not api.nvim_win_is_valid(self.code.winid) then return end
           local bufnr = api.nvim_win_get_buf(self.code.winid)
           self.code.bufnr = bufnr
+          -- The code buffer changed (different project/root), so let
+          -- reload_chat_history() pick up the correct file from metadata.json
+          -- for the new buffer rather than staying pinned to the old file.
+          self.current_history_filename = nil
           self:reload_chat_history()
         end)
       end,
@@ -3531,7 +3892,9 @@ function Sidebar:create_selected_files_container()
 end
 
 function Sidebar:create_todos_container()
-  local history = Path.history.load(self.code.bufnr)
+  -- Use in-memory history to avoid loading from disk (which would follow
+  -- the shared metadata.json and could pull in another instance's file).
+  local history = self.chat_history or Path.history.load(self.code.bufnr, self.current_history_filename)
   if #history.todos == 0 then
     if self.containers.todos and Utils.is_valid_container(self.containers.todos) then
       self.containers.todos:unmount()

--- a/lua/avante/sidebar.lua
+++ b/lua/avante/sidebar.lua
@@ -2696,6 +2696,14 @@ function Sidebar:_save_chat_history()
       if self.chat_history.system_prompt then new_stub.system_prompt = self.chat_history.system_prompt end
       if self.chat_history.tokens_usage then new_stub.tokens_usage = self.chat_history.tokens_usage end
       if self.chat_history.acp_session_id then new_stub.acp_session_id = self.chat_history.acp_session_id end
+      -- Preserve the instance identity (name + id).  This is a file-level fork
+      -- only — the logical session and its human-readable name must NOT change.
+      -- Path.history.new() generates a fresh random name; release it and keep
+      -- the existing one so the sidebar header and IPC registration stay stable.
+      local Names = require("avante.utils.names")
+      Names.release(new_stub.instance_name)
+      new_stub.instance_name = self.chat_history.instance_name
+      new_stub.instance_id = self.chat_history.instance_id
       self.chat_history = new_stub
       self.current_history_filename = new_stub.filename
       self._chat_history_mtime = nil

--- a/lua/avante/slashcommands.lua
+++ b/lua/avante/slashcommands.lua
@@ -11,9 +11,11 @@
 --- - `/clear`: clear chat history
 --- - `/new`: start a new chat
 --- - `/compact`: compact history messages
+--- - `/simplify`: aggressively simplify chat history, keeping only critical engineering context
 --- - `/model`: select model
 --- - `/lines <start>-<end> <question>`: ask about specific lines
 --- - `/commit`: generate a commit message
+--- - `/send <instance-name> <message>`: send a message to another Avante instance
 ---@brief ]]
 
 ---@class avante.SlashCommands
@@ -49,6 +51,11 @@ local builtin_commands = {
     name = "compact",
   },
   {
+    description = "Maximally simplify history, keeping only critical engineering context",
+    details = "Maximally simplify history, keeping only critical engineering context",
+    name = "simplify",
+  },
+  {
     description = "Select model",
     details = "Select model",
     name = "model",
@@ -63,6 +70,12 @@ local builtin_commands = {
     description = "Commit the changes",
     details = "Commit the changes",
     name = "commit",
+  },
+  {
+    shorthelp = "Send a message to another Avante instance",
+    description = "/send <instance-name> <intent>",
+    details = "Ask the current chat's model to draft and send a message to another active Avante instance\n/send <instance-name> <what to communicate>",
+    name = "send",
   },
 }
 
@@ -85,6 +98,7 @@ local callbacks = {
   clear = function(sidebar, args, cb) sidebar:clear_history(args, cb) end,
   new = function(sidebar, args, cb) sidebar:new_chat(args, cb) end,
   compact = function(sidebar, args, cb) sidebar:compact_history_messages(args, cb) end,
+  simplify = function(sidebar, args, cb) sidebar:simplify_history_messages(args, cb) end,
   init = function(sidebar, args, cb) sidebar:init_current_project(args, cb) end,
   lines = function(_, args, cb)
     if cb then cb(args) end
@@ -103,6 +117,7 @@ local callbacks = {
     end
     if cb then cb("") end
   end,
+  send = function(sidebar, args, cb) sidebar:send_message_to_instance(args, cb) end,
 }
 
 ---@return AvanteSlashCommand[]

--- a/lua/avante/slashcommands.lua
+++ b/lua/avante/slashcommands.lua
@@ -11,9 +11,11 @@
 --- - `/clear`: clear chat history
 --- - `/new`: start a new chat
 --- - `/compact`: compact history messages
+--- - `/simplify`: aggressively simplify chat history, keeping only critical engineering context
 --- - `/model`: select model
 --- - `/lines <start>-<end> <question>`: ask about specific lines
 --- - `/commit`: generate a commit message
+--- - `/send <instance-name> <message>`: send a message to another Avante instance (hidden when ipc_service is enabled)
 ---@brief ]]
 
 ---@class avante.SlashCommands
@@ -49,6 +51,11 @@ local builtin_commands = {
     name = "compact",
   },
   {
+    description = "Maximally simplify history, keeping only critical engineering context",
+    details = "Maximally simplify history, keeping only critical engineering context",
+    name = "simplify",
+  },
+  {
     description = "Select model",
     details = "Select model",
     name = "model",
@@ -63,6 +70,12 @@ local builtin_commands = {
     description = "Commit the changes",
     details = "Commit the changes",
     name = "commit",
+  },
+  {
+    shorthelp = "Send a message to another Avante instance",
+    description = "/send <instance-name> <intent>",
+    details = "Ask the current chat's model to draft and send a message to another active Avante instance\n/send <instance-name> <what to communicate>",
+    name = "send",
   },
 }
 
@@ -85,6 +98,7 @@ local callbacks = {
   clear = function(sidebar, args, cb) sidebar:clear_history(args, cb) end,
   new = function(sidebar, args, cb) sidebar:new_chat(args, cb) end,
   compact = function(sidebar, args, cb) sidebar:compact_history_messages(args, cb) end,
+  simplify = function(sidebar, args, cb) sidebar:simplify_history_messages(args, cb) end,
   init = function(sidebar, args, cb) sidebar:init_current_project(args, cb) end,
   lines = function(_, args, cb)
     if cb then cb(args) end
@@ -103,12 +117,27 @@ local callbacks = {
     end
     if cb then cb("") end
   end,
+  -- /send is a convenience wrapper around the send_message LLM tool for
+  -- in-process (same-nvim) instance messaging.  When the IPC service is
+  -- enabled the LLM tool handles cross-process delivery directly, so /send
+  -- is redundant and would only confuse the model with stale in-process-only
+  -- semantics.  We keep the callback in case someone invokes it at runtime
+  -- but filter the command out of the visible list below.
+  send = function(sidebar, args, cb) sidebar:send_message_to_instance(args, cb) end,
 }
 
 ---@return AvanteSlashCommand[]
 function M.get_builtin_commands()
+  local Config = require("avante.config")
+  local ipc_enabled = Config.ipc_service and Config.ipc_service.enabled
   return vim
     .iter(builtin_commands)
+    :filter(function(command)
+      -- Hide /send when the IPC service is enabled — cross-process messaging
+      -- is handled transparently by the send_message LLM tool instead.
+      if command.name == "send" and ipc_enabled then return false end
+      return true
+    end)
     :map(
       ---@param command AvanteSlashCommand
       function(command)

--- a/lua/avante/slashcommands.lua
+++ b/lua/avante/slashcommands.lua
@@ -15,7 +15,7 @@
 --- - `/model`: select model
 --- - `/lines <start>-<end> <question>`: ask about specific lines
 --- - `/commit`: generate a commit message
---- - `/send <instance-name> <message>`: send a message to another Avante instance
+--- - `/send <instance-name> <message>`: send a message to another Avante instance (hidden when ipc_service is enabled)
 ---@brief ]]
 
 ---@class avante.SlashCommands
@@ -117,13 +117,27 @@ local callbacks = {
     end
     if cb then cb("") end
   end,
+  -- /send is a convenience wrapper around the send_message LLM tool for
+  -- in-process (same-nvim) instance messaging.  When the IPC service is
+  -- enabled the LLM tool handles cross-process delivery directly, so /send
+  -- is redundant and would only confuse the model with stale in-process-only
+  -- semantics.  We keep the callback in case someone invokes it at runtime
+  -- but filter the command out of the visible list below.
   send = function(sidebar, args, cb) sidebar:send_message_to_instance(args, cb) end,
 }
 
 ---@return AvanteSlashCommand[]
 function M.get_builtin_commands()
+  local Config = require("avante.config")
+  local ipc_enabled = Config.ipc_service and Config.ipc_service.enabled
   return vim
     .iter(builtin_commands)
+    :filter(function(command)
+      -- Hide /send when the IPC service is enabled — cross-process messaging
+      -- is handled transparently by the send_message LLM tool instead.
+      if command.name == "send" and ipc_enabled then return false end
+      return true
+    end)
     :map(
       ---@param command AvanteSlashCommand
       function(command)

--- a/lua/avante/tokenizers.lua
+++ b/lua/avante/tokenizers.lua
@@ -55,7 +55,7 @@ function M.encode(prompt)
   local success, result = pcall(tokenizers.encode, prompt)
   -- Some output like terminal command output might not be utf-8 encoded, which will cause an error here
   if not success then
-    Utils.warn("Failed to encode prompt: " .. result)
+    Utils.warn("Failed to encode prompt: " .. tostring(result))
     return nil
   end
   return result

--- a/lua/avante/types.lua
+++ b/lua/avante/types.lua
@@ -118,7 +118,8 @@ vim.g.avante_login = vim.g.avante_login
 ---@field turn_id string | nil
 ---@field is_calling boolean | nil
 ---@field original_content AvanteLLMMessageContent | nil
----@field acp_tool_call? avante.acp.ToolCall | avante.acp.ToolCallUpdate
+---@field acp_tool_call? avante.acp.ToolCall
+---@field from_instance string | nil   -- instance_name of the sending chat (cross-instance message)
 
 ---@class AvanteLLMToolResult
 ---@field tool_name string
@@ -526,6 +527,8 @@ vim.g.avante_login = vim.g.avante_login
 ---@field system_prompt string | nil
 ---@field tokens_usage avante.LLMTokenUsage | nil
 ---@field acp_session_id string | nil
+---@field instance_id string | nil   -- UUID for this chat session
+---@field instance_name string | nil -- human-readable name (e.g. "swift-fox")
 ---
 ---@class avante.ChatMemory
 ---@field content string
@@ -542,7 +545,7 @@ vim.g.avante_login = vim.g.avante_login
 ---@field content string
 ---@field uri string
 ---
----@alias AvanteSlashCommandBuiltInName "clear" | "help" | "lines" | "commit" | "new" | "init" | "compact" | "model"
+---@alias AvanteSlashCommandBuiltInName "clear" | "help" | "lines" | "commit" | "new" | "init" | "compact" | "model" | "simplify" | "send"
 ---@alias AvanteSlashCommandCallback fun(self: avante.Sidebar, args: string, cb?: fun(args: string): nil): nil
 ---@class AvanteSlashCommand
 ---@field name AvanteSlashCommandBuiltInName | string

--- a/lua/avante/types.lua
+++ b/lua/avante/types.lua
@@ -267,6 +267,8 @@ vim.g.avante_login = vim.g.avante_login
 ---@field context_window? integer
 ---@field use_response_api? boolean | fun(provider: AvanteDefaultBaseProvider, ctx?: any): boolean
 ---@field support_previous_response_id? boolean
+---@field cost_per_input_token? number -- Cost in dollars per input token (e.g. 0.000003 for $3/1M tokens)
+---@field cost_per_output_token? number -- Cost in dollars per output token (e.g. 0.000015 for $15/1M tokens)
 ---
 ---@class AvanteSupportedProvider: AvanteDefaultBaseProvider
 ---@field __inherited_from? string

--- a/lua/avante/types.lua
+++ b/lua/avante/types.lua
@@ -267,7 +267,8 @@ vim.g.avante_login = vim.g.avante_login
 ---@field use_response_api? boolean | fun(provider: AvanteDefaultBaseProvider, ctx?: any): boolean
 ---@field support_previous_response_id? boolean
 --- NOTE: Response API automatically manages conversation state using previous_response_id for tool calling
----
+---@field cost_per_input_token? number -- Cost in dollars per input token (e.g. 0.000003 for $3/1M tokens)
+---@field cost_per_output_token? number -- Cost in dollars per output token (e.g. 0.000015 for $15/1M tokens)
 ---
 ---@class AvanteSupportedProvider: AvanteDefaultBaseProvider
 ---@field __inherited_from? string

--- a/lua/avante/ui/selector/init.lua
+++ b/lua/avante/ui/selector/init.lua
@@ -14,6 +14,7 @@ local Utils = require("avante.utils")
 ---@field on_select fun(item_ids: string[] | nil)
 ---@field get_preview_content fun(item_id: string): (string, string) | nil
 ---@field on_delete_item fun(item_id: string): (nil) | nil
+---@field on_write_item fun(item_id: string): (nil) | nil
 ---@field on_open fun(): (nil) | nil
 
 ---@class avante.ui.Selector
@@ -26,6 +27,7 @@ local Utils = require("avante.utils")
 ---@field selected_item_ids string[] | nil
 ---@field get_preview_content fun(item_id: string): (string, string) | nil
 ---@field on_delete_item fun(item_id: string): (nil) | nil
+---@field on_write_item fun(item_id: string): (nil) | nil
 ---@field on_open fun(): (nil) | nil
 local Selector = {}
 Selector.__index = Selector
@@ -50,6 +52,7 @@ function Selector:new(opts)
   o.selected_item_ids = opts.selected_item_ids or {}
   o.get_preview_content = opts.get_preview_content
   o.on_delete_item = opts.on_delete_item
+  o.on_write_item = opts.on_write_item
   o.on_open = opts.on_open
   return o
 end

--- a/lua/avante/ui/selector/providers/fzf_lua.lua
+++ b/lua/avante/ui/selector/providers/fzf_lua.lua
@@ -66,6 +66,16 @@ function M.show(selector)
           end,
           reload = true,
         },
+        ["ctrl-w"] = {
+          fn = function(selected)
+            if type(selector.on_write_item) ~= "function" then return end
+            if not selected or #selected == 0 then return end
+            for _, entry in ipairs(selected) do
+              local id = title_to_id[entry]
+              if id then selector.on_write_item(id) end
+            end
+          end,
+        },
       },
     }, selector.provider_opts)
   )

--- a/lua/avante/ui/selector/providers/native.lua
+++ b/lua/avante/ui/selector/providers/native.lua
@@ -19,33 +19,43 @@ function M.show(selector)
       return
     end
 
-    -- If on_delete_item callback is provided, prompt for action
-    if type(selector.on_delete_item) == "function" then
-      vim.ui.input(
-        { prompt = "Action for '" .. item.title .. "': (o)pen, (d)elete, (c)ancel?", default = "" },
-        function(input)
-          if not input then -- User cancelled input
-            selector.on_select(nil) -- Treat as cancellation of selection
-            return
-          end
-          local choice = input:lower()
-          if choice == "d" or choice == "delete" then
+    -- If on_delete_item or on_write_item callback is provided, prompt for action
+    local has_actions = type(selector.on_delete_item) == "function"
+      or type(selector.on_write_item) == "function"
+    if has_actions then
+      local prompt_parts = { "(o)pen" }
+      if type(selector.on_delete_item) == "function" then table.insert(prompt_parts, "(d)elete") end
+      if type(selector.on_write_item) == "function" then table.insert(prompt_parts, "(w)rite") end
+      table.insert(prompt_parts, "(c)ancel")
+      local prompt = "Action for '" .. item.title .. "': " .. table.concat(prompt_parts, ", ") .. "?"
+      vim.ui.input({ prompt = prompt, default = "" }, function(input)
+        if not input then -- User cancelled input
+          selector.on_select(nil) -- Treat as cancellation of selection
+          return
+        end
+        local choice = input:lower()
+        if choice == "d" or choice == "delete" then
+          if type(selector.on_delete_item) == "function" then
             selector.on_delete_item(item.id)
-            -- The native provider handles the UI flow; we just need to refresh.
-            selector.on_open() -- Re-open the selector to refresh the list
-          elseif choice == "" or choice == "o" or choice == "open" then
-            selector.on_select({ item.id })
-          elseif choice == "c" or choice == "cancel" then
-            if type(selector.on_open) == "function" then
-              selector.on_open()
-            else
-              selector.on_select(nil) -- Fallback if on_open is not defined
-            end
-          else -- c or any other input, treat as cancel
+            -- Re-open the selector to refresh the list
+            selector.on_open()
+          end
+        elseif choice == "w" or choice == "write" then
+          if type(selector.on_write_item) == "function" then
+            selector.on_write_item(item.id)
+          end
+        elseif choice == "" or choice == "o" or choice == "open" then
+          selector.on_select({ item.id })
+        elseif choice == "c" or choice == "cancel" then
+          if type(selector.on_open) == "function" then
+            selector.on_open()
+          else
             selector.on_select(nil) -- Fallback if on_open is not defined
           end
+        else -- any other input, treat as cancel
+          selector.on_select(nil)
         end
-      )
+      end)
     else
       -- Default behavior: directly select the item
       selector.on_select({ item.id })

--- a/lua/avante/ui/selector/providers/snacks.lua
+++ b/lua/avante/ui/selector/providers/snacks.lua
@@ -76,12 +76,21 @@ function M.show(selector)
           end
         end)
       end,
+      write_selection = function(picker)
+        if type(selector.on_write_item) ~= "function" then return end
+        local selections = picker:selected({ fallback = true })
+        if #selections == 0 then return end
+        for _, selection in ipairs(selections) do
+          selector.on_write_item(selection.item.id)
+        end
+      end,
     },
 
     win = {
       input = {
         keys = {
           ["<C-DEL>"] = { "delete_selection", mode = { "i", "n" } },
+          ["<C-w>"] = { "write_selection", mode = { "i", "n" } },
         },
       },
     },

--- a/lua/avante/ui/selector/providers/telescope.lua
+++ b/lua/avante/ui/selector/providers/telescope.lua
@@ -104,6 +104,12 @@ function M.show(selector)
               end
             end)
           end, { desc = "delete_selection" })
+          if type(selector.on_write_item) == "function" then
+            map("i", "<c-w>", function()
+              local entry = action_state.get_selected_entry()
+              if entry then selector.on_write_item(entry.value) end
+            end, { desc = "write_selection" })
+          end
           actions.select_default:replace(function()
             local picker = action_state.get_current_picker(prompt_bufnr)
 

--- a/lua/avante/utils/init.lua
+++ b/lua/avante/utils/init.lua
@@ -101,8 +101,8 @@ local function get_cmd_for_shell(input_cmd, shell_cmd)
     cmd = { "powershell.exe", "-NoProfile", "-Command", input_cmd:gsub('"', "'") }
   else
     -- linux and macos we will just do sh -c
-    shell_cmd = shell_cmd or "sh -c"
-    for _, cmd_part in ipairs(vim.split(shell_cmd, " ")) do
+    local effective_shell_cmd = shell_cmd or "sh -c"
+    for _, cmd_part in ipairs(vim.split(effective_shell_cmd, " ")) do
       table.insert(cmd, cmd_part)
     end
     table.insert(cmd, input_cmd)

--- a/lua/avante/utils/init.lua
+++ b/lua/avante/utils/init.lua
@@ -101,8 +101,8 @@ local function get_cmd_for_shell(input_cmd, shell_cmd)
     cmd = { "powershell.exe", "-NoProfile", "-Command", input_cmd:gsub('"', "'") }
   else
     -- linux and macos we will just do sh -c
-    local effective_shell_cmd = shell_cmd or "sh -c"
-    for _, cmd_part in ipairs(vim.split(effective_shell_cmd, " ")) do
+    shell_cmd = shell_cmd or "sh -c"
+    for _, cmd_part in ipairs(vim.split(shell_cmd, " ")) do
       table.insert(cmd, cmd_part)
     end
     table.insert(cmd, input_cmd)
@@ -1524,6 +1524,8 @@ function M.llm_tool_param_fields_to_json_schema(fields)
   for _, field in ipairs(fields) do
     if field.type == "object" and field.fields then
       local properties_, required_ = M.llm_tool_param_fields_to_json_schema(field.fields)
+      -- Ensure nested properties is always a JSON object, not array
+      if vim.tbl_isempty(properties_) then properties_ = vim.empty_dict() end
       properties[field.name] = {
         type = field.type,
         description = field.get_description and field.get_description() or field.description,

--- a/lua/avante/utils/names.lua
+++ b/lua/avante/utils/names.lua
@@ -1,0 +1,73 @@
+---@mod avante-names avante instance name generation
+---@brief [[
+--- Generates human-readable, memorable names for Avante chat instances.
+--- Each name is an adjective + noun combination chosen at random.
+---@brief ]]
+
+local M = {}
+
+-- Word lists for generating friendly instance names.
+local adjectives = {
+  "amber", "azure", "bold", "bright", "calm", "cedar", "cobalt", "cool",
+  "crisp", "cyan", "dark", "deep", "dim", "dusk", "fern", "firm", "flame",
+  "free", "frost", "gold", "jade", "keen", "light", "lime", "mist", "mint",
+  "moon", "moss", "navy", "noir", "oak", "pale", "pine", "pure", "quick",
+  "rose", "ruby", "sage", "salt", "sand", "silk", "slim", "snow", "soft",
+  "solar", "steel", "storm", "swift", "teal", "warm", "wild", "wise",
+}
+
+local nouns = {
+  "arc", "ash", "bay", "beam", "bell", "brook", "crest", "crow", "dawn",
+  "dune", "elm", "fern", "field", "finch", "fjord", "flame", "flare", "fox",
+  "gale", "glen", "grove", "hawk", "hill", "jade", "kite", "lake", "lark",
+  "leaf", "lynx", "marsh", "moon", "oak", "owl", "peak", "pine", "pond",
+  "raven", "reef", "ridge", "rift", "river", "rock", "seal", "sky", "spark",
+  "stone", "stream", "tide", "vale", "wave", "wren",
+}
+
+--- Registry of all names currently in use to avoid collisions.
+---@type table<string, boolean>
+local used_names = {}
+
+--- Generate a unique adjective-noun instance name.
+--- If a collision occurs the noun is suffixed with a counter (e.g. "swift-fox-2").
+---@return string
+function M.generate()
+  math.randomseed(os.time() + math.random(1000))
+  local max_attempts = 20
+  for _ = 1, max_attempts do
+    local adj = adjectives[math.random(#adjectives)]
+    local noun = nouns[math.random(#nouns)]
+    local name = adj .. "-" .. noun
+    if not used_names[name] then
+      used_names[name] = true
+      return name
+    end
+  end
+  -- Fallback: append a random number to guarantee uniqueness.
+  local adj = adjectives[math.random(#adjectives)]
+  local noun = nouns[math.random(#nouns)]
+  local counter = 2
+  local candidate = adj .. "-" .. noun .. "-" .. counter
+  while used_names[candidate] do
+    counter = counter + 1
+    candidate = adj .. "-" .. noun .. "-" .. counter
+  end
+  used_names[candidate] = true
+  return candidate
+end
+
+--- Mark a name as in use (for names loaded from persisted history).
+---@param name string
+function M.register(name)
+  if name and name ~= "" then used_names[name] = true end
+end
+
+--- Release a name so it may be reused.
+---@param name string
+function M.release(name)
+  if name and name ~= "" then used_names[name] = nil end
+end
+
+return M
+

--- a/lua/avante/utils/path.lua
+++ b/lua/avante/utils/path.lua
@@ -16,6 +16,7 @@ function M.is_win() return IS_WIN end
 ---@param filepath                      string
 ---@return boolean
 function M.is_absolute(filepath)
+  if not filepath then return false end
   if IS_WIN then return #filepath > 1 and string.byte(filepath, 2, 2) == BYTE_COLON end
   return string.byte(filepath, 1, 1) == BYTE_PATHSEP
 end

--- a/plugin/avante.lua
+++ b/plugin/avante.lua
@@ -188,6 +188,72 @@ end, {
   complete = function(_, _, _) return { "history", "cache" } end,
 })
 cmd("ShowRepoMap", function() require("avante.repo_map").show() end, { desc = "avante: show repo map" })
+cmd("TokenBreakdown", function()
+  local sidebar = require("avante").get()
+  if not sidebar then
+    Utils.warn("No Avante sidebar found. Open Avante first (:AvanteAsk or :AvanteChat).")
+    return
+  end
+  sidebar:get_generate_prompts_options("", function(opts)
+    local Llm = require("avante.llm")
+    local breakdown, total = Llm.calculate_tokens_breakdown(opts)
+
+    if #breakdown == 0 then
+      Utils.warn("No token breakdown available (ACP providers are not supported).")
+      return
+    end
+
+    -- Build display lines
+    local max_name_len = 0
+    for _, item in ipairs(breakdown) do
+      max_name_len = math.max(max_name_len, #item.name)
+    end
+    local fmt = "  %-" .. max_name_len .. "s  %7d  (%3d%%)"
+    local sep = string.rep("─", max_name_len + 20)
+
+    local lines = {
+      "  Token breakdown for a fresh request",
+      sep,
+      "",
+    }
+    for _, item in ipairs(breakdown) do
+      local pct = total > 0 and math.floor(item.tokens / total * 100 + 0.5) or 0
+      table.insert(lines, string.format(fmt, item.name, item.tokens, pct))
+    end
+    table.insert(lines, "")
+    table.insert(lines, sep)
+    table.insert(lines, string.format("  %-" .. max_name_len .. "s  %7d", "TOTAL", total))
+    table.insert(lines, "")
+    table.insert(lines, "  Press q or <Esc> to close")
+
+    -- Open a scratch floating window
+    local buf = vim.api.nvim_create_buf(false, true)
+    vim.api.nvim_buf_set_lines(buf, 0, -1, false, lines)
+    vim.api.nvim_set_option_value("modifiable", false, { buf = buf })
+    vim.api.nvim_set_option_value("buftype", "nofile", { buf = buf })
+    vim.api.nvim_set_option_value("filetype", "avante_token_breakdown", { buf = buf })
+
+    local width = math.min(math.max(60, max_name_len + 22), vim.o.columns - 4)
+    local height = math.min(#lines, vim.o.lines - 4)
+    local win = vim.api.nvim_open_win(buf, true, {
+      relative = "editor",
+      width = width,
+      height = height,
+      row = math.floor((vim.o.lines - height) / 2),
+      col = math.floor((vim.o.columns - width) / 2),
+      style = "minimal",
+      border = "rounded",
+      title = " Avante Token Breakdown ",
+      title_pos = "center",
+    })
+    vim.api.nvim_set_option_value("wrap", false, { win = win })
+
+    -- Close keymaps
+    for _, key in ipairs({ "q", "<Esc>" }) do
+      vim.keymap.set("n", key, function() vim.api.nvim_win_close(win, true) end, { buffer = buf, nowait = true })
+    end
+  end)
+end, { desc = "avante: show per-component token count breakdown" })
 cmd("Models", function() require("avante.model_selector").open() end, { desc = "avante: show models" })
 cmd("ACPModels", function() require("avante.api").select_acp_model() end, { desc = "avante: switch ACP model" })
 cmd("ACPModes", function() require("avante.api").select_acp_mode() end, { desc = "avante: switch ACP mode" })

--- a/py/ipc-service/Dockerfile
+++ b/py/ipc-service/Dockerfile
@@ -1,0 +1,21 @@
+FROM python:3.11-slim-bookworm
+
+WORKDIR /app
+
+RUN apt-get update && apt-get install -y --no-install-recommends curl \
+  && rm -rf /var/lib/apt/lists/* \
+  && curl -LsSf https://astral.sh/uv/install.sh | sh
+
+ENV PATH="/root/.local/bin:$PATH" \
+  PYTHONPATH=/app/src \
+  PYTHONUNBUFFERED=1 \
+  PYTHONDONTWRITEBYTECODE=1
+
+COPY requirements.txt .
+
+RUN uv pip install --system -r requirements.txt
+
+COPY . .
+
+CMD ["uvicorn", "src.main:app", "--workers", "1", "--host", "0.0.0.0", "--port", "20251"]
+

--- a/py/ipc-service/requirements.txt
+++ b/py/ipc-service/requirements.txt
@@ -1,0 +1,4 @@
+fastapi==0.115.8
+uvicorn==0.34.0
+pydantic==2.10.6
+

--- a/py/ipc-service/run.sh
+++ b/py/ipc-service/run.sh
@@ -1,0 +1,16 @@
+#!/usr/bin/env bash
+
+TARGET_DIR=$1
+if [ -z "$TARGET_DIR" ]; then
+  TARGET_DIR="$HOME/.local/state/avante-ipc-service"
+fi
+
+mkdir -p "$TARGET_DIR"
+cp -r src/ "$TARGET_DIR"
+cp requirements.txt "$TARGET_DIR"
+cp shell.nix "$TARGET_DIR"
+
+echo "Files have been copied to $TARGET_DIR"
+cd "$TARGET_DIR"
+nix-shell
+

--- a/py/ipc-service/shell.nix
+++ b/py/ipc-service/shell.nix
@@ -1,0 +1,23 @@
+{ pkgs ? import <nixpkgs> {} }:
+let
+  python = pkgs.python311;
+in pkgs.mkShell {
+  packages = [
+    python
+    pkgs.uv
+  ];
+  env = {
+    PYTHONUNBUFFERED = 1;
+    PYTHONDONTWRITEBYTECODE = 1;
+    PORT = 20251;
+  };
+  shellHook = ''
+    if [ ! -d ".venv" ]; then
+      uv venv
+    fi
+    source ".venv/bin/activate"
+    uv pip install -r requirements.txt
+    uv run fastapi run src/main.py --port $PORT --workers 1
+  '';
+}
+

--- a/py/ipc-service/src/main.py
+++ b/py/ipc-service/src/main.py
@@ -1,0 +1,268 @@
+"""Avante IPC Service - cross-process instance registry and message broker.
+
+Each Neovim process running Avante registers its root sidebar instances here so
+that instances in different nvim processes can discover, inspect, and message each
+other.  The service is stateless across restarts: a volatile in-memory registry
+backed by heartbeats; dead instances are reaped automatically.
+"""  # noqa: INP001
+
+from __future__ import annotations
+
+import asyncio
+import os
+import time
+from contextlib import asynccontextmanager
+from typing import TYPE_CHECKING
+
+from fastapi import FastAPI, HTTPException
+from pydantic import BaseModel, Field
+
+if TYPE_CHECKING:
+    from collections.abc import AsyncGenerator
+
+# ---------------------------------------------------------------------------
+# Configuration
+# ---------------------------------------------------------------------------
+
+INSTANCE_TTL_SECONDS = float(os.getenv("IPC_INSTANCE_TTL", "30"))
+REAPER_INTERVAL_SECONDS = 5.0
+
+
+# ---------------------------------------------------------------------------
+# Data models
+# ---------------------------------------------------------------------------
+
+
+class InstanceInfo(BaseModel):
+    name: str = Field(..., description="Adjective-noun instance name e.g. swift-fox")
+    instance_id: str = Field(..., description="Stable UUID assigned to this history session")
+    nvim_pid: int = Field(..., description="PID of the owning Neovim process")
+    project: str = Field("", description="Absolute path of the project this instance is working in")
+    description: str = Field("", description="Short summary of what this instance is currently doing")
+    registered_at: float = Field(default_factory=time.time)
+    last_heartbeat: float = Field(default_factory=time.time)
+
+
+class RegisterRequest(BaseModel):
+    name: str
+    instance_id: str
+    nvim_pid: int
+    project: str = ""
+    description: str = ""
+
+
+class HeartbeatRequest(BaseModel):
+    instance_id: str
+    description: str | None = None
+
+
+class UnregisterRequest(BaseModel):
+    instance_id: str
+
+
+class UpdateDescriptionRequest(BaseModel):
+    instance_id: str
+    description: str
+
+
+class SendMessageRequest(BaseModel):
+    from_name: str = Field(..., description="Sender instance name")
+    to_name: str = Field(..., description="Recipient instance name")
+    message: str = Field(..., description="Message body")
+
+
+class PendingMessage(BaseModel):
+    from_name: str
+    message: str
+    sent_at: float = Field(default_factory=time.time)
+
+
+class InstanceSummary(BaseModel):
+    name: str
+    instance_id: str
+    nvim_pid: int
+    project: str
+    description: str
+    registered_at: float
+    last_heartbeat: float
+
+
+# ---------------------------------------------------------------------------
+# In-memory registry
+# ---------------------------------------------------------------------------
+
+_registry: dict[str, InstanceInfo] = {}
+_message_queues: dict[str, list[PendingMessage]] = {}
+_registry_lock = asyncio.Lock()
+
+
+# ---------------------------------------------------------------------------
+# Background reaper
+# ---------------------------------------------------------------------------
+
+
+async def _reaper() -> None:
+    while True:
+        await asyncio.sleep(REAPER_INTERVAL_SECONDS)
+        now = time.time()
+        async with _registry_lock:
+            stale = [
+                iid for iid, info in _registry.items()
+                if now - info.last_heartbeat > INSTANCE_TTL_SECONDS
+            ]
+            for iid in stale:
+                name = _registry[iid].name
+                del _registry[iid]
+                _message_queues.pop(name, None)
+
+
+@asynccontextmanager
+async def lifespan(app: FastAPI) -> AsyncGenerator[None, None]:  # noqa: ARG001
+    task = asyncio.create_task(_reaper())
+    yield
+    task.cancel()
+    try:
+        await task
+    except asyncio.CancelledError:
+        pass
+
+
+# ---------------------------------------------------------------------------
+# Application
+# ---------------------------------------------------------------------------
+
+app = FastAPI(
+    title="Avante IPC Service",
+    description=(
+        "Cross-process instance registry and message broker for Avante.nvim. "
+        "Enables root Avante sidebar instances in separate Neovim processes to "
+        "discover each other, share responsibility context, and exchange messages."
+    ),
+    version="0.0.1",
+    lifespan=lifespan,
+)
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _find_by_name(name: str) -> InstanceInfo | None:
+    return next((i for i in _registry.values() if i.name == name), None)
+
+
+# ---------------------------------------------------------------------------
+# Endpoints
+# ---------------------------------------------------------------------------
+
+
+@app.get("/api/health")
+async def health_check() -> dict[str, str]:
+    """Health / readiness probe polled by Lua until the service is up."""
+    return {"status": "ok"}
+
+
+@app.post("/api/v1/register", response_model=dict[str, str])
+async def register(req: RegisterRequest) -> dict[str, str]:
+    """Register a sidebar instance (idempotent: re-registering refreshes metadata)."""
+    async with _registry_lock:
+        existing = _registry.get(req.instance_id)
+        if existing:
+            existing.name = req.name
+            existing.nvim_pid = req.nvim_pid
+            existing.project = req.project
+            if req.description:
+                existing.description = req.description
+            existing.last_heartbeat = time.time()
+        else:
+            _registry[req.instance_id] = InstanceInfo(
+                name=req.name,
+                instance_id=req.instance_id,
+                nvim_pid=req.nvim_pid,
+                project=req.project,
+                description=req.description,
+            )
+            _message_queues.setdefault(req.name, [])
+    return {"status": "ok", "instance_id": req.instance_id}
+
+
+@app.post("/api/v1/unregister", response_model=dict[str, str])
+async def unregister(req: UnregisterRequest) -> dict[str, str]:
+    """Unregister an instance (called on sidebar close / nvim exit)."""
+    async with _registry_lock:
+        info = _registry.pop(req.instance_id, None)
+        if info:
+            _message_queues.pop(info.name, None)
+    return {"status": "ok"}
+
+
+@app.post("/api/v1/heartbeat", response_model=dict[str, str])
+async def heartbeat(req: HeartbeatRequest) -> dict[str, str]:
+    """Refresh TTL for an instance; returns 404 if not found (need to re-register)."""
+    async with _registry_lock:
+        info = _registry.get(req.instance_id)
+        if not info:
+            raise HTTPException(status_code=404, detail="Instance not found - re-register first")
+        info.last_heartbeat = time.time()
+        if req.description is not None:
+            info.description = req.description[:500]
+    return {"status": "ok"}
+
+
+@app.post("/api/v1/update_description", response_model=dict[str, str])
+async def update_description(req: UpdateDescriptionRequest) -> dict[str, str]:
+    """Update the responsibility description for an instance."""
+    async with _registry_lock:
+        info = _registry.get(req.instance_id)
+        if not info:
+            raise HTTPException(status_code=404, detail="Instance not found")
+        info.description = req.description[:500]
+        info.last_heartbeat = time.time()
+    return {"status": "ok"}
+
+
+@app.get("/api/v1/instances", response_model=list[InstanceSummary])
+async def list_instances(exclude_instance_id: str | None = None) -> list[InstanceSummary]:
+    """List all live instances, each with their description so callers know what coworkers are doing."""
+    async with _registry_lock:
+        result = [
+            InstanceSummary(
+                name=i.name,
+                instance_id=i.instance_id,
+                nvim_pid=i.nvim_pid,
+                project=i.project,
+                description=i.description,
+                registered_at=i.registered_at,
+                last_heartbeat=i.last_heartbeat,
+            )
+            for i in _registry.values()
+            if i.instance_id != exclude_instance_id
+        ]
+    return result
+
+
+@app.post("/api/v1/send_message", response_model=dict[str, str])
+async def send_message(req: SendMessageRequest) -> dict[str, str]:
+    """Queue a message for a target instance; returns 404 if target is not registered."""
+    async with _registry_lock:
+        target = _find_by_name(req.to_name)
+        if not target:
+            available = sorted(i.name for i in _registry.values() if i.name != req.from_name)
+            raise HTTPException(
+                status_code=404,
+                detail=f"Instance {req.to_name!r} not registered. Available: {', '.join(available) or 'none'}",
+            )
+        _message_queues.setdefault(req.to_name, []).append(
+            PendingMessage(from_name=req.from_name, message=req.message)
+        )
+    return {"status": "ok", "queued_for": req.to_name}
+
+
+@app.get("/api/v1/poll_messages/{instance_name}", response_model=list[PendingMessage])
+async def poll_messages(instance_name: str) -> list[PendingMessage]:
+    """Drain and return all pending messages (at-most-once delivery)."""
+    async with _registry_lock:
+        msgs = _message_queues.get(instance_name, [])
+        _message_queues[instance_name] = []
+    return list(msgs)


### PR DESCRIPTION
## Summary

Three related fixes that prevent hard crashes and Anthropic API errors:

- **`history/helpers.lua`**: Remove `assert(#content == 1)` that crashes when a message has multiple content blocks (e.g. thinking + text, or text + tool_use). All three helpers (`get_text_data`, `get_tool_use_data`, `get_tool_result_data`) and `is_thinking_message` now safely iterate the content array. `get_text_data` concatenates all `"text"` entries.

- **`llm.lua` — `generate_prompts()`**: Before sending to any provider, normalize the message array: merge consecutive messages with the same role (Anthropic rejects these), and drop a trailing `"assistant"` message that can appear when a partially-streamed response slips through.

- **`llm_tools/init.lua` — `process_tool_use()`**: Wrap each tool call in `pcall` so an unhandled Lua error becomes a proper `tool_result` error instead of crashing the stream callback. Without this, a crashed tool leaves an orphaned `tool_use` message in history with no matching `tool_result`, causing every subsequent API call to fail with "ids were found without tool_result blocks". Also nil-guards `input.path` in `str_replace_based_edit_tool`.

## Test plan
- [ ] Trigger a tool that throws an error and confirm the conversation continues
- [ ] Use a model with extended thinking and confirm history renders without crashing
- [ ] Confirm no "conversation must alternate" errors from Anthropic
