### PR TITLE
tests: replace plenary to use busted/nlua directly

### DIFF
--- a/.busted
+++ b/.busted
@@ -1,0 +1,18 @@
+return {
+  _all = {
+    lua = "nlua",
+    helper = "tests/nlua_helper.lua",
+    lpath = table.concat({
+      "./lua/?.lua",
+      "./lua/?/init.lua",
+      "./tests/?.lua",
+    }, ";"),
+    cpath = table.concat({
+      "./lua/?.so",
+      "./lua/?/?.so",
+    }, ";"),
+  },
+  default = {
+    ROOT = { "tests" },
+  },
+}

--- a/.github/workflows/lua.yaml
+++ b/.github/workflows/lua.yaml
@@ -24,45 +24,16 @@ jobs:
       matrix:
         include:
           - os: ubuntu-24.04
-            rev: v0.11.0
     steps:
       - uses: actions/checkout@v6
 
-      - id: todays-date
-        run: echo "date=$(date +%F)" >> "$GITHUB_OUTPUT"
-
-      - name: Restore cache for today's nightly.
-        id: cache-neovim
-        uses: actions/cache@v4
-        with:
-          path: _neovim
-          key: ${{ runner.os }}-${{ matrix.rev }}-${{ steps.todays-date.outputs.date }}
-
-      - name: Download neovim ${{ matrix.rev }}
-        env:
-          GH_TOKEN: ${{ github.token }}
-          NEOVIM_VERSION: ${{ matrix.rev }}
-        if: steps.cache-neovim.outputs.cache-hit != 'true'
-        run: |
-          mkdir -p _neovim
-          gh release download \
-            --output - \
-            --pattern nvim-linux-x86_64.tar.gz \
-            --repo neovim/neovim \
-            "$NEOVIM_VERSION" | tar xvz --strip-components 1 --directory _neovim
-
-      - name: Prepare
-        run: |
-          sudo apt-get update
-          sudo apt-get install -y ripgrep
-          sudo apt-get install -y silversearcher-ag
-          echo "${PWD}/_neovim/bin" >> "$GITHUB_PATH"
-          echo VIM="${PWD}/_neovim/share/nvim/runtime" >> "$GITHUB_ENV"
+      - name: Install Nix
+        uses: DeterminateSystems/nix-installer-action@v16
 
       - name: Run tests
         run: |
-          nvim --version
-          make luatest
+          nix develop .#ci --command nvim --version
+          nix develop .#ci --command make luatest
 
   typecheck:
     name: Typecheck

--- a/flake.lock
+++ b/flake.lock
@@ -2,17 +2,17 @@
   "nodes": {
     "nixpkgs": {
       "locked": {
-        "lastModified": 1779560665,
-        "narHash": "sha256-tpyBcxPpcQb8ukyNF7DoCwfSY3VPsxHoYwj00Cayv5o=",
+        "lastModified": 1750127977,
+        "narHash": "sha256-zD1OwL7YRiurl1NW16Ke88S7JStBfawbiY/DVpS28P4=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "64c08a7ca051951c8eae34e3e3cb1e202fe36786",
+        "rev": "28ace32529a63842e4f8103e4f9b24960cf6c23a",
         "type": "github"
       },
       "original": {
         "owner": "NixOS",
-        "ref": "nixos-unstable",
         "repo": "nixpkgs",
+        "rev": "28ace32529a63842e4f8103e4f9b24960cf6c23a",
         "type": "github"
       }
     },

--- a/flake.nix
+++ b/flake.nix
@@ -2,7 +2,7 @@
   description = "Development shell for avante.nvim";
 
   inputs = {
-    nixpkgs.url = "github:NixOS/nixpkgs/nixos-unstable";
+    nixpkgs.url = "github:NixOS/nixpkgs?rev=28ace32529a63842e4f8103e4f9b24960cf6c23a";
   };
 
   outputs =
@@ -30,14 +30,14 @@
             lp.luarocks
             lp.nlua
           ]);
