### PR TITLE
feat: inter-instance messaging with optional cross-process IPC service

### DIFF
--- a/README.md
+++ b/README.md
@@ -1731,6 +1731,40 @@ The high quality and ingenuity of these projects' source code have been immensel
   </tr>
 </table>
 
+## Multi-Instance Messaging
+
+When you have multiple Avante sidebars open (across tabs, windows, or even separate Neovim processes), each instance gets a unique human-readable name shown in the winbar (e.g. `Avante [swift-fox]`). Instances can discover and message each other.
+
+### In-process messaging (no setup required)
+
+The `send_message` LLM tool is always available to the agent. It can:
+- `action="list"` — discover other active Avante instances in the same Neovim session
+- `action="send"` — deliver a message to a named instance
+
+You can also use the `/send <instance-name> <intent>` slash command to have the current chat's model draft and deliver a message to another instance based on your stated intent and the conversation history.
+
+### Context simplification
+
+Use `/simplify` to aggressively compress the current chat history down to the minimal engineering-critical context: current state, unresolved blockers, and next steps.
+
+### Cross-process IPC service (optional, requires Docker or Nix)
+
+To enable messaging between Avante instances in *different* Neovim processes:
+
+```lua
+require("avante").setup({
+  ipc_service = {
+    enabled = true,
+    runner = "docker", -- or "nix"
+    image = "quay.io/yetoneful/avante-ipc-service:0.0.1",
+  },
+})
+```
+
+Once enabled, the `send_message` tool automatically uses the IPC service for cross-process delivery, with a fallback to in-process delivery for same-Neovim peers.
+
+The IPC service requires Docker (or OrbStack on macOS) or Nix. See `py/ipc-service/` for the service source.
+
 ## License
 
 avante.nvim is licensed under the Apache 2.0 License. For more details, please refer to the [LICENSE](./LICENSE) file.

--- a/lua/avante/config.lua
+++ b/lua/avante/config.lua
@@ -323,9 +323,6 @@ M.instructions_file = "avante.md"
 ---@field behaviour avante.Config.Behaviour Behaviour and automation options.
 ---@field prompt_logger? avante.Config.PromptLogger Prompt logging options.
 ---@field windows table
