### PR TITLE
feat: async parallel dispatch_agent system with cost-aware provider selection

### DIFF
--- a/ftplugin/AvanteInput.lua
+++ b/ftplugin/AvanteInput.lua
@@ -15,7 +15,9 @@ api.nvim_create_autocmd("InsertEnter", {
 })
 
 local debounced_show_input_hint = Utils.debounce(function()
-  if vim.api.nvim_win_is_valid(sidebar.containers.input.winid) then sidebar:show_input_hint() end
+  if sidebar.containers.input and vim.api.nvim_win_is_valid(sidebar.containers.input.winid) then
+    sidebar:show_input_hint()
+  end
 end, 200)
 api.nvim_create_autocmd({ "TextChanged", "TextChangedI", "VimResized" }, {
   group = sidebar.augroup,

--- a/lua/avante/config.lua
+++ b/lua/avante/config.lua
@@ -328,9 +328,6 @@ M.instructions_file = "avante.md"
 ---@field behaviour avante.Config.Behaviour Behaviour and automation options.
 ---@field prompt_logger avante.Config.PromptLogger Prompt logging options.
 ---@field windows table
----@field slash_commands AvanteSlashCommand[] see |*avante-slashcommands*|
----@field shortcuts AvanteShortcut[]  see |*avante-shortcuts*|
----@field ask_opts AskOptions
 
 M._defaults = {
   debug = false,
@@ -599,6 +596,8 @@ M._defaults = {
       model = "gpt-4o",
       timeout = 30000,
       context_window = 128000, -- Number of tokens to send to the model for context
+      cost_per_input_token = 0.0000025, -- $2.50 per 1M tokens
+      cost_per_output_token = 0.00001, -- $10 per 1M tokens
       use_response_api = copilot_use_response_api, -- Automatically switch to Response API for GPT-5 Codex models
       support_previous_response_id = true, -- OpenAI Response API supports previous_response_id for stateful conversations
       extra_request_body = {
@@ -617,6 +616,8 @@ M._defaults = {
       allow_insecure = false, -- Allow insecure server connections
       timeout = 30000, -- Timeout in milliseconds
       context_window = 64000, -- Number of tokens to send to the model for context
+      cost_per_input_token = 0, -- Free with GitHub Copilot subscription
+      cost_per_output_token = 0,
       use_response_api = copilot_use_response_api, -- Automatically switch to Response API for GPT-5 Codex models
       support_previous_response_id = false, -- Copilot doesn't support previous_response_id, must send full history
       -- NOTE: Copilot doesn't support previous_response_id, always sends full conversation history including tool_calls
@@ -645,6 +646,8 @@ M._defaults = {
       model = "claude-sonnet-4-5-20250929",
       timeout = 30000, -- Timeout in milliseconds
       context_window = 200000,
+      cost_per_input_token = 0.000003, -- $3 per 1M tokens
+      cost_per_output_token = 0.000015, -- $15 per 1M tokens
       extra_request_body = {
         temperature = 0.75,
         max_tokens = 64000,
@@ -675,6 +678,8 @@ M._defaults = {
       model = "gemini-2.0-flash",
       timeout = 30000, -- Timeout in milliseconds
       context_window = 1048576,
+      cost_per_input_token = 0.0000001, -- $0.10 per 1M tokens
+      cost_per_output_token = 0.0000004, -- $0.40 per 1M tokens
       use_ReAct_prompt = true,
       extra_request_body = {
         generationConfig = {
@@ -688,6 +693,8 @@ M._defaults = {
       model = "gemini-1.5-flash-002",
       timeout = 30000, -- Timeout in milliseconds
       context_window = 1048576,
+      cost_per_input_token = 0.000000075, -- $0.075 per 1M tokens
+      cost_per_output_token = 0.0000003, -- $0.30 per 1M tokens
       use_ReAct_prompt = true,
       extra_request_body = {
         generationConfig = {
@@ -709,6 +716,8 @@ M._defaults = {
     ollama = {
       endpoint = "http://127.0.0.1:11434",
       timeout = 30000, -- Timeout in milliseconds
+      cost_per_input_token = 0, -- Local model, free
+      cost_per_output_token = 0,
       use_ReAct_prompt = true,
       extra_request_body = {
         options = {
@@ -744,6 +753,8 @@ M._defaults = {
       endpoint = "https://api.anthropic.com",
       model = "claude-3-5-haiku-20241022",
       timeout = 30000, -- Timeout in milliseconds
+      cost_per_input_token = 0.0000008, -- $0.80 per 1M tokens
+      cost_per_output_token = 0.000004, -- $4 per 1M tokens
       extra_request_body = {
         temperature = 0.75,
         max_tokens = 8192,
@@ -755,6 +766,8 @@ M._defaults = {
       endpoint = "https://api.anthropic.com",
       model = "claude-3-opus-20240229",
       timeout = 30000, -- Timeout in milliseconds
+      cost_per_input_token = 0.000015, -- $15 per 1M tokens
+      cost_per_output_token = 0.000075, -- $75 per 1M tokens
       extra_request_body = {
         temperature = 0.75,
         max_tokens = 20480,
@@ -763,6 +776,8 @@ M._defaults = {
     ["openai-gpt-4o-mini"] = {
       __inherited_from = "openai",
       model = "gpt-4o-mini",
+      cost_per_input_token = 0.00000015, -- $0.15 per 1M tokens
+      cost_per_output_token = 0.0000006, -- $0.60 per 1M tokens
     },
     aihubmix = {
       __inherited_from = "openai",
@@ -1087,11 +1102,22 @@ M._defaults = {
     debounce = 600,
     throttle = 600,
   },
+  --- Dispatch agent configuration
+  --- Controls how dispatch_agent selects providers for sub-tasks
+  dispatch = {
+    --- Maximum ratio of a provider's context_window that a dispatch request+file may occupy.
+    --- The cheapest provider whose context fits the payload within this ratio is selected.
+    --- @type number
+    max_context_ratio = 0.6,
+  },
   disabled_tools = {},
   ---@type AvanteLLMToolPublic[] | fun(): AvanteLLMToolPublic[]
   custom_tools = {},
+  ---@type AvanteSlashCommand[]
   slash_commands = {},
+  ---@type AvanteShortcut[]
   shortcuts = {},
+  ---@type AskOptions
   ask_opts = {},
 }
 
@@ -1099,7 +1125,6 @@ M._defaults = {
 ---@diagnostic disable-next-line: missing-fields
 M._options = {}
 
----@diagnostic disable-next-line: param-type-mismatch
 local function get_config_dir_path() return vim.fs.joinpath(vim.fn.expand("~"), ".config", "avante.nvim") end
 local function get_config_file_path() return vim.fs.joinpath(get_config_dir_path(), "config.json") end
 

--- a/lua/avante/dispatch_registry.lua
+++ b/lua/avante/dispatch_registry.lua
@@ -1,0 +1,221 @@
+--- Dispatch registry: tracks all dispatched sub-agents across the sidebar session.
+---
+--- Each dispatch is fire-and-forget from the primary chat's perspective.  The
+--- registry provides:
+---   * `register()`   - create a new dispatch entry (status = "running")
+---   * `complete()`   - mark a dispatch as done and store its result
+---   * `fail()`       - mark a dispatch as failed
+---   * `get()`        - retrieve a single dispatch by id
+---   * `get_all()`    - all dispatches for a session
+---   * `get_context()` - formatted string for injection into prompts
+---   * `pick_cheapest_provider()` - select lowest-cost provider that fits payload
+
+local Config = require("avante.config")
+local Providers = require("avante.providers")
+
+---@class avante.Dispatch
+---@field id string
+---@field prompt string
+---@field status "running" | "completed" | "failed"
+---@field last_message string
+---@field result string | nil
+---@field error string | nil
+---@field provider string | nil
+---@field model string | nil
+---@field created_at number
+---@field completed_at number | nil
+
+---@class avante.DispatchRegistry
+local M = {}
+
+---@type table<string, avante.Dispatch[]>
+M._sessions = {}
+
+---@type table<string, integer>
+M._counters = {}
+
+---@type table<string, fun(dispatch: avante.Dispatch): nil>
+M._on_complete_callbacks = {}
+
+---@param session_id string
+---@param cb fun(dispatch: avante.Dispatch): nil
+function M.set_on_complete(session_id, cb) M._on_complete_callbacks[session_id] = cb end
+
+--- Register a new dispatch and return its id.
+---@param session_id string
+---@param prompt string
+---@param provider_name? string
+---@param model_name? string
+---@return string dispatch_id
+function M.register(session_id, prompt, provider_name, model_name)
+  if not M._sessions[session_id] then
+    M._sessions[session_id] = {}
+    M._counters[session_id] = 0
+  end
+  M._counters[session_id] = M._counters[session_id] + 1
+  local id = tostring(M._counters[session_id])
+  ---@type avante.Dispatch
+  local dispatch = {
+    id = id,
+    prompt = prompt,
+    status = "running",
+    last_message = "Starting...",
+    result = nil,
+    error = nil,
+    provider = provider_name,
+    model = model_name,
+    created_at = os.clock(),
+    completed_at = nil,
+  }
+  table.insert(M._sessions[session_id], dispatch)
+  return id
+end
+
+--- Update the "last_message" for a running dispatch (progress reporting).
+---@param session_id string
+---@param dispatch_id string
+---@param message string
+function M.update_progress(session_id, dispatch_id, message)
+  local dispatch = M.get(session_id, dispatch_id)
+  if dispatch then dispatch.last_message = message end
+end
+
+--- Mark a dispatch as completed.
+---@param session_id string
+---@param dispatch_id string
+---@param result string
+function M.complete(session_id, dispatch_id, result)
+  local dispatch = M.get(session_id, dispatch_id)
+  if not dispatch then return end
+  dispatch.status = "completed"
+  dispatch.result = result
+  dispatch.last_message = "Completed"
+  dispatch.completed_at = os.clock()
+  local cb = M._on_complete_callbacks[session_id]
+  if cb then vim.schedule(function() cb(dispatch) end) end
+end
+
+--- Mark a dispatch as failed.
+---@param session_id string
+---@param dispatch_id string
+---@param error_msg string
+function M.fail(session_id, dispatch_id, error_msg)
+  local dispatch = M.get(session_id, dispatch_id)
+  if not dispatch then return end
+  dispatch.status = "failed"
+  dispatch.error = error_msg
+  dispatch.last_message = "Failed: " .. error_msg
+  dispatch.completed_at = os.clock()
+  local cb = M._on_complete_callbacks[session_id]
+  if cb then vim.schedule(function() cb(dispatch) end) end
+end
+
+--- Retrieve a single dispatch.
+---@param session_id string
+---@param dispatch_id string
+---@return avante.Dispatch | nil
+function M.get(session_id, dispatch_id)
+  local dispatches = M._sessions[session_id]
+  if not dispatches then return nil end
+  for _, d in ipairs(dispatches) do
+    if d.id == dispatch_id then return d end
+  end
+  return nil
+end
+
+--- Retrieve all dispatches for a session.
+---@param session_id string
+---@return avante.Dispatch[]
+function M.get_all(session_id) return M._sessions[session_id] or {} end
+
+--- Build a human-readable context block describing all active and recently
+--- completed dispatches. Injected into prompts so the primary agent knows
+--- what is in flight.
+---@param session_id string
+---@return string
+function M.get_context(session_id)
+  local dispatches = M._sessions[session_id]
+  if not dispatches or #dispatches == 0 then return "" end
+
+  -- Count running dispatches so we can advise the agent how to proceed.
+  local running_count = 0
+  for _, d in ipairs(dispatches) do
+    if d.status == "running" then running_count = running_count + 1 end
+  end
+
+  local lines = { "## Active & Recent Dispatches" }
+  if running_count > 0 then
+    table.insert(
+      lines,
+      string.format(
+        "%d dispatch(es) still running. If your only remaining work is to wait on them, "
+          .. "call `dispatch_await` (NOT `dispatch_status` in a loop). `dispatch_await` blocks "
+          .. "until one finishes, returns its full result inline, and compacts the polling "
+          .. "noise out of your context.",
+        running_count
+      )
+    )
+  end
+  for _, d in ipairs(dispatches) do
+    local status_icon = d.status == "running" and "running" or d.status == "completed" and "completed" or "failed"
+    local prompt_preview = d.prompt:sub(1, 120) .. (#d.prompt > 120 and "..." or "")
+    local summary = string.format("- Dispatch #%s [%s]: %s", d.id, status_icon, prompt_preview)
+    table.insert(lines, summary)
+    if d.status == "running" then
+      table.insert(lines, "  Last update: " .. d.last_message)
+    elseif d.status == "completed" and d.result then
+      local result_preview = d.result:sub(1, 2000)
+      if #d.result > 2000 then result_preview = result_preview .. "\n...[truncated]" end
+      table.insert(lines, "  Result: " .. result_preview)
+    elseif d.status == "failed" and d.error then
+      table.insert(lines, "  Error: " .. d.error)
+    end
+  end
+
+  return table.concat(lines, "\n")
+end
+
+--- Remove all dispatches for a session (e.g. on sidebar close).
+---@param session_id string
+function M.clear(session_id)
+  M._sessions[session_id] = nil
+  M._counters[session_id] = nil
+  M._on_complete_callbacks[session_id] = nil
+end
+
+--- Pick the cheapest provider whose context_window can fit the given
+--- token count within the configured max_context_ratio.
+--- Returns nil if no provider fits.
+---@param estimated_tokens integer
+---@return string | nil provider_name
+---@return table | nil provider_config
+function M.pick_cheapest_provider(estimated_tokens)
+  local dispatch_config = Config.dispatch or {}
+  local max_ratio = dispatch_config.max_context_ratio or 0.6
+
+  ---@type {name: string, config: AvanteDefaultBaseProvider, cost: number}[]
+  local candidates = {}
+
+  for name, _ in pairs(Config.providers) do
+    local ok, provider_conf = pcall(function() return Providers.parse_config(Providers.get_config(name)) end)
+    if ok and provider_conf then
+      local context_window = provider_conf.context_window
+      if context_window and context_window > 0 then
+        local max_allowed = math.floor(context_window * max_ratio)
+        if estimated_tokens <= max_allowed then
+          local cost = provider_conf.cost_per_input_token or math.huge
+          table.insert(candidates, { name = name, config = provider_conf, cost = cost })
+        end
+      end
+    end
+  end
+
+  if #candidates == 0 then return nil, nil end
+
+  table.sort(candidates, function(a, b) return a.cost < b.cost end)
+
+  local best = candidates[1]
+  return best.name, best.config
+end
+
+return M

--- a/lua/avante/llm.lua
+++ b/lua/avante/llm.lua
@@ -11,6 +11,7 @@ local Config = require("avante.config")
 local Path = require("avante.path")
 local Providers = require("avante.providers")
 local LLMToolHelpers = require("avante.llm_tools.helpers")
+local DispatchRegistry = require("avante.dispatch_registry")
 local LLMTools = require("avante.llm_tools")
 local History = require("avante.history")
 local HistoryRender = require("avante.history.render")
@@ -461,6 +462,14 @@ function M.generate_prompts(opts)
   if agents_rules then system_prompt = system_prompt .. "\n\n" .. agents_rules end
   local cursor_rules = Prompts.get_cursor_rules_prompt(selected_files)
   if cursor_rules then system_prompt = system_prompt .. "\n\n" .. cursor_rules end
+
+  -- Inject dispatch agent status context so the primary agent knows what is in-flight
+  if opts.session_ctx and opts.session_ctx.dispatch_session_id then
+    local dispatch_context = DispatchRegistry.get_context(opts.session_ctx.dispatch_session_id)
+    if dispatch_context and dispatch_context ~= "" then
+      system_prompt = system_prompt .. "\n\n" .. dispatch_context
+    end
+  end
 
   ---@type AvantePromptOptions
   return {

--- a/lua/avante/llm_tools/dispatch_agent.lua
+++ b/lua/avante/llm_tools/dispatch_agent.lua
@@ -5,6 +5,7 @@ local Base = require("avante.llm_tools.base")
 local History = require("avante.history")
 local Line = require("avante.ui.line")
 local Highlights = require("avante.highlights")
+local DispatchRegistry = require("avante.dispatch_registry")
 
 ---@class AvanteLLMTool
 local M = setmetatable({}, Base)
@@ -14,30 +15,49 @@ M.name = "dispatch_agent"
 M.get_description = function()
   local provider = Providers[Config.provider]
   if Config.provider:match("copilot") and provider.model and provider.model:match("gpt") then
-    return [[Launch a new agent that has access to the following tools: `glob`, `grep`, `ls`, `view`, `attempt_completion`. When you are searching for a keyword or file and are not confident that you will find the right match on the first try, use the Agent tool to perform the search for you.]]
+    return [[Launch a new agent that has access to the following tools: `glob`, `grep`, `ls`, `view`, `attempt_completion`. Use dispatch_agent when you need to search for keywords, files, or patterns across the codebase, or gather and SYNTHESIZE context while you continue working on other tasks.
+
+IMPORTANT: dispatch_agent is ASYNCHRONOUS. It returns immediately with a dispatch ID. The sub-agent runs in the background. Results will be delivered to you automatically when the dispatch completes. You can continue working on other tasks while dispatches are running. Check the dispatch status section at the top of the conversation for updates.
+
+KEY RULE: The sub-agent must REDUCE and SYNTHESIZE information — it must NOT dump raw file contents. Ask specific questions; get concise answers back.]]
   end
 
-  return [[Launch a new agent that has access to the following tools: `glob`, `grep`, `ls`, `view`, `attempt_completion`. When you are searching for a keyword or file and are not confident that you will find the right match on the first try, use the Agent tool to perform the search for you. For example:
+  return [[Launch a new agent that has access to the following tools: `glob`, `grep`, `ls`, `view`, `attempt_completion`. Use dispatch_agent when you need to:
 
-- If you are searching for a keyword like "config" or "logger", the Agent tool is appropriate
-- If you want to read a specific file path, use the `view` or `glob` tool instead of the `dispatch_agent` tool, to find the match more quickly
-- If you are searching for a specific class definition like "class Foo", use the `glob` tool instead, to find the match more quickly
+- Search for keywords, files, or patterns across the codebase
+- Gather and SYNTHESIZE context while you continue working on other tasks
 
-RULES:
-- Do not ask for more information than necessary. Use the tools provided to accomplish the user's request efficiently and effectively. When you've completed your task, you must use the attempt_completion tool to present the result to the user. The user may provide feedback, which you can use to make improvements and try again.
-- NEVER end attempt_completion result with a question or request to engage in further conversation! Formulate the end of your result in a way that is final and does not require further input from the user.
-
-OBJECTIVE:
-1. Analyze the user's task and set clear, achievable goals to accomplish it. Prioritize these goals in a logical order.
-2. Work through these goals sequentially, utilizing available tools one at a time as necessary. Each goal should correspond to a distinct step in your problem-solving process. You will be informed on the work completed and what's remaining as you go.
-3. Once you've completed the user's task, you must use the attempt_completion tool to present the result of the task to the user. You may also provide a CLI command to showcase the result of your task; this can be particularly useful for web development tasks, where you can run e.g. \`open index.html\` to show the website you've built.
+IMPORTANT RULES:
+- dispatch_agent is ASYNCHRONOUS and FIRE-AND-FORGET. It returns immediately with a dispatch ID.
+- The sub-agent runs in the background. You do NOT wait for results.
+- Results are delivered to you automatically when the dispatch completes (appears as a message in the conversation).
+- You can dispatch MULTIPLE agents concurrently for maximum parallelism.
+- Check the "Active & Recent Dispatches" section in your context for status updates.
+- Continue working on other tasks while dispatches are running.
+- Each dispatch invocation is stateless - provide all context the agent needs in the prompt.
 
 Usage notes:
-1. Launch multiple agents concurrently whenever possible, to maximize performance; to do that, use a single message with multiple tool uses
-2. When the agent is done, it will return a single message back to you. The result returned by the agent is not visible to the user. To show the user the result, you should send a text message back to the user with a concise summary of the result.
-3. Each agent invocation is stateless. You will not be able to send additional messages to the agent, nor will the agent be able to communicate with you outside of its final report. Therefore, your prompt should contain a highly detailed task description for the agent to perform autonomously and you should specify exactly what information the agent should return back to you in its final and only message to you.
-4. The agent's outputs should generally be trusted
-5. IMPORTANT: The agent can not use `bash`, `write`, `str_replace`, so can not modify files. If you want to use these tools, use them directly instead of going through the agent.]]
+1. Launch multiple dispatches concurrently whenever possible for maximum performance.
+2. When a dispatch is done, its result will appear in your conversation context automatically.
+3. If your only remaining work is to wait for dispatch results, DO NOT poll `dispatch_status`
+   in a loop. Instead call `dispatch_await` once — it blocks until the next dispatch finishes,
+   returns its full result inline, and compacts the polling noise out of your context.
+4. Your prompt should ask SPECIFIC QUESTIONS — the agent must return synthesized answers, not raw file dumps.
+5. The agent can NOT use `bash`, `write`, `str_replace` - it can only read/search files.
+6. The agent will use the cheapest available LLM provider that can fit the workload within its context window.
+
+## CRITICAL: The sub-agent's job is to REDUCE context, not amplify it.
+
+BAD prompt (wastes tokens — agent reads a file and dumps it back verbatim):
+  "Read lib/store.ts and return its complete contents"
+  "Read the following files in FULL and return their content verbatim: ..."
+
+GOOD prompt (agent searches, synthesizes, and returns only what matters):
+  "In lib/store.ts, find the VideoEntry type definition — list its field names and types only"
+  "In lib/processing.ts, what function handles face detection? What are its inputs/outputs?"
+  "Search for all callers of updateVideo() across the codebase and list them with file:line"
+
+If you just need to read a file yourself, use the `view` tool directly — do NOT dispatch an agent just to pass file contents back to you.]]
 end
 
 ---@type AvanteLLMToolParam
@@ -46,13 +66,17 @@ M.param = {
   fields = {
     {
       name = "prompt",
-      description = "The task for the agent to perform",
+      description = "A specific question or set of questions for the agent to research and answer. "
+        .. "The agent must SYNTHESIZE and REDUCE information — do NOT ask it to return raw file contents. "
+        .. "Ask targeted questions like 'What fields does the VideoEntry type have?' or "
+        .. "'What function handles face detection in lib/processing.ts and what are its parameters?' "
+        .. "instead of 'Read lib/store.ts and return it verbatim'.",
       type = "string",
     },
   },
   required = { "prompt" },
   usage = {
-    prompt = "The task for the agent to perform",
+    prompt = "Specific question(s) for the agent to research and synthesize (NOT a request to dump raw file contents)",
   },
 }
 
@@ -60,12 +84,12 @@ M.param = {
 M.returns = {
   {
     name = "result",
-    description = "The result of the agent",
+    description = "The dispatch ID and status message (agent runs asynchronously)",
     type = "string",
   },
   {
     name = "error",
-    description = "The error message if the agent fails",
+    description = "The error message if the dispatch could not be started",
     type = "string",
     optional = true,
   },
@@ -81,6 +105,17 @@ local function get_available_tools()
   }
 end
 
+--- Estimate tokens for a string (rough: ~1.3 tokens per word)
+---@param text string
+---@return integer
+local function estimate_tokens(text)
+  local words = 0
+  for _ in text:gmatch("%S+") do
+    words = words + 1
+  end
+  return math.ceil(words * 1.3)
+end
+
 ---@class avante.DispatchAgentInput
 ---@field prompt string
 
@@ -89,6 +124,7 @@ function M.on_render(input, opts)
   local result_message = opts.result_message
   local store = opts.store or {}
   local messages = store.messages or {}
+  local dispatch_id = store.dispatch_id
   local tool_use_summary = {}
   for _, msg in ipairs(messages) do
     local summary
@@ -138,31 +174,32 @@ function M.on_render(input, opts)
           end
         end
       end
-      if summary then summary = "  " .. Utils.icon("🛠️ ") .. summary end
+      if summary then summary = "  " .. Utils.icon("tool ") .. summary end
     else
       summary = History.Helpers.get_text_data(msg)
     end
     if summary then table.insert(tool_use_summary, summary) end
   end
   local state = "running"
-  local icon = Utils.icon("🔄 ")
+  local icon = Utils.icon("running ")
   local hl = Highlights.AVANTE_TASK_RUNNING
   if result_message then
     local result = History.Helpers.get_tool_result_data(result_message)
     if result then
       if result.is_error then
         state = "failed"
-        icon = Utils.icon("❌ ")
+        icon = Utils.icon("failed ")
         hl = Highlights.AVANTE_TASK_FAILED
       else
         state = "completed"
-        icon = Utils.icon("✅ ")
+        icon = Utils.icon("completed ")
         hl = Highlights.AVANTE_TASK_COMPLETED
       end
     end
   end
   local lines = {}
-  table.insert(lines, Line:new({ { icon .. "Subtask " .. state, hl } }))
+  local dispatch_label = dispatch_id and ("Dispatch #" .. dispatch_id) or "Dispatch"
+  table.insert(lines, Line:new({ { icon .. dispatch_label .. " " .. state, hl } }))
   table.insert(lines, Line:new({ { "" } }))
   table.insert(lines, Line:new({ { "  Task:" } }))
   local prompt_lines = vim.split(input.prompt or "", "\n")
@@ -170,11 +207,13 @@ function M.on_render(input, opts)
     table.insert(lines, Line:new({ { "    " .. line } }))
   end
   table.insert(lines, Line:new({ { "" } }))
-  table.insert(lines, Line:new({ { "  Task summary:" } }))
-  for _, summary in ipairs(tool_use_summary) do
-    local summary_lines = vim.split(summary, "\n")
-    for _, line in ipairs(summary_lines) do
-      table.insert(lines, Line:new({ { "    " .. line } }))
+  if #tool_use_summary > 0 then
+    table.insert(lines, Line:new({ { "  Task summary:" } }))
+    for _, summary in ipairs(tool_use_summary) do
+      local summary_lines = vim.split(summary, "\n")
+      for _, line in ipairs(summary_lines) do
+        table.insert(lines, Line:new({ { "    " .. line } }))
+      end
     end
   end
   return lines
@@ -187,22 +226,56 @@ function M.func(input, opts)
   local session_ctx = opts.session_ctx
 
   local Llm = require("avante.llm")
-  if not on_complete then return false, "on_complete not provided" end
 
   local prompt = input.prompt
   local tools = get_available_tools()
-  local start_time = Utils.get_timestamp()
 
   if on_log then on_log("prompt: " .. prompt) end
 
-  local system_prompt = ([[You are a helpful assistant with access to various tools.
-Your task is to help the user with their request: "${prompt}"
-Be thorough and use the tools available to you to find the most relevant information.
-When you're done, provide a clear and concise summary of what you found.]]):gsub("${prompt}", prompt)
+  -- Determine the session_id for the dispatch registry
+  local session_id = session_ctx.dispatch_session_id or "default"
+
+  -- Estimate tokens for the prompt to pick the cheapest provider
+  local prompt_tokens = estimate_tokens(prompt)
+  local dispatch_provider_name, _ = DispatchRegistry.pick_cheapest_provider(prompt_tokens + 2000) -- add headroom
+
+  -- Fall back to default provider if no cheap provider fits
+  if not dispatch_provider_name then dispatch_provider_name = Config.provider end
+
+  local dispatch_provider = Providers[dispatch_provider_name]
+  local dispatch_model = dispatch_provider and dispatch_provider.model or "unknown"
+
+  -- Register the dispatch in the registry
+  local dispatch_id = DispatchRegistry.register(session_id, prompt, dispatch_provider_name, dispatch_model)
+
+  if on_log then
+    on_log(string.format(
+      "Dispatch #%s started (provider: %s, model: %s)",
+      dispatch_id, dispatch_provider_name, dispatch_model
+    ))
+  end
+
+  -- Store the dispatch_id for rendering
+  if opts.set_store then opts.set_store("dispatch_id", dispatch_id) end
+
+  local system_prompt = "You are a focused research assistant with access to file-system tools. "
+    .. "Your ONLY job is to answer this specific request: " .. prompt .. "\n\n"
+    .. "CRITICAL RULES — follow these or you are wasting tokens and defeating the purpose:\n"
+    .. "1. SYNTHESIZE and REDUCE — never return raw file contents or long verbatim excerpts. "
+    .. "Extract exactly the information requested and discard everything else.\n"
+    .. "2. Use grep/glob FIRST to pinpoint the exact lines/symbols you need before opening a file. "
+    .. "Do NOT read an entire file when a targeted search will do.\n"
+    .. "3. Your result in attempt_completion should be COMPACT — only the facts needed to answer "
+    .. "the question. Think: could someone implement code from your answer without needing to ask "
+    .. "follow-up questions? If so, it's complete. Would they need to re-read the source file? "
+    .. "Then you're not synthesizing enough.\n"
+    .. "4. NEVER read a file and return its full contents verbatim — that is strictly forbidden. "
+    .. "If you are tempted to do that, use grep to extract only the relevant section instead.\n"
+    .. "When you have gathered exactly what is needed, call attempt_completion with a concise, "
+    .. "structured answer."
 
   local history_messages = {}
   local tool_use_messages = {}
-
   local total_tokens = 0
   local result = ""
 
@@ -238,6 +311,12 @@ When you're done, provide a clear and concise summary of what you found.]]):gsub
           end
         end
       end
+      -- Update dispatch progress
+      local last_msg = msgs[#msgs]
+      if last_msg then
+        local text = History.Helpers.get_text_data(last_msg)
+        if text and #text > 0 then DispatchRegistry.update_progress(session_id, dispatch_id, text:sub(1, 200)) end
+      end
     end,
     session_ctx = session_ctx,
     on_start = session_ctx.on_start,
@@ -247,31 +326,33 @@ When you're done, provide a clear and concise summary of what you found.]]):gsub
     end,
     on_complete = function(err)
       if err ~= nil then
-        err = string.format("dispatch_agent failed: %s", vim.inspect(err))
-        on_complete(err, nil)
+        DispatchRegistry.fail(session_id, dispatch_id, vim.inspect(err))
         return
       end
-      local end_time = Utils.get_timestamp()
-      local elapsed_time = Utils.datetime_diff(start_time, end_time)
-      local tool_use_count = vim.tbl_count(tool_use_messages)
-      local summary = "dispatch_agent Done ("
-        .. (tool_use_count <= 1 and "1 tool use" or tool_use_count .. " tool uses")
-        .. " · "
-        .. math.ceil(total_tokens)
-        .. " tokens · "
-        .. elapsed_time
-        .. "s)"
-      if session_ctx.on_messages_add then
-        local message = History.Message:new("assistant", "\n\n" .. summary, {
-          just_for_display = true,
-        })
-        session_ctx.on_messages_add({ message })
-      end
-      on_complete(result, nil)
+      DispatchRegistry.complete(session_id, dispatch_id, result)
     end,
   }
 
-  Llm.agent_loop(agent_loop_options)
+  -- Start the agent loop asynchronously (fire-and-forget)
+  -- Use vim.schedule to ensure it runs on the next event loop tick
+  vim.schedule(function() Llm.agent_loop(agent_loop_options) end)
+
+  -- Return IMMEDIATELY with the dispatch ID - do not wait for completion
+  local response = string.format(
+    "Dispatch #%s started. The sub-agent is working on your request in the background using provider '%s' (model: %s). "
+      .. "Results will be delivered to you automatically when the dispatch completes. "
+      .. "You can continue working on other tasks.",
+    dispatch_id,
+    dispatch_provider_name,
+    dispatch_model
+  )
+
+  -- Return synchronously - this makes the tool non-blocking
+  if on_complete then
+    on_complete(response, nil)
+    return
+  end
+  return response, nil
 end
 
 return M

--- a/lua/avante/llm_tools/dispatch_await.lua
+++ b/lua/avante/llm_tools/dispatch_await.lua
@@ -1,0 +1,267 @@
+--- dispatch_await tool: synchronously wait for a pending dispatch to complete,
+--- then return its full result and compact the related polling/dispatch
+--- messages from the chat history.
+---
+--- Use this tool when the primary agent has nothing else to do except wait
+--- for in-flight dispatches. It replaces the noisy "polling dispatch_status
+--- repeatedly" pattern with a single blocking call that picks one dispatch,
+--- waits for it, returns its result, and removes all the intermediate
+--- dispatch_status / dispatch_agent tool calls from the context window so
+--- only the final clean result remains.
+
+local Base = require("avante.llm_tools.base")
+local DispatchRegistry = require("avante.dispatch_registry")
+local History = require("avante.history")
+
+---@class AvanteLLMTool
+local M = setmetatable({}, Base)
+
+M.name = "dispatch_await"
+
+M.description = [[Synchronously wait for a pending dispatch_agent to complete and pull its result into the main chat.
+
+Use this when the only work left to do is waiting on one or more in-flight dispatches.
+Instead of polling `dispatch_status` repeatedly, call `dispatch_await` once:
+
+- If `dispatch_id` is supplied, waits for that specific dispatch.
+- Otherwise, picks the oldest still-running dispatch and waits for it.
+
+When the dispatch completes, this tool:
+1. Returns the dispatch's full result inline (as if you had run the task yourself).
+2. COMPACTS the chat history - all prior `dispatch_status` tool calls and the
+   original `dispatch_agent` tool_use/tool_result for this dispatch are marked
+   as compacted and disappear from your context. Only the final result remains.
+
+This keeps your context window clean and avoids burning tokens on repeated polling.]]
+
+---@type AvanteLLMToolParam
+M.param = {
+  type = "table",
+  fields = {
+    {
+      name = "dispatch_id",
+      description = "Optional: specific dispatch ID to wait for. If omitted, the oldest running dispatch is picked.",
+      type = "string",
+      optional = true,
+    },
+    {
+      name = "timeout_seconds",
+      description = "Optional: max seconds to wait before giving up. Defaults to 600 (10 min).",
+      type = "integer",
+      optional = true,
+    },
+  },
+  usage = {
+    dispatch_id = "Specific dispatch ID to wait for (optional)",
+    timeout_seconds = "Max seconds to wait (optional, default 600)",
+  },
+}
+
+---@type AvanteLLMToolReturn[]
+M.returns = {
+  {
+    name = "result",
+    description = "The completed dispatch's result, ready to use inline.",
+    type = "string",
+  },
+  {
+    name = "error",
+    description = "Error message if the await failed or timed out.",
+    type = "string",
+    optional = true,
+  },
+}
+
+---Format a completed/failed dispatch into a single concise text block.
+---@param dispatch avante.Dispatch
+---@return string
+local function format_result(dispatch)
+  if dispatch.status == "completed" then
+    return string.format(
+      "[Dispatch #%s completed inline] (provider: %s, model: %s)\nTask: %s\n\nResult:\n%s",
+      dispatch.id,
+      dispatch.provider or "unknown",
+      dispatch.model or "unknown",
+      dispatch.prompt:sub(1, 200),
+      dispatch.result or "(no result)"
+    )
+  elseif dispatch.status == "failed" then
+    return string.format(
+      "[Dispatch #%s failed inline] (provider: %s, model: %s)\nTask: %s\n\nError: %s",
+      dispatch.id,
+      dispatch.provider or "unknown",
+      dispatch.model or "unknown",
+      dispatch.prompt:sub(1, 200),
+      dispatch.error or "unknown error"
+    )
+  else
+    return string.format("[Dispatch #%s status: %s]", dispatch.id, dispatch.status or "unknown")
+  end
+end
+
+---Compact all messages related to dispatch_status, the original dispatch_agent
+---for the awaited dispatch, and any prior dispatch_result injections for the
+---same dispatch id. After compaction, only the dispatch_await tool's own
+---result message remains in the LLM context.
+---@param session_ctx table
+---@param awaited_dispatch_id string
+local function compact_dispatch_messages(session_ctx, awaited_dispatch_id)
+  if not session_ctx or not session_ctx.get_history_messages then return end
+  local ok, messages = pcall(session_ctx.get_history_messages)
+  if not ok or type(messages) ~= "table" then return end
+
+  for _, msg in ipairs(messages) do
+    if not msg.is_compacted then
+      local tool_use = History.Helpers.get_tool_use_data(msg)
+      local tool_result = History.Helpers.get_tool_result_data(msg)
+
+      -- 1) All dispatch_status tool calls become obsolete the moment we
+      --    synchronously await a dispatch.
+      if tool_use and tool_use.name == "dispatch_status" then
+        msg.is_compacted = true
+      elseif tool_result then
+        local use_msg = History.Helpers.get_tool_use_message(tool_result.tool_use_id, messages)
+        if use_msg then
+          local use_data = History.Helpers.get_tool_use_data(use_msg)
+          if use_data and use_data.name == "dispatch_status" then msg.is_compacted = true end
+        end
+      end
+
+      -- 2) The original dispatch_agent tool_use that started this dispatch
+      --    and its tool_result (the "Dispatch #N started..." placeholder).
+      if tool_use and tool_use.name == "dispatch_agent" then
+        local store = msg.tool_use_store
+        if store and store.dispatch_id == awaited_dispatch_id then msg.is_compacted = true end
+      elseif tool_result then
+        local use_msg = History.Helpers.get_tool_use_message(tool_result.tool_use_id, messages)
+        if use_msg then
+          local use_data = History.Helpers.get_tool_use_data(use_msg)
+          if use_data and use_data.name == "dispatch_agent" then
+            local store = use_msg.tool_use_store
+            if store and store.dispatch_id == awaited_dispatch_id then msg.is_compacted = true end
+          end
+        end
+      end
+
+      -- 3) Any prior "[Dispatch #X completed/failed]" user messages injected
+      --    by the sidebar's on_complete callback - we are about to deliver a
+      --    cleaner version inline, so drop the duplicate.
+      if msg.is_dispatch_result then
+        local text = History.Helpers.get_text_data(msg)
+        if text and text:match("Dispatch #" .. awaited_dispatch_id .. "[ %]]") then msg.is_compacted = true end
+      end
+    end
+  end
+end
+
+---Pick the dispatch to await. Prefers the oldest currently-running dispatch.
+---Falls back to the most recently-completed dispatch if nothing is running.
+---@param session_id string
+---@param explicit_id? string
+---@return avante.Dispatch | nil dispatch
+---@return string | nil error
+local function pick_target(session_id, explicit_id)
+  if explicit_id then
+    local d = DispatchRegistry.get(session_id, explicit_id)
+    if not d then return nil, "Dispatch #" .. explicit_id .. " not found" end
+    return d, nil
+  end
+
+  local all = DispatchRegistry.get_all(session_id)
+  for _, d in ipairs(all) do
+    if d.status == "running" then return d, nil end
+  end
+  local recent
+  for _, d in ipairs(all) do
+    if d.status == "completed" or d.status == "failed" then recent = d end
+  end
+  if recent then return recent, nil end
+  return nil, "No dispatches available to await"
+end
+
+---@class avante.DispatchAwaitInput
+---@field dispatch_id? string
+---@field timeout_seconds? integer
+
+---@type AvanteLLMToolFunc<avante.DispatchAwaitInput>
+function M.func(input, opts)
+  local on_complete = opts.on_complete
+  local on_log = opts.on_log
+  local session_ctx = opts.session_ctx or {}
+  local session_id = session_ctx.dispatch_session_id or "default"
+
+  local target, err = pick_target(session_id, input.dispatch_id)
+  if err or not target then
+    if on_complete then
+      on_complete(nil, err or "Unknown error")
+      return
+    end
+    return nil, err or "Unknown error"
+  end
+
+  if on_log then on_log("Awaiting dispatch #" .. target.id) end
+
+  -- Already finished? Return immediately + compact.
+  if target.status ~= "running" then
+    local result = format_result(target)
+    compact_dispatch_messages(session_ctx, target.id)
+    if on_complete then
+      on_complete(result, nil)
+      return
+    end
+    return result, nil
+  end
+
+  -- Still running - poll the registry on a timer until it terminates.
+  local timeout_seconds = input.timeout_seconds or 600
+  local poll_interval_ms = 200
+  local max_wait_ms = timeout_seconds * 1000
+  local elapsed = 0
+  local timer = vim.uv.new_timer()
+  if not timer then
+    local msg = "Failed to create timer for dispatch_await"
+    if on_complete then
+      on_complete(nil, msg)
+      return
+    end
+    return nil, msg
+  end
+
+  timer:start(
+    poll_interval_ms,
+    poll_interval_ms,
+    vim.schedule_wrap(function()
+      elapsed = elapsed + poll_interval_ms
+      local d = DispatchRegistry.get(session_id, target.id)
+      if not d then
+        timer:stop()
+        timer:close()
+        if on_complete then on_complete(nil, "Dispatch #" .. target.id .. " disappeared from registry") end
+        return
+      end
+      if d.status ~= "running" then
+        timer:stop()
+        timer:close()
+        local result = format_result(d)
+        compact_dispatch_messages(session_ctx, d.id)
+        if on_complete then on_complete(result, nil) end
+        return
+      end
+      if elapsed >= max_wait_ms then
+        timer:stop()
+        timer:close()
+        if on_complete then
+          on_complete(
+            nil,
+            string.format("Timed out after %ds waiting for dispatch #%s (still running)", timeout_seconds, target.id)
+          )
+        end
+        return
+      end
+    end)
+  )
+
+  -- Async: return nothing - the on_complete callback above will deliver.
+end
+
+return M

--- a/lua/avante/llm_tools/dispatch_await.lua
+++ b/lua/avante/llm_tools/dispatch_await.lua
@@ -227,29 +227,38 @@ function M.func(input, opts)
     return nil, msg
   end
 
+  -- Guard against multiple scheduled callbacks trying to close the same timer.
+  -- vim.schedule_wrap can queue several ticks before any of them runs, so the
+  -- first callback that decides to stop must prevent the rest from closing again.
+  local timer_active = true
+  local function stop_timer()
+    if not timer_active then return end
+    timer_active = false
+    timer:stop()
+    timer:close()
+  end
+
   timer:start(
     poll_interval_ms,
     poll_interval_ms,
     vim.schedule_wrap(function()
+      if not timer_active then return end
       elapsed = elapsed + poll_interval_ms
       local d = DispatchRegistry.get(session_id, target.id)
       if not d then
-        timer:stop()
-        timer:close()
+        stop_timer()
         if on_complete then on_complete(nil, "Dispatch #" .. target.id .. " disappeared from registry") end
         return
       end
       if d.status ~= "running" then
-        timer:stop()
-        timer:close()
+        stop_timer()
         local result = format_result(d)
         compact_dispatch_messages(session_ctx, d.id)
         if on_complete then on_complete(result, nil) end
         return
       end
       if elapsed >= max_wait_ms then
-        timer:stop()
-        timer:close()
+        stop_timer()
         if on_complete then
           on_complete(
             nil,

--- a/lua/avante/llm_tools/dispatch_status.lua
+++ b/lua/avante/llm_tools/dispatch_status.lua
@@ -1,0 +1,70 @@
+local Base = require("avante.llm_tools.base")
+local DispatchRegistry = require("avante.dispatch_registry")
+
+---@class AvanteLLMTool
+local M = setmetatable({}, Base)
+
+M.name = "dispatch_status"
+
+M.description = [[Check the status of dispatched sub-agents. Returns a summary of all running and completed dispatches.
+Use this to check if dispatched work has completed and retrieve their results.]]
+
+---@type AvanteLLMToolParam
+M.param = {
+  type = "table",
+  fields = {
+    {
+      name = "dispatch_id",
+      description = "Optional: specific dispatch ID to check. If omitted, returns all dispatches.",
+      type = "string",
+      optional = true,
+    },
+  },
+  usage = {
+    dispatch_id = "Specific dispatch ID to check (optional)",
+  },
+}
+
+---@type AvanteLLMToolReturn[]
+M.returns = {
+  {
+    name = "status",
+    description = "Status information about dispatches",
+    type = "string",
+  },
+  {
+    name = "error",
+    description = "Error message if the lookup failed",
+    type = "string",
+    optional = true,
+  },
+}
+
+---@type AvanteLLMToolFunc<{ dispatch_id?: string }>
+function M.func(input, opts)
+  local session_ctx = opts.session_ctx or {}
+  local session_id = session_ctx.dispatch_session_id or "default"
+
+  if input.dispatch_id then
+    local dispatch = DispatchRegistry.get(session_id, input.dispatch_id)
+    if not dispatch then return nil, "Dispatch #" .. input.dispatch_id .. " not found" end
+    return vim.json.encode({
+      id = dispatch.id,
+      status = dispatch.status,
+      prompt = dispatch.prompt:sub(1, 200),
+      last_message = dispatch.last_message,
+      result = dispatch.result,
+      error = dispatch.error,
+      provider = dispatch.provider,
+      model = dispatch.model,
+    }),
+      nil
+  end
+
+  -- Return all dispatches
+  local context = DispatchRegistry.get_context(session_id)
+  if context == "" then return "No dispatches have been created yet.", nil end
+  return context, nil
+end
+
+return M

--- a/lua/avante/llm_tools/init.lua
+++ b/lua/avante/llm_tools/init.lua
@@ -71,6 +71,7 @@ local Path = require("plenary.path")
 local Config = require("avante.config")
 local RagService = require("avante.rag_service")
 local Helpers = require("avante.llm_tools.helpers")
+local DispatchRegistry = require("avante.dispatch_registry")
 
 local M = {}
 
@@ -105,6 +106,7 @@ function M.str_replace_based_edit_tool(input, opts)
   if not input.command then return false, "command not provided" end
   if on_log then on_log("command: " .. input.command) end
   if not on_complete then return false, "on_complete not provided" end
+  if not input.path then return false, "path not provided" end
   local abs_path = Helpers.get_abs_path(input.path)
   if not Helpers.has_permission_to_access(abs_path) then return false, "No permission to access path: " .. abs_path end
   if input.command == "view" then
@@ -713,6 +715,8 @@ end
 ---@type AvanteLLMTool[]
 M._tools = {
   require("avante.llm_tools.dispatch_agent"),
+  require("avante.llm_tools.dispatch_status"),
+  require("avante.llm_tools.dispatch_await"),
   require("avante.llm_tools.glob"),
   {
     name = "rag_search",
@@ -916,7 +920,182 @@ Then you can use the "read_definitions" tool to retrieve the source code definit
     },
   },
   require("avante.llm_tools.str_replace"),
-  require("avante.llm_tools.view"),
+  {
+    name = "view",
+    description = [[Reads the content of a file by dispatching a sub-agent with a cheap LLM.
+The sub-agent reads the file and returns analyzed content relevant to your task.
+This is ASYNCHRONOUS - it returns immediately with a dispatch ID. The result
+will be delivered to you automatically when the dispatch completes.
+
+For quick searches, prefer the grep tool with context_lines instead.
+Use view when you need to understand the full structure or content of a file.
+
+IMPORTANT: If you just need a few lines around a known pattern, use grep with context_lines instead - it's synchronous and faster.]],
+    param = {
+      type = "table",
+      fields = {
+        {
+          name = "path",
+          description = "The relative path of the file to read",
+          type = "string",
+        },
+        {
+          name = "purpose",
+          description = "What you're looking for or trying to understand in this file. This helps the sub-agent provide more relevant analysis.",
+          type = "string",
+          optional = true,
+        },
+        {
+          name = "start_line",
+          description = "Optional line number to start reading on (1-based index)",
+          type = "integer",
+          optional = true,
+        },
+        {
+          name = "end_line",
+          description = "Optional line number to end reading on (1-based index, inclusive)",
+          type = "integer",
+          optional = true,
+        },
+      },
+      usage = {
+        path = "The path to the file in the current project scope",
+        purpose = "What you're looking for in this file",
+        start_line = "The start line of the view range, 1-indexed",
+        end_line = "The end line of the view range, 1-indexed",
+      },
+    },
+    returns = {
+      {
+        name = "result",
+        description = "Dispatch ID and status (async - result delivered later)",
+        type = "string",
+      },
+      {
+        name = "error",
+        description = "Error message if the dispatch could not be started",
+        type = "string",
+        optional = true,
+      },
+    },
+    func = function(input, opts)
+      local on_log = opts.on_log
+      local on_complete = opts.on_complete
+      local session_ctx = opts.session_ctx or {}
+
+      if not input.path then return nil, "path is required" end
+
+      -- Read the file content using the raw view tool
+      local raw_view = require("avante.llm_tools.view")
+      local file_result, file_err = raw_view.func(input, {
+        on_log = on_log,
+        session_ctx = session_ctx,
+      })
+
+      if file_err then
+        if on_complete then
+          on_complete(nil, file_err)
+          return
+        end
+        return nil, file_err
+      end
+
+      -- Estimate file tokens
+      local file_content = file_result or ""
+      local words = 0
+      for _ in file_content:gmatch("%S+") do
+        words = words + 1
+      end
+      local estimated_file_tokens = math.ceil(words * 1.3)
+
+      -- Build the dispatch prompt
+      local purpose = input.purpose or "Read and summarize the file content"
+      local dispatch_prompt = "Read the file '" .. input.path .. "' and provide a thorough analysis."
+        .. " Focus on: " .. purpose
+        .. "\n\nFile content:\n" .. file_content
+
+      -- Pick cheapest provider that fits
+      local total_tokens = estimated_file_tokens + 500 -- headroom for prompt overhead
+      local dispatch_provider_name, _ = DispatchRegistry.pick_cheapest_provider(total_tokens)
+
+      -- Fall back to default provider
+      if not dispatch_provider_name then dispatch_provider_name = Config.provider end
+
+      local Llm = require("avante.llm")
+      local Providers_ = require("avante.providers")
+      local dispatch_provider = Providers_[dispatch_provider_name]
+      local dispatch_model = dispatch_provider and dispatch_provider.model or "unknown"
+
+      local session_id = session_ctx.dispatch_session_id or "default"
+      local dispatch_id = DispatchRegistry.register(session_id, "view: " .. input.path, dispatch_provider_name, dispatch_model)
+
+      if on_log then
+        on_log(string.format("Dispatching file read #%s for '%s' (provider: %s)", dispatch_id, input.path, dispatch_provider_name))
+      end
+
+      local system_prompt = "You are a file analysis assistant. Read the provided file content and answer questions about it. Be thorough and precise."
+      local history_messages = {}
+      local result = ""
+
+      local agent_loop_options = {
+        system_prompt = system_prompt,
+        user_input = dispatch_prompt,
+        tools = {
+          require("avante.llm_tools.attempt_completion"),
+        },
+        on_tool_log = session_ctx.on_tool_log,
+        on_messages_add = function(msgs)
+          msgs = vim.islist(msgs) and msgs or { msgs }
+          for _, msg in ipairs(msgs) do
+            local idx = nil
+            for i, m in ipairs(history_messages) do
+              if m.uuid == msg.uuid then
+                idx = i
+                break
+              end
+            end
+            if idx ~= nil then
+              history_messages[idx] = msg
+            else
+              table.insert(history_messages, msg)
+            end
+          end
+          for _, msg in ipairs(msgs) do
+            local History_ = require("avante.history")
+            local tool_use = History_.Helpers.get_tool_use_data(msg)
+            if tool_use and tool_use.name == "attempt_completion" and tool_use.input and tool_use.input.result then
+              result = tool_use.input.result
+            end
+          end
+        end,
+        session_ctx = session_ctx,
+        on_chunk = function() end,
+        on_complete = function(err)
+          if err ~= nil then
+            DispatchRegistry.fail(session_id, dispatch_id, vim.inspect(err))
+            return
+          end
+          DispatchRegistry.complete(session_id, dispatch_id, result)
+        end,
+      }
+
+      -- Fire-and-forget
+      vim.schedule(function()
+        Llm.agent_loop(agent_loop_options)
+      end)
+
+      local response = string.format(
+        "Dispatch #%s started - reading '%s' via provider '%s' (model: %s). Result will be delivered automatically.",
+        dispatch_id, input.path, dispatch_provider_name, dispatch_model
+      )
+
+      if on_complete then
+        on_complete(response, nil)
+        return
+      end
+      return response, nil
+    end,
+  },
   require("avante.llm_tools.write_to_file"),
   require("avante.llm_tools.insert"),
   require("avante.llm_tools.undo_edit"),

--- a/lua/avante/sidebar.lua
+++ b/lua/avante/sidebar.lua
@@ -3026,6 +3026,42 @@ function Sidebar:handle_submit(request)
 
     stream_options.on_memory_summarize = on_memory_summarize
 
+    -- Register dispatch completion callback so results are injected into chat history
+    local dispatch_session_id = tostring(self.code.bufnr or "default")
+    DispatchRegistry.set_on_complete(dispatch_session_id, function(dispatch)
+      -- Inject the dispatch result as a visible user message into the chat history
+      local content_text
+      if dispatch.status == "completed" then
+        content_text = string.format(
+          "[Dispatch #%s completed] (provider: %s, model: %s)\nTask: %s\n\nResult:\n%s",
+          dispatch.id,
+          dispatch.provider or "unknown",
+          dispatch.model or "unknown",
+          dispatch.prompt:sub(1, 200),
+          dispatch.result or "(no result)"
+        )
+      else
+        content_text = string.format(
+          "[Dispatch #%s failed] (provider: %s, model: %s)\nTask: %s\n\nError: %s",
+          dispatch.id,
+          dispatch.provider or "unknown",
+          dispatch.model or "unknown",
+          dispatch.prompt:sub(1, 200),
+          dispatch.error or "unknown error"
+        )
+      end
+      local message = History.Message:new("user", content_text, {
+        visible = true,
+        is_dispatch_result = true,
+      })
+      self:add_history_messages({ message })
+      self:save_history()
+      -- Re-render the chat to show the dispatch result.
+      if Utils.is_valid_container(self.containers.result, true) then
+        pcall(function() self:update_content_with_history() end)
+      end
+    end)
+
     if request ~= "" then on_state_change("generating") end
     Llm.stream(stream_options)
   end)

--- a/lua/avante/types.lua
+++ b/lua/avante/types.lua
@@ -267,7 +267,8 @@ vim.g.avante_login = vim.g.avante_login
 ---@field use_response_api? boolean | fun(provider: AvanteDefaultBaseProvider, ctx?: any): boolean
 ---@field support_previous_response_id? boolean
 --- NOTE: Response API automatically manages conversation state using previous_response_id for tool calling
----
+---@field cost_per_input_token? number -- Cost in dollars per input token (e.g. 0.000003 for $3/1M tokens)
+---@field cost_per_output_token? number -- Cost in dollars per output token (e.g. 0.000015 for $15/1M tokens)
 ---
 ---@class AvanteSupportedProvider: AvanteDefaultBaseProvider
 ---@field __inherited_from? string


### PR DESCRIPTION
## Summary

Adds a fire-and-forget dispatch system so the primary agent can launch sub-agents in the background and continue working, enabling parallelism (read multiple files, run analyses, check errors simultaneously).

**New files:**
- `dispatch_registry.lua`: tracks in-flight dispatches per session, emits completion callbacks, and provides `pick_cheapest_provider()` which selects the lowest-cost provider whose `context_window` fits the payload
- `llm_tools/dispatch_status.lua`: `dispatch_status` tool — query which dispatches are pending, completed, or failed
- `llm_tools/dispatch_await.lua`: `dispatch_await` tool — block until the next dispatch completes and return the result inline; compacts polling noise from context

**`dispatch_agent` rewrite:**
- Now fire-and-forget: returns a dispatch ID immediately; result is injected back as a visible user message when the sub-agent finishes
- Detailed usage rules and context-reduction guidelines in the description

**`view` tool (async):**
- Replaced with an async dispatch wrapper that picks the cheapest provider that fits the file's token budget, runs an `agent_loop` to analyse the content, and returns the result via the registry
- The raw `view.lua` is still used internally for file reading

**Other changes:**
- `llm.lua`: injects "Active & Recent Dispatches" context into the system prompt when `session_ctx.dispatch_session_id` is set
- `sidebar.lua`: sets `dispatch_session_id` on `session_ctx` and registers a completion callback that injects results as chat messages
- `config.lua`: `dispatch.max_context_ratio` (default `0.6`) and `cost_per_input_token` / `cost_per_output_token` for all built-in providers
- `types.lua`: cost field annotations on `AvanteDefaultBaseProvider`

## Test plan
- [ ] Use `dispatch_agent` to launch a sub-task and confirm the primary agent continues immediately
- [ ] Use `dispatch_status` to check pending dispatches
- [ ] Use `dispatch_await` to wait for a result and confirm it's returned inline
- [ ] Use the `view` tool on a large file and confirm it dispatches asynchronously