-        in
-        {
+
           default = pkgs.mkShell {
             name = "avante";
 
             packages = with pkgs; [
               lua5_1.pkgs.luacheck
               lua-language-server
+              ripgrep
               yq
               silver-searcher
               python3
@@ -52,6 +52,15 @@
               export DEPS_PATH="target/tests/deps"
             '';
           };
+
+        in
+        {
+          inherit default;
+          ci = default.overrideAttrs(oa: {
+            buildInputs = oa.buildInputs ++ [
+              pkgs.neovim-unwrapped
+            ];
+          });
         }
       );
     };

--- a/scripts/run-luatest.sh
+++ b/scripts/run-luatest.sh
@@ -2,7 +2,7 @@
 set -e
 
 DEST_DIR="$PWD/target/tests"
-DEPS_DIR="$DEST_DIR/deps"
+NVIM_TEST_HOME="$DEST_DIR/nvim"
 
 log() {
     echo "$1" >&2
@@ -17,43 +17,34 @@ check_tools() {
         log "Error: silversearcher-ag (ag) is not installed. Please install it."
         exit 1
     }
-}
-
-setup_deps() {
-    local plenary_path="$DEPS_DIR/plenary.nvim"
-    if [ -d "$plenary_path/.git" ]; then
-        log "plenary.nvim already exists. Updating..."
-        (
-            cd "$plenary_path"
-            git fetch -q
-            if git show-ref --verify --quiet refs/remotes/origin/main; then
-                git reset -q --hard origin/main
-            elif git show-ref --verify --quiet refs/remotes/origin/master; then
-                git reset -q --hard origin/master
-            fi
-        )
-    else
-        if [ -d "$plenary_path" ]; then
-            log "Removing non-git plenary.nvim directory and re-cloning."
-            rm -rf "$plenary_path"
-        fi
-        log "Cloning plenary.nvim..."
-        mkdir -p "$DEPS_DIR"
-        git clone --depth 1 "https://github.com/nvim-lua/plenary.nvim.git" "$plenary_path"
-    fi
+    command -v nlua &>/dev/null || {
+        log "Error: nlua is not installed. Please install nlua."
+        exit 1
+    }
+    command -v busted &>/dev/null || {
+        log "Error: busted is not installed. Please install busted."
+        exit 1
+    }
 }
 
 run_tests() {
     log "Running tests..."
-    nvim --headless --clean \
-        -c "set runtimepath+=$DEPS_DIR/plenary.nvim" \
-        -c "lua require('plenary.test_harness').test_directory('tests/', { minimal_init = 'NONE' })"
+    mkdir -p "$NVIM_TEST_HOME"/{config,data,state,cache}
+    local test_roots=("$@")
+    if [ ${#test_roots[@]} -eq 0 ]; then
+        test_roots=("tests")
+    fi
+
+    XDG_CONFIG_HOME="$NVIM_TEST_HOME/config" \
+        XDG_DATA_HOME="$NVIM_TEST_HOME/data" \
+        XDG_STATE_HOME="$NVIM_TEST_HOME/state" \
+        XDG_CACHE_HOME="$NVIM_TEST_HOME/cache" \
+        busted "${test_roots[@]}"
 }
 
 main() {
     check_tools
-    setup_deps
-    run_tests
+    run_tests "$@"
 }
 
 main "$@"

--- a/tests/llm_spec.lua
+++ b/tests/llm_spec.lua
@@ -1,5 +1,4 @@
 local utils = require("avante.utils")
-local PPath = require("plenary.path")
 
 local llm = require("avante.llm")
 
@@ -7,11 +6,13 @@ describe("generate_prompts", function()
   local project_root = "/tmp/project_root"
 
   before_each(function()
-    local mock_dir = PPath:new("tests", project_root)
-    mock_dir:mkdir({ parents = true })
+    local mock_dir = vim.fs.joinpath("tests", project_root)
+    vim.fn.mkdir(mock_dir, "p")
 
-    local mock_file = PPath:new("tests", project_root, "avante.md")
-    mock_file:write("# Mock Instructions\nThis is a mock instruction file.", "w")
+    local mock_file = vim.fs.joinpath("tests", project_root, "avante.md")
+    local file = assert(io.open(mock_file, "w"))
+    file:write("# Mock Instructions\nThis is a mock instruction file.")
+    file:close()
 
     -- Mock the project root
     utils.root = {}
@@ -96,8 +97,8 @@ describe("generate_prompts", function()
 
   after_each(function()
     -- Clean up created test files and directories
-    local mock_dir = PPath:new("tests", project_root)
-    if mock_dir:exists() then vim.fs.rm(tostring(mock_dir), { recursive = true }) end
+    local mock_dir = vim.fs.joinpath("tests", project_root)
+    if vim.uv.fs_stat(mock_dir) then vim.fs.rm(mock_dir, { recursive = true }) end
   end)
 
   it("should include instruction file content when the file exists", function()
@@ -107,8 +108,8 @@ describe("generate_prompts", function()
   end)
 
   it("should not modify instructions if the file does not exist", function()
-    local mock_file = PPath:new("tests", project_root, "avante.md")
-    if mock_file:exists() then vim.fs.rm(tostring(mock_file)) end
+    local mock_file = vim.fs.joinpath("tests", project_root, "avante.md")
+    if vim.uv.fs_stat(mock_file) then vim.fs.rm(mock_file) end
 
     local opts = {}
     llm.generate_prompts(opts)

--- a/tests/nlua_helper.lua
+++ b/tests/nlua_helper.lua
@@ -1,0 +1,147 @@
+local cwd = vim.fn.getcwd()
+
+vim.opt.runtimepath:prepend(cwd)
+
+local Path = {}
+Path.__index = Path
+
+local function join(parts)
+  local result = parts[1] or ""
+  for i = 2, #parts do
+    local part = tostring(parts[i])
+    if result == "" or part:sub(1, 1) == "/" then
+      result = part
+    else
+      result = result:gsub("/$", "") .. "/" .. part:gsub("^/", "")
+    end
+  end
+  return result
+end
+
+function Path:new(...)
+  local value = join({ ... })
+  return setmetatable({ filename = value }, self)
+end
+
+function Path:__tostring() return self.filename end
+
+function Path:joinpath(...) return Path:new(self.filename, ...) end
+
+function Path:parent() return Path:new(vim.fs.dirname(self.filename)) end
+
+function Path:normalize(root)
+  if root and not self:is_absolute() then return tostring(Path:new(root, self.filename)) end
+  return vim.fs.normalize(self.filename)
+end
+
+function Path:exists() return vim.uv.fs_stat(self.filename) ~= nil end
+
+function Path:is_file()
+  local stat = vim.uv.fs_stat(self.filename)
+  return stat and stat.type == "file" or false
+end
+
+function Path:is_dir()
+  local stat = vim.uv.fs_stat(self.filename)
+  return stat and stat.type == "directory" or false
+end
+
+function Path:is_absolute() return vim.fs.normalize(self.filename):sub(1, 1) == "/" end
+
+function Path:mkdir(opts) vim.fn.mkdir(self.filename, opts and opts.parents and "p" or "") end
+
+function Path:read()
+  local fd = assert(io.open(self.filename, "r"))
+  local content = fd:read("*a")
+  fd:close()
+  return content
+end
+
+function Path:write(content, mode)
+  local parent = vim.fs.dirname(self.filename)
+  if parent and parent ~= "." then vim.fn.mkdir(parent, "p") end
+  local fd = assert(io.open(self.filename, mode or "w"))
+  fd:write(content)
+  fd:close()
+end
+
+function Path:list()
+  local entries = {}
+  local fs = vim.uv.fs_scandir(self.filename)
+  if not fs then return entries end
+  while true do
+    local name = vim.uv.fs_scandir_next(fs)
+    if not name then break end
+    table.insert(entries, name)
+  end
+  return entries
+end
+
+function Path:unlink() vim.fs.rm(self.filename, { recursive = true, force = true }) end
+
+function Path:copy(opts)
+  local destination = tostring(opts.destination)
+  if self:is_dir() then
+    if opts.recursive then
+      vim.fn.mkdir(destination, "p")
+      for _, entry in ipairs(self:list()) do
+        local source = self:joinpath(entry)
+        source:copy({ destination = vim.fs.joinpath(destination, entry), recursive = true, override = opts.override })
+      end
+    end
+    return
+  end
+
+  if not opts.override and vim.uv.fs_stat(destination) then return end
+  local parent = vim.fs.dirname(destination)
+  if parent and parent ~= "." then vim.fn.mkdir(parent, "p") end
+  vim.fn.writefile(vim.fn.readfile(self.filename, "b"), destination, "b")
+end
+
+package.preload["plenary.path"] = function() return Path end
+
+local function scan_dir(root, opts)
+  opts = opts or {}
+  local results = {}
+  local max_depth = opts.depth or math.huge
+
+  local function scan(dir, depth)
+    if depth > max_depth then return end
+
+    local fs = vim.uv.fs_scandir(dir)
+    if not fs then return end
+
+    while true do
+      local name, kind = vim.uv.fs_scandir_next(fs)
+      if not name then break end
+
+      local path = vim.fs.joinpath(dir, name)
+      local is_dir = kind == "directory"
+      local include = (is_dir and opts.add_dirs ~= false) or (not is_dir and not opts.only_dirs)
+      if include then table.insert(results, path) end
+      if is_dir and opts.recursive ~= false then scan(path, depth + 1) end
+    end
+  end
+
+  scan(root, 1)
+  return results
+end
+
+package.preload["plenary.scandir"] = function()
+  return {
+    scan_dir = scan_dir,
+  }
+end
+
+package.preload["plenary.filetype"] = function()
+  return {
+    detect = function(filepath) return vim.filetype.match({ filename = filepath }) end,
+  }
+end
+
+package.preload["plenary.curl"] = function()
+  return {
+    get = function() error("plenary.curl.get was not stubbed for this test") end,
+    post = function() error("plenary.curl.post was not stubbed for this test") end,
+  }
+end

--- a/tests/providers/claude_spec.lua
+++ b/tests/providers/claude_spec.lua
@@ -1,7 +1,4 @@
 ---@diagnostic disable: duplicate-set-field, need-check-nil
-local busted = require("plenary.busted")
-local async = require("plenary.async.tests")
-local async_util = require("plenary.async")
 local test_util = require("avante.utils.test")
 local pkce = require("avante.auth.pkce")
 
@@ -25,11 +22,13 @@ local function create_mock_token_response()
   }
 end
 
-busted.describe("claude provider", function()
+local function wait_for_schedule() vim.wait(100) end
+
+describe("claude provider", function()
   -- PKCE Implementation Tests
-  busted.describe("PKCE implementation", function()
-    busted.describe("generate_verifier", function()
-      busted.it("should return a non-empty string", function()
+  describe("PKCE implementation", function()
+    describe("generate_verifier", function()
+      it("should return a non-empty string", function()
         local verifier, err = pkce.generate_verifier()
         assert.not_nil(verifier)
         assert.is_nil(err)
@@ -37,19 +36,19 @@ busted.describe("claude provider", function()
         assert.is_true(#verifier > 0)
       end)
 
-      busted.it("should generate URL-safe base64 string (no +, /, or =)", function()
+      it("should generate URL-safe base64 string (no +, /, or =)", function()
         local verifier, err = pkce.generate_verifier()
         assert.is_nil(err)
         assert.is_false(verifier:match("[+/=]") ~= nil, "Verifier should not contain +, /, or =")
       end)
 
-      busted.it("should generate verifier within valid length range (43-128 chars)", function()
+      it("should generate verifier within valid length range (43-128 chars)", function()
         local verifier, err = pkce.generate_verifier()
         assert.is_nil(err)
         assert.is_true(#verifier >= 43 and #verifier <= 128, "Verifier length should be 43-128 characters")
       end)
 
-      busted.it("should generate different verifiers on multiple calls", function()
+      it("should generate different verifiers on multiple calls", function()
         local verifier1, err1 = pkce.generate_verifier()
         local verifier2, err2 = pkce.generate_verifier()
         assert.is_nil(err1)
@@ -58,8 +57,8 @@ busted.describe("claude provider", function()
       end)
     end)
 
-    busted.describe("generate_challenge", function()
-      busted.it("should return a non-empty string", function()
+    describe("generate_challenge", function()
+      it("should return a non-empty string", function()
         local verifier = "test_verifier_123456"
         local challenge, err = pkce.generate_challenge(verifier)
         assert.not_nil(challenge)
@@ -68,7 +67,7 @@ busted.describe("claude provider", function()
         assert.is_true(#challenge > 0)
       end)
 
-      busted.it("should be deterministic (same verifier produces same challenge)", function()
+      it("should be deterministic (same verifier produces same challenge)", function()
         local verifier = "test_verifier_123456"
         local challenge1, err1 = pkce.generate_challenge(verifier)
         local challenge2, err2 = pkce.generate_challenge(verifier)
@@ -77,14 +76,14 @@ busted.describe("claude provider", function()
         assert.equals(challenge1, challenge2)
       end)
 
-      busted.it("should generate URL-safe base64 string (no +, /, or =)", function()
+      it("should generate URL-safe base64 string (no +, /, or =)", function()
         local verifier = "test_verifier_123456"
         local challenge, err = pkce.generate_challenge(verifier)
         assert.is_nil(err)
         assert.is_false(challenge:match("[+/=]") ~= nil, "Challenge should not contain +, /, or =")
       end)
 
-      busted.it("should generate different challenges for different verifiers", function()
+      it("should generate different challenges for different verifiers", function()
         local verifier1 = "test_verifier_1"
         local verifier2 = "test_verifier_2"
         local challenge1, err1 = pkce.generate_challenge(verifier1)
@@ -94,7 +93,7 @@ busted.describe("claude provider", function()
         assert.not_equal(challenge1, challenge2)
       end)
 
-      busted.it("should generate challenge of correct length for SHA256 (43 chars)", function()
+      it("should generate challenge of correct length for SHA256 (43 chars)", function()
         local verifier = "test_verifier_123456"
         local challenge, err = pkce.generate_challenge(verifier)
         assert.is_nil(err)
@@ -104,17 +103,17 @@ busted.describe("claude provider", function()
   end)
 
   -- Token Storage Tests
-  busted.describe("Token storage and retrieval", function()
+  describe("Token storage and retrieval", function()
     local claude_provider
 
-    busted.before_each(function()
+    before_each(function()
       -- Reload the provider module to get a fresh state
       package.loaded["avante.providers.claude"] = nil
       claude_provider = require("avante.providers.claude")
     end)
 
-    busted.describe("store_tokens", function()
-      async.it("should store tokens with correct structure in state", function()
+    describe("store_tokens", function()
+      it("should store tokens with correct structure in state", function()
         -- Initialize state
         claude_provider.state = { claude_token = nil }
 
@@ -137,7 +136,7 @@ busted.describe("claude provider", function()
         claude_provider.store_tokens(mock_tokens)
 
         -- Wait for vim.schedule callback to execute
-        async_util.util.sleep(100)
+        wait_for_schedule()
 
         -- Restore mocks
         io.open = original_open
@@ -151,7 +150,7 @@ busted.describe("claude provider", function()
         assert.is_true(claude_provider.state.claude_token.expires_at > original_time)
       end)
 
-      async.it("should include all required fields", function()
+      it("should include all required fields", function()
         claude_provider.state = { claude_token = nil }
 
         local mock_tokens = create_mock_token_response()
@@ -170,7 +169,7 @@ busted.describe("claude provider", function()
         claude_provider.store_tokens(mock_tokens)
 
         -- Wait for vim.schedule callback to execute
-        async_util.util.sleep(100)
+        wait_for_schedule()
 
         io.open = original_open
         vim.fn.system = original_system
@@ -184,11 +183,11 @@ busted.describe("claude provider", function()
   end)
 
   -- Authentication Flow Start Tests
-  busted.describe("Authentication flow initiation", function()
+  describe("Authentication flow initiation", function()
     local claude_provider
     local Config
 
-    busted.before_each(function()
+    before_each(function()
       package.loaded["avante.providers.claude"] = nil
       package.loaded["avante.config"] = nil
       Config = require("avante.config")
@@ -200,8 +199,8 @@ busted.describe("claude provider", function()
       claude_provider = require("avante.providers.claude")
     end)
 
-    busted.describe("authenticate", function()
-      async.it("should generate PKCE parameters", function()
+    describe("authenticate", function()
+      it("should generate PKCE parameters", function()
         -- Mock vim.ui.open to prevent browser opening
         local captured_url = nil
         local original_open = vim.ui.open
@@ -226,7 +225,7 @@ busted.describe("claude provider", function()
         claude_provider.authenticate()
 
         -- Wait for vim.schedule callback to execute
-        async_util.util.sleep(100)
+        wait_for_schedule()
 
         vim.ui.open = original_open
         vim.notify = original_notify
@@ -237,7 +236,7 @@ busted.describe("claude provider", function()
         assert.is_true(captured_url:match("code_challenge_method=S256") ~= nil)
       end)
 
-      async.it("should construct authorization URL with correct parameters", function()
+      it("should construct authorization URL with correct parameters", function()
         local captured_url = nil
         local original_open = vim.ui.open
         vim.ui.open = function(url)
@@ -259,7 +258,7 @@ busted.describe("claude provider", function()
         claude_provider.authenticate()
 
         -- Wait for vim.schedule callback to execute
-        async_util.util.sleep(100)
+        wait_for_schedule()
 
         vim.ui.open = original_open
         vim.notify = original_notify
@@ -274,7 +273,7 @@ busted.describe("claude provider", function()
         assert.is_true(captured_url:match("code_challenge_method=S256") ~= nil)
       end)
 
-      async.it("should use correct OAuth endpoint", function()
+      it("should use correct OAuth endpoint", function()
         local captured_url = nil
         local original_open = vim.ui.open
         vim.ui.open = function(url)
@@ -296,7 +295,7 @@ busted.describe("claude provider", function()
         claude_provider.authenticate()
 
         -- Wait for vim.schedule callback to execute
-        async_util.util.sleep(100)
+        wait_for_schedule()
 
         vim.ui.open = original_open
         vim.notify = original_notify
@@ -304,7 +303,7 @@ busted.describe("claude provider", function()
         assert.is_true(captured_url:match("^https://claude.ai/oauth/authorize") ~= nil)
       end)
 
-      async.it("should fallback to clipboard when vim.ui.open fails", function()
+      it("should fallback to clipboard when vim.ui.open fails", function()
         -- Mock vim.ui.open to fail
         local original_open = vim.ui.open
         vim.ui.open = function(url) error("Browser open failed") end
@@ -329,7 +328,7 @@ busted.describe("claude provider", function()
         claude_provider.authenticate()
 
         -- Wait for vim.schedule callback to execute
-        async_util.util.sleep(100)
+        wait_for_schedule()
 
         vim.ui.open = original_open
         vim.fn.setreg = original_setreg
@@ -344,31 +343,31 @@ busted.describe("claude provider", function()
   end)
 
   -- Token Refresh Logic Tests
-  busted.describe("Token refresh logic", function()
+  describe("Token refresh logic", function()
     local claude_provider
     local curl
 
-    busted.before_each(function()
+    before_each(function()
       package.loaded["avante.providers.claude"] = nil
       package.loaded["plenary.curl"] = nil
       claude_provider = require("avante.providers.claude")
       curl = require("plenary.curl")
     end)
 
-    busted.describe("refresh_token", function()
-      busted.it("should exit early when no state exists", function()
+    describe("refresh_token", function()
+      it("should exit early when no state exists", function()
         claude_provider.state = nil
         local result = claude_provider.refresh_token(false, false)
         assert.is_false(result)
       end)
 
-      busted.it("should exit early when no token exists in state", function()
+      it("should exit early when no token exists in state", function()
         claude_provider.state = { claude_token = nil }
         local result = claude_provider.refresh_token(false, false)
         assert.is_false(result)
       end)
 
-      busted.it("should skip refresh when token is not expired and not forced", function()
+      it("should skip refresh when token is not expired and not forced", function()
         local non_expired_token = create_mock_token_data(false)
         claude_provider.state = { claude_token = non_expired_token }
 
@@ -376,7 +375,7 @@ busted.describe("claude provider", function()
         assert.is_false(result)
       end)
 
-      async.it("should proceed when forced even if token not expired", function()
+      it("should proceed when forced even if token not expired", function()
         local non_expired_token = create_mock_token_data(false)
         claude_provider.state = { claude_token = non_expired_token }
 
@@ -405,7 +404,7 @@ busted.describe("claude provider", function()
         claude_provider.refresh_token(false, true)
 
         -- Wait for any vim.schedule callbacks to complete
-        async_util.util.sleep(100)
+        wait_for_schedule()
 
         curl.post = original_post
         io.open = original_open
@@ -414,7 +413,7 @@ busted.describe("claude provider", function()
         assert.is_true(post_called)
       end)
 
-      async.it("should make POST request with correct structure", function()
+      it("should make POST request with correct structure", function()
         local expired_token = create_mock_token_data(true)
         claude_provider.state = { claude_token = expired_token }
 
@@ -448,7 +447,7 @@ busted.describe("claude provider", function()
         claude_provider.refresh_token(false, false)
 
         -- Wait for any vim.schedule callbacks to complete
-        async_util.util.sleep(100)
+        wait_for_schedule()
 
         curl.post = original_post
         io.open = original_open
@@ -464,7 +463,7 @@ busted.describe("claude provider", function()
         assert.equals("application/json", captured_headers["Content-Type"])
       end)
 
-      async.it("should handle successful refresh response", function()
+      it("should handle successful refresh response", function()
         local expired_token = create_mock_token_data(true)
         claude_provider.state = { claude_token = expired_token }
 
@@ -493,7 +492,7 @@ busted.describe("claude provider", function()
         claude_provider.refresh_token(false, false)
 
         -- Wait for any vim.schedule callbacks to complete
-        async_util.util.sleep(100)
+        wait_for_schedule()
 
         curl.post = original_post
         io.open = original_open
@@ -504,7 +503,7 @@ busted.describe("claude provider", function()
         assert.equals(mock_response.refresh_token, claude_provider.state.claude_token.refresh_token)
       end)
 
-      async.it("should handle error response (status >= 400)", function()
+      it("should handle error response (status >= 400)", function()
         local expired_token = create_mock_token_data(true)
         claude_provider.state = { claude_token = expired_token }
 
@@ -527,7 +526,7 @@ busted.describe("claude provider", function()
         local result = claude_provider.refresh_token(false, false)
 
         -- Wait for any vim.schedule callbacks to complete
-        async_util.util.sleep(100)
+        wait_for_schedule()
 
         -- Should not crash and return gracefully
         -- State should remain unchanged
@@ -540,11 +539,11 @@ busted.describe("claude provider", function()
   end)
 
   -- Lockfile Management Tests
-  busted.describe("Lockfile management", function()
+  describe("Lockfile management", function()
     -- Note: These tests are more integration-style as the functions are local to the module
     -- We test the observable behavior rather than the internal functions directly
 
-    busted.it("should handle lockfile scenarios through setup", function()
+    it("should handle lockfile scenarios through setup", function()
       -- This is a basic smoke test that the lockfile logic doesn't crash
       -- More detailed testing would require exposing the internal functions or using integration tests
       local claude_provider = require("avante.providers.claude")
@@ -556,19 +555,19 @@ busted.describe("claude provider", function()
   end)
 
   -- Provider Setup Tests
-  busted.describe("Provider setup", function()
+  describe("Provider setup", function()
     local claude_provider
     local Config
 
-    busted.before_each(function()
+    before_each(function()
       package.loaded["avante.providers.claude"] = nil
       package.loaded["avante.config"] = nil
       Config = require("avante.config")
       claude_provider = require("avante.providers.claude")
     end)
 
-    busted.describe("API mode setup", function()
-      busted.it("should set correct api_key_name for API auth", function()
+    describe("API mode setup", function()
+      it("should set correct api_key_name for API auth", function()
         -- Mock the provider config
         local P = require("avante.providers")
         local original_parse = P.parse_config
@@ -592,8 +591,8 @@ busted.describe("claude provider", function()
       end)
     end)
 
-    busted.describe("Max mode setup", function()
-      async.it("should initialize state when nil", function()
+    describe("Max mode setup", function()
+      it("should initialize state when nil", function()
         -- Start with no state
         claude_provider.state = nil
 
@@ -640,7 +639,7 @@ busted.describe("claude provider", function()
         pcall(function() claude_provider.setup() end)
 
         -- Wait for any vim.schedule callbacks to complete
-        async_util.util.sleep(100)
+        wait_for_schedule()
 
         Path.new = original_new
         vim.ui.open = original_open

--- a/tests/providers/watsonx_code_assistant_spec.lua
+++ b/tests/providers/watsonx_code_assistant_spec.lua
@@ -1,15 +1,13 @@
-local busted = require("plenary.busted")
-
-busted.describe("watsonx_code_assistant provider", function()
+describe("watsonx_code_assistant provider", function()
   local watsonx_provider
 
-  busted.before_each(function()
+  before_each(function()
     -- Minimal setup without extensive mocking
     watsonx_provider = require("avante.providers.watsonx_code_assistant")
   end)
 
-  busted.describe("basic configuration", function()
-    busted.it("should have required properties", function()
+  describe("basic configuration", function()
+    it("should have required properties", function()
       assert.is_not_nil(watsonx_provider.api_key_name)
       assert.equals("WCA_API_KEY", watsonx_provider.api_key_name)
       assert.is_not_nil(watsonx_provider.role_map)
@@ -17,17 +15,17 @@ busted.describe("watsonx_code_assistant provider", function()
       assert.equals("ASSISTANT", watsonx_provider.role_map.assistant)
     end)
 
-    busted.it("should disable streaming", function() assert.is_true(watsonx_provider:is_disable_stream()) end)
+    it("should disable streaming", function() assert.is_true(watsonx_provider:is_disable_stream()) end)
 
-    busted.it("should have required functions", function()
+    it("should have required functions", function()
       assert.is_function(watsonx_provider.parse_messages)
       assert.is_function(watsonx_provider.parse_response_without_stream)
       assert.is_function(watsonx_provider.parse_curl_args)
     end)
   end)
 
-  busted.describe("parse_messages", function()
-    busted.it("should parse messages with correct role mapping", function()
+  describe("parse_messages", function()
+    it("should parse messages with correct role mapping", function()
       ---@type AvantePromptOptions
       local opts = {
         system_prompt = "You are a helpful assistant",
@@ -49,7 +47,7 @@ busted.describe("watsonx_code_assistant provider", function()
       assert.equals("Hi there", result[3].content)
     end)
 
-    busted.it("should handle WCA_COMMAND system prompt", function()
+    it("should handle WCA_COMMAND system prompt", function()
       ---@type AvantePromptOptions
       local opts = {
         system_prompt = "WCA_COMMAND",

--- a/tests/utils/file_spec.lua
+++ b/tests/utils/file_spec.lua
@@ -1,6 +1,13 @@
-local File = require("avante.utils.file")
 local mock = require("luassert.mock")
 local stub = require("luassert.stub")
+
+package.loaded["plenary.filetype"] = package.loaded["plenary.filetype"]
+  or {
+    detect = function(filepath) return vim.filetype.match({ filename = filepath }) end,
+  }
+
+local Filetype = package.loaded["plenary.filetype"]
+local File = require("avante.utils.file")
 
 describe("File", function()
   local test_file = "test.txt"
@@ -71,12 +78,10 @@ describe("File", function()
   end)
 
   describe("get_file_icon", function()
-    local Filetype
     local devicons_mock
 
     before_each(function()
-      -- Mock plenary.filetype
-      Filetype = mock(require("plenary.filetype"), true)
+      Filetype = mock(Filetype, true)
       -- Prepare devicons mock
       devicons_mock = {
         get_icon = stub().returns(""),


### PR DESCRIPTION
plenary.nvim was archived and was relying on busted. Instead use busted directly. nlua is a small wrapper to run busted with neovim as lua interpreter.

If we dont like the current output we could switch to another such as https://github.com/hishamhm/busted-htest. Adding a new dep just for that seemed not worth it so let's avoid it for now.

NB: Codex generated an equivalent of plenary's path