### PR TITLE
feat: multi-instance session isolation and per-instance identity names

### DIFF
--- a/lua/avante/api.lua
+++ b/lua/avante/api.lua
@@ -268,8 +268,12 @@ function M.select_history()
     vim.api.nvim_buf_call(buf, function()
       if not require("avante").is_sidebar_open() then require("avante").open_sidebar({}) end
       local Path = require("avante.path")
+      -- Update the global metadata pointer so the NEXT fresh instance opens
+      -- the right file, but also pin THIS sidebar to the selected file so
+      -- it doesn't get hijacked by a concurrent instance's save.
       Path.history.save_latest_filename(buf, filename)
       local sidebar = require("avante").get()
+      sidebar.current_history_filename = filename
       sidebar:update_content_with_history()
       sidebar:create_todos_container()
       sidebar:initialize_token_count()

--- a/lua/avante/history/message.lua
+++ b/lua/avante/history/message.lua
@@ -17,6 +17,7 @@ M.__index = M
 ---@field is_user_submission? boolean
 ---@field just_for_display? boolean
 ---@field visible? boolean
+---@field from_instance? string -- instance_name of the sending chat (cross-instance message)
 ---
 ---@param role "user" | "assistant"
 ---@param content AvanteLLMMessageContentItem

--- a/lua/avante/init.lua
+++ b/lua/avante/init.lua
@@ -148,6 +148,9 @@ local M = {
   current = { sidebar = nil, selection = nil, suggestion = nil },
   ---@type table<string, any> Global ACP client registry for cleanup on exit
   acp_clients = {},
+  --- instance_name → Sidebar: cross-instance messaging registry
+  ---@type table<string, avante.Sidebar>
+  instance_registry = {},
 }
 
 M.did_setup = false
@@ -423,7 +426,13 @@ function H.autocmds()
       local tab = tonumber(ev.file)
       local s = M.sidebars[tab]
       local sl = M.selections[tab]
-      if s then s:reset() end
+      if s then
+        -- Remove this sidebar from the cross-instance registry before reset.
+        if s.chat_history and s.chat_history.instance_name then
+          M.instance_registry[s.chat_history.instance_name] = nil
+        end
+        s:reset()
+      end
       if sl then sl:delete_autocmds() end
       if tab ~= nil then M.sidebars[tab] = nil end
     end,

--- a/lua/avante/llm.lua
+++ b/lua/avante/llm.lua
@@ -778,15 +778,7 @@ function M.curl(opts)
   return active_job
 end
 
-local retry_timer = nil
-local abort_retry_timer = false
-local function stop_retry_timer()
-  if retry_timer then
-    retry_timer:stop()
-    pcall(function() retry_timer:close() end)
-    retry_timer = nil
-  end
-end
+
 
 -- Intelligently truncate chat history for session recovery to avoid token limits
 ---@param history_messages table[]
@@ -1751,8 +1743,25 @@ end
 
 ---@param opts AvanteLLMStreamOptions
 function M._stream(opts)
-  -- Reset the cancellation flag at the start of a new request
+  -- Initialise the per-session cancellation flag.  Using session_ctx isolates each
+  -- avante instance so that cancelling one stream does not affect concurrent streams
+  -- running in other sidebar instances.
+  opts.session_ctx = opts.session_ctx or {}
+  opts.session_ctx.is_cancelled = false
+  -- Keep the legacy global in sync for any code that still reads it directly.
   if LLMToolHelpers then LLMToolHelpers.is_cancelled = false end
+
+  -- Per-stream retry-timer state. Using per-stream locals instead of module-level
+  -- variables prevents multiple avante instances from clobbering each other's timers.
+  local retry_timer = nil
+  local stream_cancelled = false
+  local function stop_retry_timer()
+    if retry_timer then
+      retry_timer:stop()
+      pcall(function() retry_timer:close() end)
+      retry_timer = nil
+    end
+  end
 
   local acp_provider = Config.acp_providers[Config.provider]
   if acp_provider then return M._stream_acp(opts) end
@@ -1911,7 +1920,13 @@ function M._stream(opts)
         })
         if result ~= nil or error ~= nil then return handle_tool_result(result, error) end
       end
