### PR TITLE
fix: UTF-8 safety for JSON encoding in API requests and history saves

### DIFF
--- a/lua/avante/llm.lua
+++ b/lua/avante/llm.lua
@@ -484,6 +484,134 @@ function M.calculate_tokens(opts)
   return tokens
 end
 
+--- Strip CESU-8 surrogate pairs and any other invalid UTF-8 byte sequences,
+--- replacing them with the UTF-8 replacement character U+FFFD.
+--- cjson rejects strings that contain surrogate code points (0xED 0xA0-0xBF …)
+--- with "surrogates not allowed", so all user-supplied strings must be cleaned
+--- before being JSON-encoded.
+---@param s string
+---@return string
+local function sanitize_string(s)
+  if type(s) ~= "string" then return s end
+  local out = {}
+  local repl = "ï¿½" -- U+FFFD replacement character in UTF-8
+  local len = #s
+  local i = 1
+  while i <= len do
+    local b = s:byte(i)
+    if b < 0x80 then
+      -- ASCII fast path.
+      out[#out + 1] = s:sub(i, i)
+      i = i + 1
+    elseif b >= 0xED and b <= 0xED then
+      -- Surrogate range: ED [A0-BF] [80-BF] — always invalid UTF-8.
+      if i + 2 <= len then
+        local b2 = s:byte(i + 1)
+        if b2 >= 0xA0 and b2 <= 0xBF then
+          out[#out + 1] = repl
+          i = i + 3 -- skip the full 3-byte surrogate sequence
+        else
+          out[#out + 1] = repl
+          i = i + 1
+        end
+      else
+        out[#out + 1] = repl
+        i = i + 1
+      end
+    elseif b < 0xC0 then
+      -- Stray continuation byte (0x80-0xBF outside a multi-byte sequence).
+      out[#out + 1] = repl
+      i = i + 1
+    elseif b < 0xE0 then
+      -- 2-byte sequence: leader 0xC2-0xDF, one continuation 0x80-0xBF.
+      if i + 1 <= len then
+        local b2 = s:byte(i + 1)
+        if b2 >= 0x80 and b2 <= 0xBF then
+          out[#out + 1] = s:sub(i, i + 1)
+          i = i + 2
+        else
+          out[#out + 1] = repl
+          i = i + 1
+        end
+      else
+        out[#out + 1] = repl
+        i = i + 1
+      end
+    elseif b < 0xF0 then
+      -- 3-byte sequence: leader 0xE0-0xEF, two continuations.
+      if i + 2 <= len then
+        local b2, b3 = s:byte(i + 1), s:byte(i + 2)
+        local ok2 = b2 >= 0x80 and b2 <= 0xBF
+        local ok3 = b3 >= 0x80 and b3 <= 0xBF
+        -- Over-long: E0 must be followed by A0-BF.
+        if b == 0xE0 and b2 < 0xA0 then ok2 = false end
+        -- Surrogate range ED A0-BF already handled in step 1; defensive check.
+        if b == 0xED and b2 >= 0xA0 then ok2 = false end
+        if ok2 and ok3 then
+          out[#out + 1] = s:sub(i, i + 2)
+          i = i + 3
+        else
+          out[#out + 1] = repl
+          i = i + 1
+        end
+      else
+        out[#out + 1] = repl
+        i = i + 1
+      end
+    elseif b < 0xF5 then
+      -- 4-byte sequence: leader 0xF0-0xF4, three continuations.
+      -- F0 must be followed by 90-BF (over-long); F4 by 80-8F (max U+10FFFF).
+      if i + 3 <= len then
+        local b2, b3, b4 = s:byte(i + 1), s:byte(i + 2), s:byte(i + 3)
+        local ok2 = b2 >= 0x80 and b2 <= 0xBF
+        local ok3 = b3 >= 0x80 and b3 <= 0xBF
+        local ok4 = b4 >= 0x80 and b4 <= 0xBF
+        if b == 0xF0 and b2 < 0x90 then ok2 = false end
+        if b == 0xF4 and b2 > 0x8F then ok2 = false end
+        if ok2 and ok3 and ok4 then
+          out[#out + 1] = s:sub(i, i + 3)
+          i = i + 4
+        else
+          out[#out + 1] = repl
+          i = i + 1
+        end
+      else
+        out[#out + 1] = repl
+        i = i + 1
+      end
+    else
+      -- 0xF5-0xFF are never valid UTF-8.
+      out[#out + 1] = repl
+      i = i + 1
+    end
+  end
+  return table.concat(out)
+end
+
+--- Recursively sanitize a value so it can be safely JSON-encoded by cjson / vim.json.encode.
+--- All strings are passed through sanitize_string which ensures valid UTF-8 with no
+--- surrogate code points.  Tables are traversed recursively; other types are returned as-is.
+---@param value any
+---@return any
+local function sanitize_for_json(value)
+  local t = type(value)
+  if t == "string" then
+    return sanitize_string(value)
+  elseif t == "table" then
+    -- Preserve vim.empty_dict() marker so cjson encodes as {} not []
+    if vim.tbl_isempty(value) and not vim.islist(value) then return vim.empty_dict() end
+    local out = {}
+    for k, v in pairs(value) do
+      out[sanitize_for_json(k)] = sanitize_for_json(v)
+    end
+    -- Preserve array vs. hash-table metatable so cjson encodes them correctly.
+    if vim.islist(value) then return vim.list_slice(out, 1) end
+    return out
+  else
+    return value
+  end
+end
+
 local parse_headers = function(headers_file)
   local headers = {}
   local file = io.open(headers_file, "r")
@@ -592,8 +720,16 @@ function M.curl(opts)
       raw = spec.rawArgs,
     }
   else
-    -- For regular JSON requests, encode as JSON and write to file
-    local json_content = vim.json.encode(spec.body)
+    -- For regular JSON requests, encode as JSON and write to file.
+    -- sanitize_for_json strips invalid UTF-8 surrogates that cause cjson to reject the body.
+    local ok, json_content = pcall(vim.json.encode, sanitize_for_json(spec.body))
+    if not ok then
+      Utils.error("Failed to encode request body: " .. tostring(json_content), { title = "Avante" })
+      if handler_opts.on_stop then
+        handler_opts.on_stop({ reason = "error", error = { message = "Failed to encode request body: " .. tostring(json_content) } })
+      end
+      return
+    end
     fn.writefile(vim.split(json_content, "\n"), curl_body_file)
     curl_options = {
       headers = spec.headers,

--- a/lua/avante/path.lua
+++ b/lua/avante/path.lua
@@ -173,12 +173,43 @@ function History.load(bufnr, filename)
   return History.from_file(history_filepath) or History.new(bufnr)
 end
 
+--- Recursively strip UTF-8 surrogate code points (CESU-8: 0xED [0xA0-0xBF] [0x80-0xBF])
+--- from all string values in `value`, replacing each 3-byte sequence with U+FFFD.
+--- This prevents cjson from rejecting the JSON with "surrogates not allowed" when
+--- file content or tool results contain characters encoded in modified UTF-8.
+---@param value any
+---@return any
+local function deep_sanitize_utf8(value)
+  local t = type(value)
+  if t == "string" then
+    return (value:gsub("\xED[\xA0-\xBF][\x80-\xBF]", "\xEF\xBF\xBD"))
+  elseif t == "table" then
+    local out = {}
+    for k, v in pairs(value) do
+      out[deep_sanitize_utf8(k)] = deep_sanitize_utf8(v)
+    end
+    if vim.islist(value) then return vim.list_slice(out, 1) end
+    return out
+  else
+    return value
+  end
+end
+
 -- Saves the chat history for the given buffer.
 ---@param bufnr integer
 ---@param history avante.ChatHistory
 function History.save(bufnr, history)
   local history_filepath = History.get_filepath(bufnr, history.filename)
-  history_filepath:write(vim.json.encode(history), "w")
+  -- Sanitize surrogate code points before encoding so that history files
+  -- remain valid UTF-8 JSON even when tool results or file contents contain
+  -- CESU-8 / modified-UTF-8 surrogate bytes.
+  local ok, json_content = pcall(vim.json.encode, deep_sanitize_utf8(history))
+  if not ok then
+    -- Fallback: encode without sanitization (better to save something than nothing)
+    ok, json_content = pcall(vim.json.encode, history)
+    if not ok then return end
+  end
+  history_filepath:write(json_content, "w")
   History.save_latest_filename(bufnr, history.filename)
 end
 
@@ -295,8 +326,7 @@ function Prompt.get_templates_dir(project_root)
   -- get root directory of given bufnr
   local directory = Path:new(project_root)
   if Utils.get_os_name() == "windows" then
-    local win_path = vim.fs.abspath(tostring(directory)):gsub("^%a:", ""):gsub("^[/\\]+", "")
-    directory = Path:new(vim.fs.normalize(win_path))
+    directory = Path:new(vim.fs.abspath(tostring(directory)):gsub("^%a:", ""))
   end
   local cache_prompt_dir = Path:new(P.cache_path):joinpath(directory)
   if not cache_prompt_dir:exists() then cache_prompt_dir:mkdir({ parents = true }) end

--- a/lua/avante/rag_service.lua
+++ b/lua/avante/rag_service.lua
@@ -290,12 +290,11 @@ function M.to_local_uri(uri)
 end
 
 function M.is_ready()
-  return vim
-    .system(
-      { "curl", "-s", "-o", "/dev/null", "-w", "%{http_code}", M.get_rag_service_url() .. "/api/health" },
-      { text = true }
-    )
-    :wait().code == 0
+  local result = vim.system(
+    { "curl", "-s", "-o", "/dev/null", "-w", "%{http_code}", M.get_rag_service_url() .. "/api/health" },
+    { text = true }
+  ):wait()
+  return result.code == 0 and vim.trim(result.stdout or "") == "200"
 end
 
 ---@class AvanteRagServiceAddResourceResponse
@@ -468,9 +467,10 @@ function M.get_resources()
     headers = {
       ["Content-Type"] = "application/json",
     },
+    timeout = 10000, -- 10 seconds; the RAG service can be slow to respond on startup
   })
-  if resp.status ~= 200 then
-    Utils.error("Failed to get resources: " .. resp.body)
+  if not resp or resp.status ~= 200 then
+    Utils.error("Failed to get resources: " .. (resp and resp.body or "no response"))
     return
   end
   local jsn = vim.json.decode(resp.body)

--- a/lua/avante/utils/path.lua
+++ b/lua/avante/utils/path.lua
@@ -16,6 +16,7 @@ function M.is_win() return IS_WIN end
 ---@param filepath                      string
 ---@return boolean
 function M.is_absolute(filepath)
+  if not filepath then return false end
   if IS_WIN then return #filepath > 1 and string.byte(filepath, 2, 2) == BYTE_COLON end
   return string.byte(filepath, 1, 1) == BYTE_PATHSEP
 end


### PR DESCRIPTION
## Summary

Prevents `"surrogates not allowed"` errors from `cjson` / `vim.json.encode` when tool results or file content contains CESU-8 / modified-UTF-8 surrogate byte sequences (common in Java `.class`
file paths, some Windows filenames, etc.).

- **`llm.lua`**: Add `sanitize_string()` (full UTF-8 validator/sanitizer) and `sanitize_for_json()` (recursive table sanitizer). Wrap `vim.json.encode()` in `pcall` with sanitization in the curl body writer; encoding failures surface as proper `on_stop` errors instead of crashing the stream.
- **`path.lua`**: Add `deep_sanitize_utf8()` for history data. Wrap `History.save()` encode in `pcall` + sanitization so history files stay valid UTF-8 JSON. Fix Windows template-directory path construction (remove spurious `gsub`).
- **`utils/path.lua`**: Nil-guard `M.is_absolute()` to return `false` instead of crashing when `filepath` is nil.
- **`rag_service.lua`**: Fix `is_ready()` to check both exit code == 0 AND stdout == "200". Add 10-second timeout and nil-guard to `get_resources()`.

## Test plan
- [ ] Open a file with non-ASCII characters in its path and run an agent task
- [ ] Confirm history saves without error on projects with binary/CESU-8 content