----@field slash_commands AvanteSlashCommand[] see |*avante-slashcommands*|
----@field shortcuts AvanteShortcut[]  see |*avante-shortcuts*|
----@field ask_opts AskOptions
 
 M._defaults = {
   debug = false,
@@ -374,6 +371,15 @@ M._defaults = {
       extra = nil, -- Extra configuration options for the embedding model
     },
     docker_extra_args = "", -- Extra arguments to pass to the docker command
+  },
+  ipc_service = { -- Cross-process instance IPC service configuration
+    -- Enables the IPC service so root Avante instances in *different* Neovim
+    -- processes can discover each other, share responsibility context, and
+    -- exchange messages via send_message.  Requires Docker or Nix.
+    enabled = false,
+    runner = "docker", -- "docker" or "nix"
+    image = "quay.io/yetoneful/avante-ipc-service:0.0.1",
+    docker_extra_args = "",
   },
   web_search_engine = {
     provider = "tavily",
@@ -594,6 +600,8 @@ M._defaults = {
       model = "gpt-4o",
       timeout = 30000, -- Timeout in milliseconds, increase this for reasoning models
       context_window = 128000, -- Number of tokens to send to the model for context
+      cost_per_input_token = 0.0000025, -- $2.50 per 1M tokens
+      cost_per_output_token = 0.00001, -- $10 per 1M tokens
       use_response_api = copilot_use_response_api, -- Automatically switch to Response API for GPT-5 Codex models
       support_previous_response_id = true, -- OpenAI Response API supports previous_response_id for stateful conversations
       -- NOTE: Response API automatically manages conversation state using previous_response_id for tool calling
@@ -613,6 +621,8 @@ M._defaults = {
       allow_insecure = false, -- Allow insecure server connections
       timeout = 30000, -- Timeout in milliseconds
       context_window = 64000, -- Number of tokens to send to the model for context
+      cost_per_input_token = 0, -- Free with GitHub Copilot subscription
+      cost_per_output_token = 0,
       use_response_api = copilot_use_response_api, -- Automatically switch to Response API for GPT-5 Codex models
       support_previous_response_id = false, -- Copilot doesn't support previous_response_id, must send full history
       -- NOTE: Copilot doesn't support previous_response_id, always sends full conversation history including tool_calls
@@ -641,6 +651,8 @@ M._defaults = {
       model = "claude-sonnet-4-5-20250929",
       timeout = 30000, -- Timeout in milliseconds
       context_window = 200000,
+      cost_per_input_token = 0.000003, -- $3 per 1M tokens
+      cost_per_output_token = 0.000015, -- $15 per 1M tokens
       extra_request_body = {
         temperature = 0.75,
         max_tokens = 64000,
@@ -670,6 +682,8 @@ M._defaults = {
       model = "gemini-2.0-flash",
       timeout = 30000, -- Timeout in milliseconds
       context_window = 1048576,
+      cost_per_input_token = 0.0000001, -- $0.10 per 1M tokens
+      cost_per_output_token = 0.0000004, -- $0.40 per 1M tokens
       use_ReAct_prompt = true,
       extra_request_body = {
         generationConfig = {
@@ -683,6 +697,8 @@ M._defaults = {
       model = "gemini-1.5-flash-002",
       timeout = 30000, -- Timeout in milliseconds
       context_window = 1048576,
+      cost_per_input_token = 0.000000075, -- $0.075 per 1M tokens
+      cost_per_output_token = 0.0000003, -- $0.30 per 1M tokens
       use_ReAct_prompt = true,
       extra_request_body = {
         generationConfig = {
@@ -704,6 +720,8 @@ M._defaults = {
     ollama = {
       endpoint = "http://127.0.0.1:11434",
       timeout = 30000, -- Timeout in milliseconds
+      cost_per_input_token = 0, -- Local model, free
+      cost_per_output_token = 0,
       use_ReAct_prompt = true,
       extra_request_body = {
         options = {
@@ -738,6 +756,8 @@ M._defaults = {
       __inherited_from = "claude",
       model = "claude-3-5-haiku-20241022",
       timeout = 30000, -- Timeout in milliseconds
+      cost_per_input_token = 0.0000008, -- $0.80 per 1M tokens
+      cost_per_output_token = 0.000004, -- $4 per 1M tokens
       extra_request_body = {
         temperature = 0.75,
         max_tokens = 8192,
@@ -748,6 +768,8 @@ M._defaults = {
       __inherited_from = "claude",
       model = "claude-3-opus-20240229",
       timeout = 30000, -- Timeout in milliseconds
+      cost_per_input_token = 0.000015, -- $15 per 1M tokens
+      cost_per_output_token = 0.000075, -- $75 per 1M tokens
       extra_request_body = {
         temperature = 0.75,
         max_tokens = 20480,
@@ -756,6 +778,8 @@ M._defaults = {
     ["openai-gpt-4o-mini"] = {
       __inherited_from = "openai",
       model = "gpt-4o-mini",
+      cost_per_input_token = 0.00000015, -- $0.15 per 1M tokens
+      cost_per_output_token = 0.0000006, -- $0.60 per 1M tokens
     },
     aihubmix = {
       __inherited_from = "openai",
@@ -1085,11 +1109,22 @@ M._defaults = {
     debounce = 600,
     throttle = 600,
   },
+  --- Dispatch agent configuration
+  --- Controls how dispatch_agent selects providers for sub-tasks (e.g. file reading)
+  dispatch = {
+    --- Maximum ratio of a provider's context_window that a dispatch request+file may occupy.
+    --- The cheapest provider whose context fits the payload within this ratio is selected.
+    --- @type number
+    max_context_ratio = 0.6,
+  },
   disabled_tools = {},
   ---@type AvanteLLMToolPublic[] | fun(): AvanteLLMToolPublic[]
   custom_tools = {},
+  ---@type AvanteSlashCommand[]
   slash_commands = {},
+  ---@type AvanteShortcut[]
   shortcuts = {},
+  ---@type AskOptions
   ask_opts = {},
 }
 
@@ -1097,7 +1132,6 @@ M._defaults = {
 ---@diagnostic disable-next-line: missing-fields
 M._options = {}
 
----@diagnostic disable-next-line: param-type-mismatch
 local function get_config_dir_path() return vim.fs.joinpath(vim.fn.expand("~"), ".config", "avante.nvim") end
 local function get_config_file_path() return vim.fs.joinpath(get_config_dir_path(), "config.json") end
 

--- a/lua/avante/history/message.lua
+++ b/lua/avante/history/message.lua
@@ -17,6 +17,7 @@ M.__index = M
 ---@field is_user_submission? boolean
 ---@field just_for_display? boolean
 ---@field visible? boolean
+---@field from_instance? string -- instance_name of the sending chat (cross-instance message)
 ---
 ---@param role "user" | "assistant"
 ---@param content AvanteLLMMessageContentItem

--- a/lua/avante/init.lua
+++ b/lua/avante/init.lua
@@ -133,6 +133,7 @@ local Suggestion = require("avante.suggestion")
 local Config = require("avante.config")
 local Diff = require("avante.diff")
 local RagService = require("avante.rag_service")
+local IpcService = require("avante.ipc_service")
 
 ---@class Avante
 local M = {
@@ -148,6 +149,9 @@ local M = {
   current = { sidebar = nil, selection = nil, suggestion = nil },
   ---@type table<string, any> Global ACP client registry for cleanup on exit
   acp_clients = {},
+  --- instance_name → Sidebar: cross-instance messaging registry
+  ---@type table<string, avante.Sidebar>
+  instance_registry = {},
 }
 
 M.did_setup = false
@@ -423,7 +427,13 @@ function H.autocmds()
       local tab = tonumber(ev.file)
       local s = M.sidebars[tab]
       local sl = M.selections[tab]
-      if s then s:reset() end
+      if s then
+        -- Remove this sidebar from the cross-instance registry before reset.
+        if s.chat_history and s.chat_history.instance_name then
+          M.instance_registry[s.chat_history.instance_name] = nil
+        end
+        s:reset()
+      end
       if sl then sl:delete_autocmds() end
       if tab ~= nil then M.sidebars[tab] = nil end
     end,
@@ -649,6 +659,51 @@ function M.setup(opts)
   end
 
   if Config.rag_service.enabled then run_rag_service() end
+
+  -- Launch the IPC service when enabled.  Once the service is ready, all
+  -- currently open sidebars register themselves and start their heartbeat +
+  -- message-poll timers.  New sidebars register in reload_chat_history().
+  if Config.ipc_service and Config.ipc_service.enabled then
+    local started_at = os.time()
+    local function try_ipc_ready()
+      if IpcService.is_ready() then
+        Utils.debug("IPC service is ready; registering open sidebars")
+        -- Register every currently open sidebar.
+        for _, sidebar in pairs(M.instance_registry) do
+          if sidebar and sidebar.chat_history then
+            sidebar:ipc_register()
+          end
+        end
+      else
+        local elapsed = os.time() - started_at
+        if elapsed < 60 * 5 then
+          vim.defer_fn(try_ipc_ready, 5000)
+        else
+          Utils.warn("IPC service did not become ready within 5 minutes — giving up")
+        end
+      end
+    end
+    vim.schedule(function()
+      Utils.info("Starting IPC Service ...")
+      IpcService.launch_ipc_service(function()
+        vim.defer_fn(try_ipc_ready, 2000)
+      end)
+    end)
+
+    -- Unregister all sidebars from IPC on nvim exit.
+    api.nvim_create_autocmd("VimLeavePre", {
+      group = H.augroup,
+      desc = "Unregister all Avante sidebars from the IPC service",
+      callback = function()
+        for _, sidebar in pairs(M.instance_registry) do
+          if sidebar and sidebar.chat_history then
+            pcall(function() sidebar:ipc_unregister() end)
+          end
+        end
+        IpcService.stop_timers()
+      end,
+    })
+  end
 
   local has_cmp, cmp = pcall(require, "cmp")
   if has_cmp then

--- a/lua/avante/ipc_service.lua
+++ b/lua/avante/ipc_service.lua
@@ -1,0 +1,379 @@
+---@mod avante-ipc-service Avante IPC service
+---@brief [[
+---
+--- The IPC service is a lightweight Docker/Nix sidecar that lets root Avante
+--- sidebar instances running in *separate Neovim processes* discover each other,
+--- share responsibility summaries, and exchange messages.
+---
+--- Without this service, `send_message` only works between sidebars inside the
+--- same nvim process.  With it, any nvim process with Avante open can see and
+--- message every other live instance on the machine.
+---
+--->
+---   require("avante").setup({
+---     ipc_service = {
+---       enabled = false,
+---       runner = "docker",      -- "docker" or "nix"
+---       image  = "quay.io/yetoneful/avante-ipc-service:0.0.1",
+---       docker_extra_args = "",
+---     },
+---   })
+---<
+---
+---@brief ]]
+
+local curl = require("plenary.curl")
+local PlenaryPath = require("plenary.path")
+local Config = require("avante.config")
+local Utils = require("avante.utils")
+
+local M = {}
+
+local container_name = "avante-ipc-service"
+local service_path = "/tmp/" .. container_name
+
+-- Port for the IPC service (distinct from RAG service port 20250).
+local IPC_PORT = 20251
+
+-- How often (ms) to send heartbeats / poll for incoming messages.
+local HEARTBEAT_INTERVAL_MS = 10000 -- 10 seconds
+local POLL_INTERVAL_MS = 3000 -- 3 seconds
+
+-- Module-level state.
+local _instance_id = nil ---@type string | nil
+local _instance_name = nil ---@type string | nil
+local _heartbeat_timer = nil ---@type any
+local _poll_timer = nil ---@type any
+-- Callback invoked when messages arrive: fun(from_name: string, message: string)
+local _on_message_cb = nil ---@type fun(from_name: string, message: string) | nil
+
+---@return string
+function M.get_ipc_service_url() return string.format("http://localhost:%d", IPC_PORT) end
+
+---@return string
+function M.get_ipc_service_image()
+  if Config.ipc_service and Config.ipc_service.image then return Config.ipc_service.image end
+  return "quay.io/yetoneful/avante-ipc-service:0.0.1"
+end
+
+---@return string
+function M.get_ipc_service_runner()
+  return (Config.ipc_service and Config.ipc_service.runner) or "docker"
+end
+
+---@return string
+function M.get_data_path()
+  local p = PlenaryPath:new(vim.fn.stdpath("data")):joinpath("avante/ipc_service")
+  if not p:exists() then p:mkdir({ parents = true }) end
+  return tostring(p)
+end
+
+-- ---------------------------------------------------------------------------
+-- Readiness check
+-- ---------------------------------------------------------------------------
+
+---@return boolean
+function M.is_ready()
+  local url = M.get_ipc_service_url() .. "/api/health"
+  local cmd = { "curl", "-s", "-o", "/dev/null", "-w", "%{http_code}", url }
+  local result = vim.system(cmd, { text = true }):wait()
+  return result.code == 0 and vim.trim(result.stdout or "") == "200"
+end
+
+-- ---------------------------------------------------------------------------
+-- Launch / stop
+-- ---------------------------------------------------------------------------
+
+---@param cb fun()
+function M.launch_ipc_service(cb)
+  if M.get_ipc_service_runner() == "docker" then
+    local image = M.get_ipc_service_image()
+    local data_path = M.get_data_path()
+    local docker_extra = (Config.ipc_service and Config.ipc_service.docker_extra_args) or ""
+
+    -- Check existing container state.
+    local inspect = vim.system({ "docker", "inspect", "--format", "{{.State.Status}}", container_name }, { text = true }):wait()
+    local status = vim.trim(inspect.stdout or "")
+
+    if status == "running" then
+      -- Check if it's the same image.
+      local cur_img_result = vim.system({ "docker", "inspect", "--format", "{{.Config.Image}}", container_name }, { text = true }):wait()
+      local cur_img = vim.trim(cur_img_result.stdout or "")
+      if cur_img == image then
+        cb()
+        return
+      end
+      Utils.debug(string.format("ipc container running with different image (%s vs %s), restarting", cur_img, image))
+      M.stop_ipc_service()
+    elseif status ~= "" then
+      -- Exists but not running.
+      M.stop_ipc_service()
+    end
+
+    local cmd_ = string.format(
+      "docker run --platform=linux/amd64 -d -p 0.0.0.0:%d:%d --name %s -v %s:/data -e DATA_DIR=/data %s %s",
+      IPC_PORT,
+      IPC_PORT,
+      container_name,
+      data_path,
+      docker_extra,
+      image
+    )
+    vim.fn.jobstart(cmd_, {
+      detach = true,
+      on_exit = function(_, exit_code)
+        if exit_code ~= 0 then
+          Utils.error(string.format("avante-ipc-service container failed to start (exit %d)", exit_code))
+        else
+          Utils.debug("avante-ipc-service container started")
+          cb()
+        end
+      end,
+    })
+  elseif M.get_ipc_service_runner() == "nix" then
+    local check_result = vim.system({ "pgrep", "-f", service_path }, { text = true }):wait().stdout
+    if check_result ~= "" then
+      Utils.debug("avante-ipc-service already running")
+      cb()
+      return
+    end
+
+    local dirname = Utils.trim(
+      string.sub(debug.getinfo(1).source, 2, #"/lua/avante/ipc_service.lua" * -1),
+      { suffix = "/" }
+    )
+    local ipc_service_dir = dirname .. "/py/ipc-service"
+
+    -- Spawn the nix-shell service detached. Because the process runs
+    -- indefinitely (it IS the service), the on_exit callback would never
+    -- fire during normal operation, so we cannot use it to signal readiness.
+    -- Instead, call cb() immediately and let the try_ipc_ready polling loop
+    -- in init.lua detect when the service actually responds to /api/health.
+    vim.system({ "sh", "run.sh", service_path }, {
+      detach = true,
+      cwd = ipc_service_dir,
+      env = {
+        PORT = tostring(IPC_PORT),
+        DATA_DIR = service_path,
+      },
+    })
+    cb()
+  end
+end
+
+function M.stop_ipc_service()
+  if M.get_ipc_service_runner() == "docker" then
+    local status = vim.trim((vim.system({ "docker", "inspect", "--format", "{{.State.Status}}", container_name }, { text = true }):wait().stdout) or "")
+    if status ~= "" then vim.system({ "docker", "rm", "-fv", container_name }):wait() end
+  else
+    local pid = vim.trim((vim.system({ "pgrep", "-f", service_path }, { text = true }):wait().stdout) or "")
+    if pid ~= "" then vim.system({ "kill", "-9", pid }):wait() end
+  end
+end
+
+-- ---------------------------------------------------------------------------
+-- HTTP helpers (non-blocking)
+-- ---------------------------------------------------------------------------
+
+---@param path string
+---@param body table
+---@param cb fun(ok: boolean, data: any)|nil
+local function post_async(path, body, cb)
+  local url = M.get_ipc_service_url() .. path
+  local ok, json = pcall(vim.json.encode, body)
+  if not ok then
+    Utils.debug("ipc_service: failed to encode request body: " .. tostring(json))
+    if cb then cb(false, nil) end
+    return
+  end
+  curl.post(url, {
+    body = json,
+    headers = { ["Content-Type"] = "application/json" },
+    callback = function(res)
+      if not res or res.status ~= 200 then
+        if cb then cb(false, nil) end
+        return
+      end
+      local ok2, data = pcall(vim.json.decode, res.body)
+      if cb then cb(ok2, data) end
+    end,
+  })
+end
+
+---@param path string
+---@param cb fun(ok: boolean, data: any)
+local function get_async(path, cb)
+  local url = M.get_ipc_service_url() .. path
+  curl.get(url, {
+    callback = function(res)
+      if not res or res.status ~= 200 then
+        cb(false, nil)
+        return
+      end
+      local ok, data = pcall(vim.json.decode, res.body)
+      cb(ok, data)
+    end,
+  })
+end
+
+-- ---------------------------------------------------------------------------
+-- Registry API
+-- ---------------------------------------------------------------------------
+
+---Register (or re-register) this sidebar with the IPC service.
+---@param name string Instance name, e.g. "swift-fox"
+---@param instance_id string Stable UUID from chat_history
+---@param description string Current responsibility summary
+---@param project string Absolute project root path
+function M.register(name, instance_id, description, project)
+  _instance_id = instance_id
+  _instance_name = name
+  post_async("/api/v1/register", {
+    name = name,
+    instance_id = instance_id,
+    nvim_pid = vim.fn.getpid(),
+    project = project or "",
+    description = description or "",
+  }, function(ok)
+    if not ok then Utils.debug("ipc_service: register failed") end
+  end)
+end
+
+---Unregister this instance (call on sidebar close).
+function M.unregister()
+  if not _instance_id then return end
+  M.stop_timers()
+  post_async("/api/v1/unregister", { instance_id = _instance_id }, nil)
+  _instance_id = nil
+  _instance_name = nil
+end
+
+---Update the responsibility description advertised to coworkers.
+---@param description string
+function M.update_description(description)
+  if not _instance_id then return end
+  post_async("/api/v1/update_description", {
+    instance_id = _instance_id,
+    description = description or "",
+  }, nil)
+end
+
+-- ---------------------------------------------------------------------------
+-- Instance listing (synchronous — called from tool func on the main thread)
+-- ---------------------------------------------------------------------------
+
+---Return all live peer instances (excluding self).
+---@return { name: string, project: string, description: string }[]
+function M.list_instances()
+  if not _instance_id then return {} end
+  local url = M.get_ipc_service_url()
+    .. "/api/v1/instances?exclude_instance_id="
+    .. vim.uri_encode(_instance_id)
+  local res = curl.get(url, { timeout = 3000 })
+  if not res or res.status ~= 200 then return {} end
+  local ok, data = pcall(vim.json.decode, res.body)
+  if not ok or type(data) ~= "table" then return {} end
+  return data
+end
+
+---Send a message to a named peer (synchronous).
+---@param to_name string
+---@param message string
+---@return boolean ok
+---@return string|nil err
+function M.send_message(to_name, message)
+  if not _instance_name then return false, "IPC: not registered" end
+  local url = M.get_ipc_service_url() .. "/api/v1/send_message"
+  local ok, json = pcall(vim.json.encode, {
+    from_name = _instance_name,
+    to_name = to_name,
+    message = message,
+  })
+  if not ok then return false, "IPC: encode error" end
+  local res = curl.post(url, {
+    body = json,
+    headers = { ["Content-Type"] = "application/json" },
+    timeout = 3000,
+  })
+  if not res then return false, "IPC: no response" end
+  if res.status == 404 then
+    local ok2, data = pcall(vim.json.decode, res.body or "")
+    local detail = (ok2 and data and data.detail) or "target not found"
+    return false, detail
+  end
+  if res.status ~= 200 then return false, string.format("IPC: HTTP %d", res.status) end
+  return true, nil
+end
+
+-- ---------------------------------------------------------------------------
+-- Heartbeat + message polling timers
+-- ---------------------------------------------------------------------------
+
+---Send a heartbeat, re-registering if the service has forgotten us.
+local function do_heartbeat()
+  if not _instance_id or not _instance_name then return end
+  post_async("/api/v1/heartbeat", {
+    instance_id = _instance_id,
+  }, function(ok, _)
+    if not ok then
+      -- 404 means the service was restarted; re-register.
+      Utils.debug("ipc_service: heartbeat failed, re-registering...")
+      M.register(_instance_name, _instance_id, nil, nil)
+    end
+  end)
+end
+
+---Poll for pending messages and deliver them via the registered callback.
+local function do_poll()
+  if not _instance_name then return end
+  get_async("/api/v1/poll_messages/" .. _instance_name, function(ok, data)
+    if not ok or type(data) ~= "table" then return end
+    if #data == 0 then return end
+    if not _on_message_cb then return end
+    vim.schedule(function()
+      for _, msg in ipairs(data) do
+        if _on_message_cb and msg.from_name and msg.message then
+          _on_message_cb(msg.from_name, msg.message)
+        end
+      end
+    end)
+  end)
+end
+
+---Start periodic heartbeat and message-poll timers.
+---@param on_message fun(from_name: string, message: string)
+function M.start_timers(on_message)
+  _on_message_cb = on_message
+
+  if _heartbeat_timer then
+    _heartbeat_timer:stop()
+    _heartbeat_timer:close()
+  end
+  _heartbeat_timer = vim.uv.new_timer()
+  _heartbeat_timer:start(HEARTBEAT_INTERVAL_MS, HEARTBEAT_INTERVAL_MS, vim.schedule_wrap(do_heartbeat))
+
+  if _poll_timer then
+    _poll_timer:stop()
+    _poll_timer:close()
+  end
+  _poll_timer = vim.uv.new_timer()
+  _poll_timer:start(POLL_INTERVAL_MS, POLL_INTERVAL_MS, vim.schedule_wrap(do_poll))
+end
+
+---Stop heartbeat and poll timers.
+function M.stop_timers()
+  if _heartbeat_timer then
+    _heartbeat_timer:stop()
+    _heartbeat_timer:close()
+    _heartbeat_timer = nil
+  end
+  if _poll_timer then
+    _poll_timer:stop()
+    _poll_timer:close()
+    _poll_timer = nil
+  end
+  _on_message_cb = nil
+end
+
+return M
+

--- a/lua/avante/llm.lua
+++ b/lua/avante/llm.lua
@@ -29,9 +29,28 @@ local group = api.nvim_create_augroup("avante_llm", { clear = true })
 ---@param prev_memory string | nil
 ---@param history_messages avante.HistoryMessage[]
 ---@param cb fun(memory: avante.ChatMemory | nil): nil
-function M.summarize_memory(prev_memory, history_messages, cb)
-  local system_prompt =
-    [[You are an expert coding assistant. Your goal is to generate a concise, structured summary of the conversation below that captures all essential information needed to continue development after context replacement. Include tasks performed, code areas modified or reviewed, key decisions or assumptions, test results or errors, and outstanding tasks or next steps.]]
+---@param prev_memory string | nil
+---@param history_messages avante.HistoryMessage[]
+---@param cb fun(memory: avante.ChatMemory | nil): nil
+---@param mode? "compact" | "simplify"  -- "compact" (default): readable structured summary; "simplify": ultra-terse bullet points
+function M.summarize_memory(prev_memory, history_messages, cb, mode)
+  local system_prompt
+  local user_prompt_suffix
+  if mode == "simplify" then
+    system_prompt = [[You are an expert software engineering assistant.
+Your task is to create the most compact possible summary of a coding conversation.
+Be EXTREMELY concise. Include only what an engineer MUST know to continue the work:
+- Current state of the code (what was built, changed, or fixed)
+- Exact errors or blockers still unresolved
+- The precise next step(s) remaining
+- Any critical decisions, constraints, or gotchas
+Omit all explanations, rationale, and conversational filler. Output dense, terse bullet points.]]
+    user_prompt_suffix = "\n\nProvide the minimal engineering-context summary. Use terse bullet points only."
+  else
+    system_prompt = [[You are an expert coding assistant. Your goal is to generate a concise, structured summary of the conversation below that captures all essential information needed to continue development after context replacement. Include tasks performed, code areas modified or reviewed, key decisions or assumptions, test results or errors, and outstanding tasks or next steps.]]
+    user_prompt_suffix = "\n\nPlease summarize this conversation, covering:\n1. Tasks performed and outcomes\n2. Code files, modules, or functions modified or examined\n3. Important decisions or assumptions made\n4. Errors encountered and test or build results\n5. Remaining tasks, open questions, or next steps\nProvide the summary in a clear, concise format."
+  end
+
   if #history_messages == 0 then
     cb(nil)
     return
@@ -55,9 +74,7 @@ function M.summarize_memory(prev_memory, history_messages, cb)
     :map(function(msg) return msg.message.role .. ": " .. HistoryRender.message_to_text(msg, history_messages) end)
     :totable()
   local conversation_text = table.concat(conversation_items, "\n")
-  local user_prompt = "Here is the conversation so far:\n"
-    .. conversation_text
-    .. "\n\nPlease summarize this conversation, covering:\n1. Tasks performed and outcomes\n2. Code files, modules, or functions modified or examined\n3. Important decisions or assumptions made\n4. Errors encountered and test or build results\n5. Remaining tasks, open questions, or next steps\nProvide the summary in a clear, concise format."
+  local user_prompt = "Here is the conversation so far:\n" .. conversation_text .. user_prompt_suffix
   if prev_memory then user_prompt = user_prompt .. "\n\nThe previous summary is:\n\n" .. prev_memory end
   local messages = {
     {
@@ -92,6 +109,89 @@ function M.summarize_memory(prev_memory, history_messages, cb)
             last_message_uuid = latest_message_uuid,
           }
           cb(memory)
+        else
+          cb(nil)
+        end
+      end,
+    },
+  })
+end
+
+--- Alias for `summarize_memory` with mode="simplify".
+--- Kept as a separate entry-point so call-sites remain explicit.
+---@param prev_memory string | nil
+---@param history_messages avante.HistoryMessage[]
+---@param cb fun(memory: avante.ChatMemory | nil): nil
+function M.simplify_history(prev_memory, history_messages, cb)
+  M.summarize_memory(prev_memory, history_messages, cb, "simplify")
+end
+
+--- Draft a message to send to another Avante chat instance.
+--- The LLM uses the current conversation history as context and composes a
+--- self-contained message that captures the user's intent so that the
+--- receiving instance has all the information it needs.
+---@param history_messages avante.HistoryMessage[]  current chat's history
+---@param user_intent string                        what the user wants to communicate
+---@param sender_name string                        instance name of the sending chat
+---@param target_name string                        instance name of the receiving chat
+---@param cb fun(drafted_message: string | nil): nil
+function M.draft_inter_instance_message(history_messages, user_intent, sender_name, target_name, cb)
+  local system_prompt = string.format(
+    [[You are the AI assistant for the coding chat session "%s".
+You are composing a message to send to another AI assistant session named "%s".
+Both sessions are running concurrently inside the same editor on the same codebase.
+
+Given the conversation history below and the user's stated intent, draft a clear,
+self-contained message for the receiving session.  The message must:
+- Include all context the receiving session needs (it cannot see our history)
+- Be concise but complete — the receiver will act on it directly
+- Sound like a peer-to-peer handoff, not a forwarded chat log
+
+Output ONLY the message body — no preamble, no "Here is the message:", no quotes.]],
+    sender_name,
+    target_name
+  )
+
+  local conversation_items = vim
+    .iter(history_messages)
+    :filter(function(msg) return not msg.is_dummy and not msg.just_for_display end)
+    :map(function(msg) return msg.message.role .. ": " .. HistoryRender.message_to_text(msg, history_messages) end)
+    :totable()
+  local conversation_text = table.concat(conversation_items, "\n")
+
+  local user_prompt = "Current conversation history:\n"
+    .. conversation_text
+    .. "\n\nUser's intent for the message to send:\n"
+    .. user_intent
+    .. "\n\nDraft the message to send to ["
+    .. target_name
+    .. "]:"
+
+  local messages = { { role = "user", content = user_prompt } }
+  local response_content = ""
+  local provider = Providers.get_memory_summary_provider()
+
+  M.curl({
+    provider = provider,
+    prompt_opts = {
+      system_prompt = system_prompt,
+      messages = messages,
+    },
+    handler_opts = {
+      on_start = function(_) end,
+      on_chunk = function(chunk)
+        if not chunk then return end
+        response_content = response_content .. chunk
+      end,
+      on_stop = function(stop_opts)
+        if stop_opts.error ~= nil then
+          Utils.error(string.format("draft_inter_instance_message failed: %s", vim.inspect(stop_opts.error)))
+          cb(nil)
+          return
+        end
+        if stop_opts.reason == "complete" then
+          response_content = Utils.trim_think_content(response_content)
+          cb(response_content ~= "" and response_content or nil)
         else
           cb(nil)
         end

--- a/lua/avante/path.lua
+++ b/lua/avante/path.lua
@@ -3,6 +3,7 @@ local Utils = require("avante.utils")
 local Path = require("plenary.path")
 local Scan = require("plenary.scandir")
 local Config = require("avante.config")
+local Names = require("avante.utils.names")
 
 ---@class avante.Path
 ---@field history_path string
@@ -128,6 +129,7 @@ end
 ---@param bufnr integer
 function History.new(bufnr)
   local filepath = History.get_latest_filepath(bufnr, true)
+  local instance_name = Names.generate()
   ---@type avante.ChatHistory
   local history = {
     title = "untitled",
@@ -136,6 +138,8 @@ function History.new(bufnr)
     messages = {},
     todos = {},
     filename = filepath_to_filename(filepath),
+    instance_id = Utils.uuid(),
+    instance_name = instance_name,
   }
   return history
 end
@@ -157,6 +161,12 @@ function History.from_file(filepath)
         if not vim.islist(history.todos) then history.todos = {} end
         ---@cast history avante.ChatHistory
         history.filename = filepath_to_filename(filepath)
+        if not history.instance_id or history.instance_id == "" then history.instance_id = Utils.uuid() end
+        if not history.instance_name or history.instance_name == "" then
+          history.instance_name = Names.generate()
+        else
+          Names.register(history.instance_name)
+        end
         return history
       end
     end

--- a/lua/avante/sidebar.lua
+++ b/lua/avante/sidebar.lua
@@ -2579,6 +2579,242 @@ function Sidebar:show_selected_files_hint()
   local line_number = cursor_pos[1]
   local col_number = cursor_pos[2]
 
+  -- Build sender identity now so closures capture the current values.
+  local sender_name = self.chat_history and self.chat_history.instance_name or "unknown"
+  local sender_id = self.chat_history and self.chat_history.instance_id or nil
+
+  -- Determine IPC mode: cross-process IPC service, or fallback in-process registry.
+  local Config = require("avante.config")
+  local ipc_enabled = Config.ipc_service and Config.ipc_service.enabled
+
+  -- Build sub-agent dispatch IDs owned by this sidebar so we can label them
+  -- correctly in the listing (they are employees/dispatched workers, not peers).
+  local session_id = tostring(self.code.bufnr or "default")
+  local DispatchRegistry = require("avante.dispatch_registry")
+
+  table.insert(tools, {
+    name = "send_message",
+    description = string.format(
+      [[Send a message to another root-level Avante co-agent instance.
+
+This tool connects peer Avante instances (co-workers with equal standing).
+It does NOT target dispatch_agent sub-agents — those are background workers
+you already control directly via dispatch_agent / dispatch_await.
+
+⚠️  Use this tool ONLY when:
+1. The user EXPLICITLY asks you to contact another instance, OR
+2. You received a message from another co-agent (shown with "← From [name]") and need to reply.
+
+Do NOT contact peers proactively on your own initiative.
+
+YOUR instance name: [%s]
+
+⚠️  IDENTITY RULES — read carefully:
+- You are a co-agent instance named [%s], NOT a human user.
+- When you send a message, the receiver has NO idea who you are unless you tell them.
+- ALWAYS open your message with an identity line so the receiver knows they are
+  talking to another AI instance, not a human.  Use this exact format:
+    "← From [%s] (Avante co-agent, not a user): <your message here>"
+- If you omit this header, the receiving instance will assume they are talking to
+  a human user and will behave incorrectly.
+
+Relationship guide:
+  • Co-agents (peers / co-workers): other root Avante instances — use THIS tool.
+  • Sub-agents (employees): dispatched via dispatch_agent — they report back to you,
+    you do not message them; monitor them with dispatch_status / dispatch_await instead.
+
+Steps:
+  1. Call with action="list" to see live co-agents and what they are working on.
+  2. Call with action="send" to deliver your message.
+
+When action="send":
+  - "target_instance": exact name of the peer (e.g. "swift-fox")
+  - "message": the text to deliver — be concise and contextual, and ALWAYS begin
+    with the identity header described above]],
+      sender_name,
+      sender_name,
+      sender_name
+    ),
+    ---@type AvanteLLMToolFunc<{ action: "list"|"send", target_instance?: string, message?: string }>
+    func = function(input, opts)
+      local Avante = require("avante")
+
+      -- ----------------------------------------------------------------
+      -- LIST
+      -- ----------------------------------------------------------------
+      if input.action == "list" then
+        if ipc_enabled then
+          -- Cross-process listing via IPC service.
+          local IpcService = require("avante.ipc_service")
+          local peers = IpcService.list_instances() -- synchronous
+          -- Also include in-process siblings (same nvim, different tabs/buffers).
+          local in_proc = vim.tbl_keys(Avante.instance_registry)
+          local in_proc_names = vim.iter(in_proc):filter(function(n) return n ~= sender_name end):totable()
+
+          -- Merge: IPC peers already exclude self (by instance_id); de-dup with in-proc list.
+          local seen = {}
+          local lines = {}
+          for _, peer in ipairs(peers) do
+            if not seen[peer.name] then
+              seen[peer.name] = true
+              local desc = (peer.description and peer.description ~= "") and peer.description or "(no description)"
+              local project = (peer.project and peer.project ~= "") and (" | project: " .. peer.project) or ""
+              table.insert(lines, string.format("  • %s — %s%s", peer.name, desc, project))
+            end
+          end
+          for _, n in ipairs(in_proc_names) do
+            if not seen[n] then
+              seen[n] = true
+              table.insert(lines, string.format("  • %s — (same nvim process, no description available)", n))
+            end
+          end
+
+          if #lines == 0 then return "No other active co-agent instances found.", nil end
+          return "Active co-agent instances:\n" .. table.concat(lines, "\n"), nil
+        else
+          -- In-process only listing.
+          local Avante2 = require("avante")
+          local names = vim.iter(vim.tbl_keys(Avante2.instance_registry))
+            :filter(function(n) return n ~= sender_name end)
+            :totable()
+          if #names == 0 then
+            return "No other active co-agent instances found in this Neovim session.\n"
+              .. "Tip: enable ipc_service to discover instances in other Neovim processes.",
+              nil
+          end
+          return "Active co-agent instances (this nvim session only):\n  • "
+            .. table.concat(names, "\n  • "),
+            nil
+        end
+      end
+
+      -- ----------------------------------------------------------------
+      -- SEND
+      -- ----------------------------------------------------------------
+      if input.action == "send" then
+        local target_name = input.target_instance
+        local message_text = input.message
+        if not target_name or target_name == "" then return nil, "target_instance is required" end
+        if not message_text or message_text == "" then return nil, "message is required" end
+
+        local on_log = opts and opts.on_log
+        if on_log then on_log(string.format("→ [%s]: %s", target_name, message_text:sub(1, 80))) end
+
+        -- Try IPC delivery first (cross-process) when enabled.
+        if ipc_enabled then
+          local IpcService = require("avante.ipc_service")
+          local ok, err = IpcService.send_message(target_name, message_text)
+          if ok then
+            -- Also attempt in-process delivery in case the target is in the same nvim.
+            local in_proc_target = Avante.instance_registry[target_name]
+            if in_proc_target and in_proc_target ~= self then
+              local injected = History.Message:new("user", message_text, {
+                from_instance = sender_name,
+                is_user_submission = false,
+                visible = true,
+              })
+              injected.is_coagent_message = true
+              in_proc_target:add_history_messages({ injected })
+              in_proc_target:save_history()
+              if Utils.is_valid_container(in_proc_target.containers.result, true) then
+                pcall(function() in_proc_target:update_content_with_history() end)
+              end
+            end
+            return string.format("Message queued for co-agent [%s].", target_name), nil
+          end
+          -- If IPC failed, try in-process as last resort.
+          local in_proc_target = Avante.instance_registry[target_name]
+          if in_proc_target and in_proc_target ~= self then
+            local injected = History.Message:new("user", message_text, {
+              from_instance = sender_name,
+              is_user_submission = false,
+              visible = true,
+            })
+            injected.is_coagent_message = true
+            in_proc_target:add_history_messages({ injected })
+            in_proc_target:save_history()
+            if Utils.is_valid_container(in_proc_target.containers.result, true) then
+              pcall(function() in_proc_target:update_content_with_history() end)
+            end
+            return string.format("Message delivered (in-process) to co-agent [%s].", target_name), nil
+          end
+          return nil, string.format("Co-agent '%s' not found: %s", target_name, err or "unknown error")
+        end
+
+        -- In-process only delivery.
+        local target_sidebar = Avante.instance_registry[target_name]
+        if not target_sidebar then
+          local available = table.concat(
+            vim.iter(vim.tbl_keys(Avante.instance_registry))
+              :filter(function(n) return n ~= sender_name end)
+              :totable(),
+            ", "
+          )
+          return nil,
+            string.format(
+              "Co-agent '%s' not found in this nvim session. Available: %s\nTip: enable ipc_service to reach instances in other Neovim processes.",
+              target_name,
+              available ~= "" and available or "(none)"
+            )
+        end
+        if target_sidebar == self then return nil, "Cannot send a message to yourself" end
+
+        local injected = History.Message:new("user", message_text, {
+          from_instance = sender_name,
+          is_user_submission = false,
+          visible = true,
+        })
+        injected.is_coagent_message = true
+        target_sidebar:add_history_messages({ injected })
+        target_sidebar:save_history()
+        if Utils.is_valid_container(target_sidebar.containers.result, true) then
+          pcall(function() target_sidebar:update_content_with_history() end)
+        end
+        return string.format("Message delivered to co-agent [%s].", target_name), nil
+      end
+
+      return nil, "Unknown action '" .. tostring(input.action) .. "'. Use 'list' or 'send'."
+    end,
+    param = {
+      type = "table",
+      fields = {
+        {
+          name = "action",
+          description = "'list' to see available co-agent instances with their current responsibilities, 'send' to deliver a message",
+          type = "string",
+        },
+        {
+          name = "target_instance",
+          description = "The name of the destination co-agent instance (required when action='send')",
+          type = "string",
+          optional = true,
+        },
+        {
+          name = "message",
+          description = "The message text to deliver (required when action='send')",
+          type = "string",
+          optional = true,
+        },
+      },
+      usage = {
+        action = "list",
+      },
+    },
+    returns = {
+      {
+        name = "result",
+        description = "Confirmation message or formatted list of co-agent instances with their responsibilities",
+        type = "string",
+      },
+      {
+        name = "error",
+        description = "Error message if the operation failed",
+        type = "string",
+        optional = true,
+      },
+    },
+  })
+
   local selected_filepaths_ = self.file_selector:get_selected_filepaths()
   local hint
   if #selected_filepaths_ == 0 then

--- a/lua/avante/slashcommands.lua
+++ b/lua/avante/slashcommands.lua
@@ -11,9 +11,11 @@
 --- - `/clear`: clear chat history
 --- - `/new`: start a new chat
 --- - `/compact`: compact history messages
+--- - `/simplify`: aggressively simplify chat history, keeping only critical engineering context
 --- - `/model`: select model
 --- - `/lines <start>-<end> <question>`: ask about specific lines
 --- - `/commit`: generate a commit message
+--- - `/send <instance-name> <message>`: send a message to another Avante instance (hidden when ipc_service is enabled)
 ---@brief ]]
 
 ---@class avante.SlashCommands
@@ -49,6 +51,11 @@ local builtin_commands = {
     name = "compact",
   },
   {
+    description = "Maximally simplify history, keeping only critical engineering context",
+    details = "Maximally simplify history, keeping only critical engineering context",
+    name = "simplify",
+  },
+  {
     description = "Select model",
     details = "Select model",
     name = "model",
@@ -63,6 +70,12 @@ local builtin_commands = {
     description = "Commit the changes",
     details = "Commit the changes",
     name = "commit",
+  },
+  {
+    shorthelp = "Send a message to another Avante instance",
+    description = "/send <instance-name> <intent>",
+    details = "Ask the current chat's model to draft and send a message to another active Avante instance\n/send <instance-name> <what to communicate>",
+    name = "send",
   },
 }
 
@@ -85,6 +98,7 @@ local callbacks = {
   clear = function(sidebar, args, cb) sidebar:clear_history(args, cb) end,
   new = function(sidebar, args, cb) sidebar:new_chat(args, cb) end,
   compact = function(sidebar, args, cb) sidebar:compact_history_messages(args, cb) end,
+  simplify = function(sidebar, args, cb) sidebar:simplify_history_messages(args, cb) end,
   init = function(sidebar, args, cb) sidebar:init_current_project(args, cb) end,
   lines = function(_, args, cb)
     if cb then cb(args) end
@@ -103,12 +117,27 @@ local callbacks = {
     end
     if cb then cb("") end
   end,
+  -- /send is a convenience wrapper around the send_message LLM tool for
+  -- in-process (same-nvim) instance messaging.  When the IPC service is
+  -- enabled the LLM tool handles cross-process delivery directly, so /send
+  -- is redundant and would only confuse the model with stale in-process-only
+  -- semantics.  We keep the callback in case someone invokes it at runtime
+  -- but filter the command out of the visible list below.
+  send = function(sidebar, args, cb) sidebar:send_message_to_instance(args, cb) end,
 }
 
 ---@return AvanteSlashCommand[]
 function M.get_builtin_commands()
+  local Config = require("avante.config")
+  local ipc_enabled = Config.ipc_service and Config.ipc_service.enabled
   return vim
     .iter(builtin_commands)
+    :filter(function(command)
+      -- Hide /send when the IPC service is enabled — cross-process messaging
+      -- is handled transparently by the send_message LLM tool instead.
+      if command.name == "send" and ipc_enabled then return false end
+      return true
+    end)
     :map(
       ---@param command AvanteSlashCommand
       function(command)

--- a/lua/avante/types.lua
+++ b/lua/avante/types.lua
@@ -118,7 +118,8 @@ vim.g.avante_login = vim.g.avante_login
 ---@field turn_id string | nil
 ---@field is_calling boolean | nil
 ---@field original_content AvanteLLMMessageContent | nil
----@field acp_tool_call? avante.acp.ToolCall | avante.acp.ToolCallUpdate
+---@field acp_tool_call? avante.acp.ToolCall
+---@field from_instance string | nil   -- instance_name of the sending chat (cross-instance message)
 
 ---@class AvanteLLMToolResult
 ---@field tool_name string
@@ -526,6 +527,8 @@ vim.g.avante_login = vim.g.avante_login
 ---@field system_prompt string | nil
 ---@field tokens_usage avante.LLMTokenUsage | nil
 ---@field acp_session_id string | nil
+---@field instance_id string | nil   -- UUID for this chat session
+---@field instance_name string | nil -- human-readable name (e.g. "swift-fox")
 ---
 ---@class avante.ChatMemory
 ---@field content string
@@ -542,7 +545,7 @@ vim.g.avante_login = vim.g.avante_login
 ---@field content string
 ---@field uri string
 ---
----@alias AvanteSlashCommandBuiltInName "clear" | "help" | "lines" | "commit" | "new" | "init" | "compact" | "model"
+---@alias AvanteSlashCommandBuiltInName "clear" | "help" | "lines" | "commit" | "new" | "init" | "compact" | "model" | "simplify" | "send"
 ---@alias AvanteSlashCommandCallback fun(self: avante.Sidebar, args: string, cb?: fun(args: string): nil): nil
 ---@class AvanteSlashCommand
 ---@field name AvanteSlashCommandBuiltInName | string

--- a/lua/avante/utils/names.lua
+++ b/lua/avante/utils/names.lua
@@ -1,0 +1,73 @@
+---@mod avante-names avante instance name generation
+---@brief [[
+--- Generates human-readable, memorable names for Avante chat instances.
+--- Each name is an adjective + noun combination chosen at random.
+---@brief ]]
+
+local M = {}
+
+-- Word lists for generating friendly instance names.
+local adjectives = {
+  "amber", "azure", "bold", "bright", "calm", "cedar", "cobalt", "cool",
+  "crisp", "cyan", "dark", "deep", "dim", "dusk", "fern", "firm", "flame",
+  "free", "frost", "gold", "jade", "keen", "light", "lime", "mist", "mint",
+  "moon", "moss", "navy", "noir", "oak", "pale", "pine", "pure", "quick",
+  "rose", "ruby", "sage", "salt", "sand", "silk", "slim", "snow", "soft",
+  "solar", "steel", "storm", "swift", "teal", "warm", "wild", "wise",
+}
+
+local nouns = {
+  "arc", "ash", "bay", "beam", "bell", "brook", "crest", "crow", "dawn",
+  "dune", "elm", "fern", "field", "finch", "fjord", "flame", "flare", "fox",
+  "gale", "glen", "grove", "hawk", "hill", "jade", "kite", "lake", "lark",
+  "leaf", "lynx", "marsh", "moon", "oak", "owl", "peak", "pine", "pond",
+  "raven", "reef", "ridge", "rift", "river", "rock", "seal", "sky", "spark",
+  "stone", "stream", "tide", "vale", "wave", "wren",
+}
+
+--- Registry of all names currently in use to avoid collisions.
+---@type table<string, boolean>
+local used_names = {}
+
+--- Generate a unique adjective-noun instance name.
+--- If a collision occurs the noun is suffixed with a counter (e.g. "swift-fox-2").
+---@return string
+function M.generate()
+  math.randomseed(os.time() + math.random(1000))
+  local max_attempts = 20
+  for _ = 1, max_attempts do
+    local adj = adjectives[math.random(#adjectives)]
+    local noun = nouns[math.random(#nouns)]
+    local name = adj .. "-" .. noun
+    if not used_names[name] then
+      used_names[name] = true
+      return name
+    end
+  end
+  -- Fallback: append a random number to guarantee uniqueness.
+  local adj = adjectives[math.random(#adjectives)]
+  local noun = nouns[math.random(#nouns)]
+  local counter = 2
+  local candidate = adj .. "-" .. noun .. "-" .. counter
+  while used_names[candidate] do
+    counter = counter + 1
+    candidate = adj .. "-" .. noun .. "-" .. counter
+  end
+  used_names[candidate] = true
+  return candidate
+end
+
+--- Mark a name as in use (for names loaded from persisted history).
+---@param name string
+function M.register(name)
+  if name and name ~= "" then used_names[name] = true end
+end
+
+--- Release a name so it may be reused.
+---@param name string
+function M.release(name)
+  if name and name ~= "" then used_names[name] = nil end
+end
+
+return M
+

--- a/py/ipc-service/Dockerfile
+++ b/py/ipc-service/Dockerfile
@@ -1,0 +1,21 @@
+FROM python:3.11-slim-bookworm
+
+WORKDIR /app
+
+RUN apt-get update && apt-get install -y --no-install-recommends curl \
+  && rm -rf /var/lib/apt/lists/* \
+  && curl -LsSf https://astral.sh/uv/install.sh | sh
+
+ENV PATH="/root/.local/bin:$PATH" \
+  PYTHONPATH=/app/src \
+  PYTHONUNBUFFERED=1 \
+  PYTHONDONTWRITEBYTECODE=1
+
+COPY requirements.txt .
+
+RUN uv pip install --system -r requirements.txt
+
+COPY . .
+
+CMD ["uvicorn", "src.main:app", "--workers", "1", "--host", "0.0.0.0", "--port", "20251"]
+

--- a/py/ipc-service/requirements.txt
+++ b/py/ipc-service/requirements.txt
@@ -1,0 +1,4 @@
+fastapi==0.115.8
+uvicorn==0.34.0
+pydantic==2.10.6
+

--- a/py/ipc-service/run.sh
+++ b/py/ipc-service/run.sh
@@ -1,0 +1,16 @@
+#!/usr/bin/env bash
+
+TARGET_DIR=$1
+if [ -z "$TARGET_DIR" ]; then
+  TARGET_DIR="$HOME/.local/state/avante-ipc-service"
+fi
+
+mkdir -p "$TARGET_DIR"
+cp -r src/ "$TARGET_DIR"
+cp requirements.txt "$TARGET_DIR"
+cp shell.nix "$TARGET_DIR"
+
+echo "Files have been copied to $TARGET_DIR"
+cd "$TARGET_DIR"
+nix-shell
+

--- a/py/ipc-service/shell.nix
+++ b/py/ipc-service/shell.nix
@@ -1,0 +1,23 @@
+{ pkgs ? import <nixpkgs> {} }:
+let
+  python = pkgs.python311;
+in pkgs.mkShell {
+  packages = [
+    python
+    pkgs.uv
+  ];
+  env = {
+    PYTHONUNBUFFERED = 1;
+    PYTHONDONTWRITEBYTECODE = 1;
+    PORT = 20251;
+  };
+  shellHook = ''
+    if [ ! -d ".venv" ]; then
+      uv venv
+    fi
+    source ".venv/bin/activate"
+    uv pip install -r requirements.txt
+    uv run fastapi run src/main.py --port $PORT --workers 1
+  '';
+}
+

--- a/py/ipc-service/src/main.py
+++ b/py/ipc-service/src/main.py
@@ -1,0 +1,268 @@
+"""Avante IPC Service - cross-process instance registry and message broker.
+
+Each Neovim process running Avante registers its root sidebar instances here so
+that instances in different nvim processes can discover, inspect, and message each
+other.  The service is stateless across restarts: a volatile in-memory registry
+backed by heartbeats; dead instances are reaped automatically.
+"""  # noqa: INP001
+
+from __future__ import annotations
+
+import asyncio
+import os
+import time
+from contextlib import asynccontextmanager
+from typing import TYPE_CHECKING
+
+from fastapi import FastAPI, HTTPException
+from pydantic import BaseModel, Field
+
+if TYPE_CHECKING:
+    from collections.abc import AsyncGenerator
+
+# ---------------------------------------------------------------------------
+# Configuration
+# ---------------------------------------------------------------------------
+
+INSTANCE_TTL_SECONDS = float(os.getenv("IPC_INSTANCE_TTL", "30"))
+REAPER_INTERVAL_SECONDS = 5.0
+
+
+# ---------------------------------------------------------------------------
+# Data models
+# ---------------------------------------------------------------------------
+
+
+class InstanceInfo(BaseModel):
+    name: str = Field(..., description="Adjective-noun instance name e.g. swift-fox")
+    instance_id: str = Field(..., description="Stable UUID assigned to this history session")
+    nvim_pid: int = Field(..., description="PID of the owning Neovim process")
+    project: str = Field("", description="Absolute path of the project this instance is working in")
+    description: str = Field("", description="Short summary of what this instance is currently doing")
+    registered_at: float = Field(default_factory=time.time)
+    last_heartbeat: float = Field(default_factory=time.time)
+
+
+class RegisterRequest(BaseModel):
+    name: str
+    instance_id: str
+    nvim_pid: int
+    project: str = ""
+    description: str = ""
+
+
+class HeartbeatRequest(BaseModel):
+    instance_id: str
+    description: str | None = None
+
+
+class UnregisterRequest(BaseModel):
+    instance_id: str
+
+
+class UpdateDescriptionRequest(BaseModel):
+    instance_id: str
+    description: str
+
+
+class SendMessageRequest(BaseModel):
+    from_name: str = Field(..., description="Sender instance name")
+    to_name: str = Field(..., description="Recipient instance name")
+    message: str = Field(..., description="Message body")
+
+
+class PendingMessage(BaseModel):
+    from_name: str
+    message: str
+    sent_at: float = Field(default_factory=time.time)
+
+
+class InstanceSummary(BaseModel):
+    name: str
+    instance_id: str
+    nvim_pid: int
+    project: str
+    description: str
+    registered_at: float
+    last_heartbeat: float
+
+
+# ---------------------------------------------------------------------------
+# In-memory registry
+# ---------------------------------------------------------------------------
+
+_registry: dict[str, InstanceInfo] = {}
+_message_queues: dict[str, list[PendingMessage]] = {}
+_registry_lock = asyncio.Lock()
+
+
+# ---------------------------------------------------------------------------
+# Background reaper
+# ---------------------------------------------------------------------------
+
+
+async def _reaper() -> None:
+    while True:
+        await asyncio.sleep(REAPER_INTERVAL_SECONDS)
+        now = time.time()
+        async with _registry_lock:
+            stale = [
+                iid for iid, info in _registry.items()
+                if now - info.last_heartbeat > INSTANCE_TTL_SECONDS
+            ]
+            for iid in stale:
+                name = _registry[iid].name
+                del _registry[iid]
+                _message_queues.pop(name, None)
+
+
+@asynccontextmanager
+async def lifespan(app: FastAPI) -> AsyncGenerator[None, None]:  # noqa: ARG001
+    task = asyncio.create_task(_reaper())
+    yield
+    task.cancel()
+    try:
+        await task
+    except asyncio.CancelledError:
+        pass
+
+
+# ---------------------------------------------------------------------------
+# Application
+# ---------------------------------------------------------------------------
+
+app = FastAPI(
+    title="Avante IPC Service",
+    description=(
+        "Cross-process instance registry and message broker for Avante.nvim. "
+        "Enables root Avante sidebar instances in separate Neovim processes to "
+        "discover each other, share responsibility context, and exchange messages."
+    ),
+    version="0.0.1",
+    lifespan=lifespan,
+)
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _find_by_name(name: str) -> InstanceInfo | None:
+    return next((i for i in _registry.values() if i.name == name), None)
+
+
+# ---------------------------------------------------------------------------
+# Endpoints
+# ---------------------------------------------------------------------------
+
+
+@app.get("/api/health")
+async def health_check() -> dict[str, str]:
+    """Health / readiness probe polled by Lua until the service is up."""
+    return {"status": "ok"}
+
+
+@app.post("/api/v1/register", response_model=dict[str, str])
+async def register(req: RegisterRequest) -> dict[str, str]:
+    """Register a sidebar instance (idempotent: re-registering refreshes metadata)."""
+    async with _registry_lock:
+        existing = _registry.get(req.instance_id)
+        if existing:
+            existing.name = req.name
+            existing.nvim_pid = req.nvim_pid
+            existing.project = req.project
+            if req.description:
+                existing.description = req.description
+            existing.last_heartbeat = time.time()
+        else:
+            _registry[req.instance_id] = InstanceInfo(
+                name=req.name,
+                instance_id=req.instance_id,
+                nvim_pid=req.nvim_pid,
+                project=req.project,
+                description=req.description,
+            )
+            _message_queues.setdefault(req.name, [])
+    return {"status": "ok", "instance_id": req.instance_id}
+
+
+@app.post("/api/v1/unregister", response_model=dict[str, str])
+async def unregister(req: UnregisterRequest) -> dict[str, str]:
+    """Unregister an instance (called on sidebar close / nvim exit)."""
+    async with _registry_lock:
+        info = _registry.pop(req.instance_id, None)
+        if info:
+            _message_queues.pop(info.name, None)
+    return {"status": "ok"}
+
+
+@app.post("/api/v1/heartbeat", response_model=dict[str, str])
+async def heartbeat(req: HeartbeatRequest) -> dict[str, str]:
+    """Refresh TTL for an instance; returns 404 if not found (need to re-register)."""
+    async with _registry_lock:
+        info = _registry.get(req.instance_id)
+        if not info:
+            raise HTTPException(status_code=404, detail="Instance not found - re-register first")
+        info.last_heartbeat = time.time()
+        if req.description is not None:
+            info.description = req.description[:500]
+    return {"status": "ok"}
+
+
+@app.post("/api/v1/update_description", response_model=dict[str, str])
+async def update_description(req: UpdateDescriptionRequest) -> dict[str, str]:
+    """Update the responsibility description for an instance."""
+    async with _registry_lock:
+        info = _registry.get(req.instance_id)
+        if not info:
+            raise HTTPException(status_code=404, detail="Instance not found")
+        info.description = req.description[:500]
+        info.last_heartbeat = time.time()
+    return {"status": "ok"}
+
+
+@app.get("/api/v1/instances", response_model=list[InstanceSummary])
+async def list_instances(exclude_instance_id: str | None = None) -> list[InstanceSummary]:
+    """List all live instances, each with their description so callers know what coworkers are doing."""
+    async with _registry_lock:
+        result = [
+            InstanceSummary(
+                name=i.name,
+                instance_id=i.instance_id,
+                nvim_pid=i.nvim_pid,
+                project=i.project,
+                description=i.description,
+                registered_at=i.registered_at,
+                last_heartbeat=i.last_heartbeat,
+            )
+            for i in _registry.values()
+            if i.instance_id != exclude_instance_id
+        ]
+    return result
+
+
+@app.post("/api/v1/send_message", response_model=dict[str, str])
+async def send_message(req: SendMessageRequest) -> dict[str, str]:
+    """Queue a message for a target instance; returns 404 if target is not registered."""
+    async with _registry_lock:
+        target = _find_by_name(req.to_name)
+        if not target:
+            available = sorted(i.name for i in _registry.values() if i.name != req.from_name)
+            raise HTTPException(
+                status_code=404,
+                detail=f"Instance {req.to_name!r} not registered. Available: {', '.join(available) or 'none'}",
+            )
+        _message_queues.setdefault(req.to_name, []).append(
+            PendingMessage(from_name=req.from_name, message=req.message)
+        )
+    return {"status": "ok", "queued_for": req.to_name}
+
+
+@app.get("/api/v1/poll_messages/{instance_name}", response_model=list[PendingMessage])
+async def poll_messages(instance_name: str) -> list[PendingMessage]:
+    """Drain and return all pending messages (at-most-once delivery)."""
+    async with _registry_lock:
+        msgs = _message_queues.get(instance_name, [])
+        _message_queues[instance_name] = []
+    return list(msgs)


### PR DESCRIPTION
## Summary

Allows multiple concurrent Avante chat instances (same or different Neovim processes) to discover each other, exchange LLM-drafted messages, and coordinate work on the same codebase.

**In-process messaging (no setup required):**
- `send_message` LLM tool: `action="list"` discovers peers; `action="send"` delivers a message to a named instance
- `/send <instance-name> <intent>` slash command: the current chat's model drafts a self-contained message from conversation history and injects it into the target sidebar with a `"← From [name]"` attribution header
- `llm.lua`: `M.draft_inter_instance_message()` composes a peer-to-peer handoff message using the LLM
- `from_instance` field on `History.Message` marks cross-instance messages for the renderer

**History simplification:**
- `/simplify` slash command: aggressively distils the chat memory to minimal engineering-critical context (current state, blockers, next steps)
- `M.summarize_memory()` gains a `mode` parameter; `"simplify"` uses an ultra-terse system prompt

**Optional cross-process IPC service (requires Docker or Nix):**
- `py/ipc-service/`: FastAPI service with REST endpoints for registration, heartbeats, listing, and message routing
- `ipc_service.lua`: Lua client matching the `rag_service` architecture; manages heartbeat/poll timers
- Enable with `ipc_service = { enabled = true, runner = "docker" }` in your config
- `send_message` tool automatically uses IPC for cross-process delivery with in-process fallback
- `/send` is hidden from slash-command completions when IPC is enabled (the tool handles delivery transparently)

**Docs:** New "Multi-Instance Messaging" section added to README.

## Test plan
- [ ] Open two Avante sidebars, use `send_message` tool with `action="list"` and confirm both appear
- [ ] Use `/send <name> <intent>` and confirm the message appears in the target sidebar with the `"← From"` header
- [ ] Use `/simplify` and confirm the chat memory is condensed
- [ ] (Optional) Enable `ipc_service`, open two separate Neovim processes, and confirm cross-process messaging works