-      if stop_opts.reason == "cancelled" then dispatch_cancel_message() end
+      if stop_opts.reason == "cancelled" then
+        stream_cancelled = true -- signal any running retry countdown to stop
+        -- Per-session flag: lets process_tool_use polling detect the cancel
+        -- without touching other instances' session_ctx.
+        opts.session_ctx.is_cancelled = true
+        dispatch_cancel_message()
+      end
       local history_messages = opts.get_history_messages and opts.get_history_messages({ all = true }) or {}
       local pending_tools, pending_tool_use_messages = History.get_pending_tools(history_messages)
       if stop_opts.reason == "complete" and Config.mode == "agentic" then
@@ -1993,10 +2008,12 @@ function M._stream(opts)
         Utils.info("Rate limit reached. Retrying in " .. retry_count .. " seconds", { title = "Avante" })
 
         local function countdown()
-          if abort_retry_timer then
+          -- stream_cancelled is set to true when on_stop fires with reason "cancelled"
+          -- (triggered by the CANCEL_PATTERN autocmd from cancel_inflight_request).
+          -- dispatch_cancel_message() is already called at that point; here we just stop.
+          if stream_cancelled then
             Utils.info("Retry aborted due to user requested cancellation.")
             stop_retry_timer()
-            dispatch_cancel_message()
             return
           end
 
@@ -2168,7 +2185,6 @@ function M.stream(opts)
 
   opts.mode = opts.mode or Config.mode
 
-  abort_retry_timer = false
   if Config.dual_boost.enabled and valid_dual_boost_modes[opts.mode] then
     M._dual_boost_stream(
       opts,
@@ -2181,13 +2197,15 @@ function M.stream(opts)
 end
 
 function M.cancel_inflight_request()
-  if LLMToolHelpers.is_cancelled ~= nil then LLMToolHelpers.is_cancelled = true end
+  -- Close any open confirmation popup immediately.
   if LLMToolHelpers.confirm_popup ~= nil then
     LLMToolHelpers.confirm_popup:cancel()
     LLMToolHelpers.confirm_popup = nil
   end
-  abort_retry_timer = true
-
+  -- Fire the CANCEL_PATTERN autocmd.  Each active _stream() invocation has registered
+  -- a once-handler that (a) shuts down the curl job and (b) calls on_stop({reason="cancelled"}),
+  -- which in turn sets session_ctx.is_cancelled=true so tool-execution polling stops,
+  -- and stream_cancelled=true so any running rate-limit retry countdown stops.
   api.nvim_exec_autocmds("User", { pattern = M.CANCEL_PATTERN })
 end
 

--- a/lua/avante/llm_tools/helpers.lua
+++ b/lua/avante/llm_tools/helpers.lua
@@ -7,14 +7,33 @@ local M = {}
 
 M.CANCEL_TOKEN = "__CANCELLED__"
 
--- Track cancellation state
+-- Track cancellation state (legacy global — prefer session_ctx.is_cancelled for new code).
+-- This flag is kept for backward compatibility with external callers but is no longer the
+-- primary cancellation signal; per-stream session_ctx._cancel_state is used instead.
 M.is_cancelled = false
 ---@type avante.ui.Confirm
 M.confirm_popup = nil
 
+--- Check whether the current execution has been cancelled.
+--- Prefers per-stream session_ctx (set via session_ctx.is_cancelled) over the legacy global.
+---@param session_ctx? table
+---@return boolean
+function M.check_cancelled(session_ctx)
+  if session_ctx then return session_ctx.is_cancelled == true end
+  return M.is_cancelled
+end
+
+--- Clear the cancellation flag for a session without touching the global.
+---@param session_ctx? table
+function M.reset_cancelled(session_ctx)
+  if session_ctx then session_ctx.is_cancelled = false end
+  -- Intentionally does NOT reset M.is_cancelled — the global is only reset at stream start.
+end
+
 ---@param rel_path string
 ---@return string
 function M.get_abs_path(rel_path)
+  if not rel_path then error("get_abs_path: path argument is nil", 2) end
   local project_root = Utils.get_project_root()
   local p = Utils.is_absolute_path(rel_path) and rel_path or vim.fs.normalize(vim.fs.joinpath(project_root, rel_path))
   if p:sub(-2) == "/." then p = p:sub(1, -3) end

--- a/lua/avante/path.lua
+++ b/lua/avante/path.lua
@@ -3,6 +3,7 @@ local Utils = require("avante.utils")
 local Path = require("plenary.path")
 local Scan = require("plenary.scandir")
 local Config = require("avante.config")
+local Names = require("avante.utils.names")
 
 ---@class avante.Path
 ---@field history_path string
@@ -128,6 +129,7 @@ end
 ---@param bufnr integer
 function History.new(bufnr)
   local filepath = History.get_latest_filepath(bufnr, true)
+  local instance_name = Names.generate()
   ---@type avante.ChatHistory
   local history = {
     title = "untitled",
@@ -136,6 +138,8 @@ function History.new(bufnr)
     messages = {},
     todos = {},
     filename = filepath_to_filename(filepath),
+    instance_id = Utils.uuid(),
+    instance_name = instance_name,
   }
   return history
 end
@@ -157,6 +161,14 @@ function History.from_file(filepath)
         if not vim.islist(history.todos) then history.todos = {} end
         ---@cast history avante.ChatHistory
         history.filename = filepath_to_filename(filepath)
+        -- Backfill instance_id / instance_name for histories created before this feature.
+        if not history.instance_id or history.instance_id == "" then history.instance_id = Utils.uuid() end
+        if not history.instance_name or history.instance_name == "" then
+          history.instance_name = Names.generate()
+        else
+          -- Register the persisted name so the collision table stays accurate.
+          Names.register(history.instance_name)
+        end
         return history
       end
     end

--- a/lua/avante/sidebar.lua
+++ b/lua/avante/sidebar.lua
@@ -124,6 +124,8 @@ local SIDEBAR_CONTAINERS = {
 ---@field containers { result?: NuiSplit, todos?: NuiSplit, selected_code?: NuiSplit, selected_files?: NuiSplit, input?: NuiSplit }
 ---@field file_selector FileSelector
 ---@field chat_history avante.ChatHistory | nil
+---@field current_history_filename string | nil Tracks which history file this sidebar is using; prevents concurrent instances from hijacking each other's session via the shared metadata.json pointer.
+---@field _chat_history_mtime integer | nil Disk mtime (seconds) of the history file at the last load/save; used to detect concurrent writes from other Avante instances.
 ---@field current_state avante.GenerateState | nil
 ---@field state_timer table | nil
 ---@field state_spinner_chars string[]
@@ -170,6 +172,13 @@ function Sidebar:new(id)
     file_selector = FileSelector:new(id),
     is_generating = false,
     chat_history = nil,
+    -- Tracks which history file THIS sidebar instance is using so that two
+    -- Avante instances open on the same project do not steal each other's
+    -- session when one of them saves or creates a new chat.
+    current_history_filename = nil,
+    -- mtime (seconds) of the history file as it was when last loaded or saved
+    -- by THIS instance. Used to detect concurrent writes from other instances.
+    _chat_history_mtime = nil,
     current_state = nil,
     state_timer = nil,
     state_spinner_chars = Config.windows.spinner.generating,
@@ -229,6 +238,9 @@ function Sidebar:reset()
   self.current_tool_use_extmark_id = nil
   self.win_size_store = {}
   self.is_in_full_view = false
+  -- Clear the pinned history filename so that initialize() -> reload_chat_history()
+  -- reads from metadata.json for whatever project/buffer is opened next.
+  self.current_history_filename = nil
 end
 
 ---@class SidebarOpenOptions: AskOptions
@@ -1120,7 +1132,9 @@ end
 
 function Sidebar:render_result()
   if not Utils.is_valid_container(self.containers.result) then return end
+  local instance_name = self.chat_history and self.chat_history.instance_name
   local header_text = Utils.icon("󰭻 ") .. "Avante"
+  if instance_name then header_text = header_text .. " [" .. instance_name .. "]" end
   self:render_header(
     self.containers.result.winid,
     self.containers.result.bufnr,
@@ -2352,6 +2366,16 @@ end
 
 function Sidebar:new_chat(args, cb)
   local history = Path.history.new(self.code.bufnr)
+  local Avante = require("avante")
+  -- Eagerly update the instance registry so other sidebars can find the new
+  -- name immediately, before the save -> reload cycle completes.
+  if self.chat_history and self.chat_history.instance_name then
+    Avante.instance_registry[self.chat_history.instance_name] = nil
+  end
+  if history.instance_name then Avante.instance_registry[history.instance_name] = self end
+  -- Pin this sidebar to the new file BEFORE saving so reload_chat_history()
+  -- uses the correct file and doesn't read a stale metadata.json value.
+  self.current_history_filename = history.filename
   Path.history.save(self.code.bufnr, history)
   self:reload_chat_history()
   self.current_state = nil
@@ -2368,7 +2392,7 @@ function Sidebar:new_chat(args, cb)
 end
 
 local debounced_save_history = Utils.debounce(
-  function(self) Path.history.save(self.code.bufnr, self.chat_history) end,
+  function(self) self:_save_chat_history() end,
   1000
 )
 
@@ -2605,8 +2629,87 @@ end
 function Sidebar:reload_chat_history()
   self.token_count = nil
   if not self.code.bufnr or not api.nvim_buf_is_valid(self.code.bufnr) then return end
-  self.chat_history = Path.history.load(self.code.bufnr)
+
+  local Avante = require("avante")
+  -- Deregister the old instance name before loading the new history so that
+  -- stale entries don't accumulate across /new cycles.
+  if self.chat_history and self.chat_history.instance_name then
+    Avante.instance_registry[self.chat_history.instance_name] = nil
+  end
+
+  -- Load the specific file this sidebar is pinned to (if any), so that a
+  -- concurrent Avante instance saving to the shared metadata.json cannot
+  -- hijack this sidebar's history.
+  self.chat_history = Path.history.load(self.code.bufnr, self.current_history_filename)
+
+  -- Isolation guard: if the history we just loaded is already owned by a
+  -- *different* live sidebar, fork to a fresh independent history.  This
+  -- prevents two Avante windows that share the same source buffer from
+  -- inheriting the same chat timeline, and guarantees each window gets a
+  -- unique instance_name for cross-instance messaging.
+  if self.chat_history and self.chat_history.instance_name then
+    local existing_owner = Avante.instance_registry[self.chat_history.instance_name]
+    if existing_owner ~= nil and existing_owner ~= self then
+      -- The loaded history is already in use -- branch off to a fresh session.
+      local fresh = Path.history.new(self.code.bufnr)
+      self.chat_history = fresh
+      self.current_history_filename = fresh.filename
+      self._chat_history_mtime = nil -- no disk file yet; suppress false conflicts
+    end
+  end
+
+  if self.chat_history then self.current_history_filename = self.chat_history.filename end
+  -- Record the disk mtime so _save_chat_history() can detect concurrent writes.
+  if self._chat_history_mtime == nil and self.current_history_filename then
+    local fp = Path.history.get_filepath(self.code.bufnr, self.current_history_filename)
+    local stat = vim.uv.fs_stat(tostring(fp))
+    self._chat_history_mtime = stat and stat.mtime.sec or nil
+  end
+  -- Register this sidebar under its (now-unique) instance name.
+  if self.chat_history and self.chat_history.instance_name then
+    Avante.instance_registry[self.chat_history.instance_name] = self
+  end
   self._history_cache_invalidated = true
+  -- Update the result header to reflect the (possibly new) instance name.
+  vim.schedule(function() self:render_result() end)
+end
+
+--- Save self.chat_history to disk, forking to a new file first when a
+--- concurrent Avante instance has modified the file since we last loaded it.
+function Sidebar:_save_chat_history()
+  if not self.chat_history or not self.code.bufnr then return end
+
+  -- Conflict detection: if the file on disk has a newer mtime, someone else wrote to it.
+  if self.current_history_filename and self._chat_history_mtime then
+    local fp = Path.history.get_filepath(self.code.bufnr, self.current_history_filename)
+    local stat = vim.uv.fs_stat(tostring(fp))
+    local disk_mtime = stat and stat.mtime.sec or nil
+    if disk_mtime and disk_mtime ~= self._chat_history_mtime then
+      -- Another instance wrote to our file. Branch to a new file.
+      local new_stub = Path.history.new(self.code.bufnr)
+      new_stub.title = self.chat_history.title
+      new_stub.timestamp = self.chat_history.timestamp
+      new_stub.entries = self.chat_history.entries
+      new_stub.messages = self.chat_history.messages
+      new_stub.todos = self.chat_history.todos
+      if self.chat_history.memory then new_stub.memory = self.chat_history.memory end
+      if self.chat_history.system_prompt then new_stub.system_prompt = self.chat_history.system_prompt end
+      if self.chat_history.tokens_usage then new_stub.tokens_usage = self.chat_history.tokens_usage end
+      if self.chat_history.acp_session_id then new_stub.acp_session_id = self.chat_history.acp_session_id end
+      self.chat_history = new_stub
+      self.current_history_filename = new_stub.filename
+      self._chat_history_mtime = nil
+    end
+  end
+
+  Path.history.save(self.code.bufnr, self.chat_history)
+
+  -- Update the stored mtime for the next conflict check.
+  if self.current_history_filename then
+    local fp = Path.history.get_filepath(self.code.bufnr, self.current_history_filename)
+    local stat = vim.uv.fs_stat(tostring(fp))
+    self._chat_history_mtime = stat and stat.mtime.sec or nil
+  end
 end
 
 ---@param opts? {all?: boolean}
@@ -2982,10 +3085,9 @@ function Sidebar:handle_submit(request)
       end,
       set_tool_use_store = set_tool_use_store,
       get_history_messages = function(opts) return self:get_history_messages_for_api(opts) end,
-      get_todos = function()
-        local history = Path.history.load(self.code.bufnr)
-        return history.todos
-      end,
+      -- Use in-memory todos to avoid a disk read that could race with another
+      -- Avante instance and return a different session's todos.
+      get_todos = function() return self.chat_history and self.chat_history.todos or {} end,
       update_todos = function(todos) self:update_todos(todos) end,
       session_ctx = {},
       ---@param usage avante.LLMTokenUsage
@@ -3230,8 +3332,10 @@ function Sidebar:get_selected_code_container_height()
 end
 
 function Sidebar:get_todos_container_height()
-  local history = Path.history.load(self.code.bufnr)
-  if #history.todos == 0 then return 0 end
+  -- Use the in-memory chat_history to avoid a disk read that could return a
+  -- different instance's file via the shared metadata.json pointer.
+  local todos = self.chat_history and self.chat_history.todos or {}
+  if #todos == 0 then return 0 end
   return 3
 end
 
@@ -3338,6 +3442,10 @@ function Sidebar:render(opts)
           if not self.code.winid or not api.nvim_win_is_valid(self.code.winid) then return end
           local bufnr = api.nvim_win_get_buf(self.code.winid)
           self.code.bufnr = bufnr
+          -- The code buffer changed (different project/root), so let
+          -- reload_chat_history() pick up the correct file from metadata.json
+          -- for the new buffer rather than staying pinned to the old file.
+          self.current_history_filename = nil
           self:reload_chat_history()
         end)
       end,
@@ -3531,7 +3639,9 @@ function Sidebar:create_selected_files_container()
 end
 
 function Sidebar:create_todos_container()
-  local history = Path.history.load(self.code.bufnr)
+  -- Use in-memory history to avoid loading from disk (which would follow
+  -- the shared metadata.json and could pull in another instance's file).
+  local history = self.chat_history or Path.history.load(self.code.bufnr, self.current_history_filename)
   if #history.todos == 0 then
     if self.containers.todos and Utils.is_valid_container(self.containers.todos) then
       self.containers.todos:unmount()

--- a/lua/avante/sidebar.lua
+++ b/lua/avante/sidebar.lua
@@ -259,8 +259,16 @@ function Sidebar:open(opts)
     self:focus()
   else
     if in_visual_mode or opts.selection then
+      -- Preserve the history pin across the close/reset cycle so that this
+      -- sidebar does not lose its identity and fall back to reading
+      -- metadata.json (a shared last-writer-wins pointer that races between
+      -- all concurrent instances).  reset() was designed to clear the pin
+      -- only when the sidebar is truly starting from scratch (first open);
+      -- for visual-mode re-renders we are staying in the same session.
+      local saved_filename = self.current_history_filename
       self:close()
       self:reset()
+      self.current_history_filename = saved_filename
       self:initialize()
       if opts.selection then self.code.selection = opts.selection end
       self:render(opts)
@@ -3448,12 +3456,20 @@ function Sidebar:render(opts)
       on_detach = function(_, _)
         vim.schedule(function()
           if not self.code.winid or not api.nvim_win_is_valid(self.code.winid) then return end
-          local bufnr = api.nvim_win_get_buf(self.code.winid)
-          self.code.bufnr = bufnr
-          -- The code buffer changed (different project/root), so let
-          -- reload_chat_history() pick up the correct file from metadata.json
-          -- for the new buffer rather than staying pinned to the old file.
-          self.current_history_filename = nil
+          local old_root = Utils.root.get({ buf = self.code.bufnr })
+          local new_bufnr = api.nvim_win_get_buf(self.code.winid)
+          local new_root = Utils.root.get({ buf = new_bufnr })
+          self.code.bufnr = new_bufnr
+          -- Only drop the history pin when the buffer genuinely moved to a
+          -- different project root.  Within the same project the pin MUST be
+          -- kept so that reload_chat_history() continues to load *this*
+          -- instance's own file instead of reading metadata.json — which is a
+          -- shared, last-writer-wins pointer that races between all concurrent
+          -- instances saving their histories.  Without this guard, any buffer
+          -- detach (e.g. :bdelete of a file in the same project) would clear
+          -- the pin and cause the sidebar to converge onto whichever instance
+          -- wrote metadata.json most recently.
+          if old_root ~= new_root then self.current_history_filename = nil end
           self:reload_chat_history()
         end)
       end,

--- a/lua/avante/sidebar.lua
+++ b/lua/avante/sidebar.lua
@@ -2696,6 +2696,14 @@ function Sidebar:_save_chat_history()
       if self.chat_history.system_prompt then new_stub.system_prompt = self.chat_history.system_prompt end
       if self.chat_history.tokens_usage then new_stub.tokens_usage = self.chat_history.tokens_usage end
       if self.chat_history.acp_session_id then new_stub.acp_session_id = self.chat_history.acp_session_id end
+      -- Preserve the instance identity (name + id).  This is a file-level fork
+      -- only — the logical session and its human-readable name must NOT change.
+      -- Path.history.new() generates a fresh random name; release it and keep
+      -- the existing one so the sidebar header and IPC registration stay stable.
+      local Names = require("avante.utils.names")
+      Names.release(new_stub.instance_name)
+      new_stub.instance_name = self.chat_history.instance_name
+      new_stub.instance_id = self.chat_history.instance_id
       self.chat_history = new_stub
       self.current_history_filename = new_stub.filename
       self._chat_history_mtime = nil

--- a/lua/avante/tokenizers.lua
+++ b/lua/avante/tokenizers.lua
@@ -55,7 +55,7 @@ function M.encode(prompt)
   local success, result = pcall(tokenizers.encode, prompt)
   -- Some output like terminal command output might not be utf-8 encoded, which will cause an error here
   if not success then
-    Utils.warn("Failed to encode prompt: " .. result)
+    Utils.warn("Failed to encode prompt: " .. tostring(result))
     return nil
   end
   return result

--- a/lua/avante/types.lua
+++ b/lua/avante/types.lua
@@ -118,7 +118,8 @@ vim.g.avante_login = vim.g.avante_login
 ---@field turn_id string | nil
 ---@field is_calling boolean | nil
 ---@field original_content AvanteLLMMessageContent | nil
----@field acp_tool_call? avante.acp.ToolCall | avante.acp.ToolCallUpdate
+---@field acp_tool_call? avante.acp.ToolCall
+---@field from_instance string | nil   -- instance_name of the sending chat (cross-instance message)
 
 ---@class AvanteLLMToolResult
 ---@field tool_name string
@@ -526,6 +527,8 @@ vim.g.avante_login = vim.g.avante_login
 ---@field system_prompt string | nil
 ---@field tokens_usage avante.LLMTokenUsage | nil
 ---@field acp_session_id string | nil
+---@field instance_id string | nil   -- UUID for this chat session
+---@field instance_name string | nil -- human-readable name (e.g. "swift-fox")
 ---
 ---@class avante.ChatMemory
 ---@field content string
@@ -542,7 +545,7 @@ vim.g.avante_login = vim.g.avante_login
 ---@field content string
 ---@field uri string
 ---
----@alias AvanteSlashCommandBuiltInName "clear" | "help" | "lines" | "commit" | "new" | "init" | "compact" | "model"
+---@alias AvanteSlashCommandBuiltInName "clear" | "help" | "lines" | "commit" | "new" | "init" | "compact" | "model" | "simplify" | "send"
 ---@alias AvanteSlashCommandCallback fun(self: avante.Sidebar, args: string, cb?: fun(args: string): nil): nil
 ---@class AvanteSlashCommand
 ---@field name AvanteSlashCommandBuiltInName | string

--- a/lua/avante/utils/names.lua
+++ b/lua/avante/utils/names.lua
@@ -1,0 +1,73 @@
+---@mod avante-names avante instance name generation
+---@brief [[
+--- Generates human-readable, memorable names for Avante chat instances.
+--- Each name is an adjective + noun combination chosen at random.
+---@brief ]]
+
+local M = {}
+
+-- Word lists for generating friendly instance names.
+local adjectives = {
+  "amber", "azure", "bold", "bright", "calm", "cedar", "cobalt", "cool",
+  "crisp", "cyan", "dark", "deep", "dim", "dusk", "fern", "firm", "flame",
+  "free", "frost", "gold", "jade", "keen", "light", "lime", "mist", "mint",
+  "moon", "moss", "navy", "noir", "oak", "pale", "pine", "pure", "quick",
+  "rose", "ruby", "sage", "salt", "sand", "silk", "slim", "snow", "soft",
+  "solar", "steel", "storm", "swift", "teal", "warm", "wild", "wise",
+}
+
+local nouns = {
+  "arc", "ash", "bay", "beam", "bell", "brook", "crest", "crow", "dawn",
+  "dune", "elm", "fern", "field", "finch", "fjord", "flame", "flare", "fox",
+  "gale", "glen", "grove", "hawk", "hill", "jade", "kite", "lake", "lark",
+  "leaf", "lynx", "marsh", "moon", "oak", "owl", "peak", "pine", "pond",
+  "raven", "reef", "ridge", "rift", "river", "rock", "seal", "sky", "spark",
+  "stone", "stream", "tide", "vale", "wave", "wren",
+}
+
+--- Registry of all names currently in use to avoid collisions.
+---@type table<string, boolean>
+local used_names = {}
+
+--- Generate a unique adjective-noun instance name.
+--- If a collision occurs the noun is suffixed with a counter (e.g. "swift-fox-2").
+---@return string
+function M.generate()
+  math.randomseed(os.time() + math.random(1000))
+  local max_attempts = 20
+  for _ = 1, max_attempts do
+    local adj = adjectives[math.random(#adjectives)]
+    local noun = nouns[math.random(#nouns)]
+    local name = adj .. "-" .. noun
+    if not used_names[name] then
+      used_names[name] = true
+      return name
+    end
+  end
+  -- Fallback: append a random number to guarantee uniqueness.
+  local adj = adjectives[math.random(#adjectives)]
+  local noun = nouns[math.random(#nouns)]
+  local counter = 2
+  local candidate = adj .. "-" .. noun .. "-" .. counter
+  while used_names[candidate] do
+    counter = counter + 1
+    candidate = adj .. "-" .. noun .. "-" .. counter
+  end
+  used_names[candidate] = true
+  return candidate
+end
+
+--- Mark a name as in use (for names loaded from persisted history).
+---@param name string
+function M.register(name)
+  if name and name ~= "" then used_names[name] = true end
+end
+
+--- Release a name so it may be reused.
+---@param name string
+function M.release(name)
+  if name and name ~= "" then used_names[name] = nil end
+end
+
+return M
+


### PR DESCRIPTION
## Summary

Prevents two concurrent Avante windows from clobbering each other's chat history, and gives each chat session a unique human-readable name shown in the winbar.

**Instance naming** (`utils/names.lua`):
- New module generates unique adjective-noun names (e.g. `"swift-fox"`, `"amber-ridge"`) with collision detection
- `path.lua`: every new chat gets a fresh `instance_name` and `instance_id` (UUID); older histories are backfilled on load
- Winbar shows `Avante [swift-fox]` so users can immediately identify which window they're in

**Session isolation** (`sidebar.lua`, `llm.lua`):
- Each `Sidebar` is pinned to a specific history file (`current_history_filename`); all reads use this pin instead of following the shared `metadata.json` pointer
- `_chat_history_mtime` detects concurrent writes from another instance; on conflict the session forks to a fresh file, preserving all in-memory messages
- `reload_chat_history()` applies an isolation guard: if the loaded history is already owned by a different live sidebar, it forks to a fresh session immediately
- `get_todos`, `get_todos_container_height`, `create_todos_container` read from `self.chat_history` directly (no disk read that could return the wrong instance's file)
- Per-stream `retry_timer` and `stream_cancelled` locals in `_stream()` prevent concurrent instances from clobbering each other's rate-limit countdown
- `session_ctx.is_cancelled` provides per-stream cancellation isolation

**Instance registry** (`init.lua`):
- `M.instance_registry` (name → Sidebar) enables in-process cross-instance lookup; updated by `reload_chat_history()` and cleaned up on tab close

## Test plan
- [ ] Open two Avante sidebars on the same project and confirm each shows a different name in the winbar
- [ ] Verify that sending a message in one window does not corrupt the other's history
- [ ] Confirm `/new` chat generates a new name and updates the winbar