### PR TITLE
Fix: Per-request cancellation handling to prevent unintentional parallel agent loops

### DIFF
--- a/lua/avante/llm.lua
+++ b/lua/avante/llm.lua
@@ -1931,7 +1931,9 @@ function M._stream(opts)
             and LLMToolHelpers.is_token_cancelled(opts.session_ctx.cancel_token)
             and error ~= LLMToolHelpers.CANCEL_TOKEN
           then
-            Utils.debug("handle_tool_result: dropping recursion for cancelled request " .. tostring(opts.session_ctx.request_id))
+            Utils.debug(
+              "handle_tool_result: dropping recursion for cancelled request " .. tostring(opts.session_ctx.request_id)
+            )
             return
           end
           -- Special handling for cancellation signal from tools

--- a/lua/avante/llm.lua
+++ b/lua/avante/llm.lua
@@ -21,6 +21,22 @@ local log = require("avante.utils.log")
 local M = {}
 
 M.CANCEL_PATTERN = "AvanteLLMEscape"
+-- Per-request cancel autocmd patterns are emitted as `CANCEL_PATTERN_PREFIX .. request_id`
+-- so a single in-flight request can be cancelled in isolation without disturbing other
+-- sidebars / concurrent requests. The global M.CANCEL_PATTERN remains a broadcast
+-- "cancel everything" signal used by cleanup paths (:AvanteStop, shutdown, file leave).
+M.CANCEL_PATTERN_PREFIX = "AvanteLLMEscape_"
+
+-- Monotonic counter used to mint per-request ids. Strings are used so that callers
+-- can safely store these as table keys or compare with `==`.
+M._next_request_id = 0
+
+---Allocate a unique id for an in-flight LLM request.
+---@return string
+function M.next_request_id()
+  M._next_request_id = M._next_request_id + 1
+  return tostring(M._next_request_id)
+end
 
 ------------------------------Prompt and type------------------------------
 
@@ -741,39 +757,58 @@ function M.curl(opts)
   end
   active_job = new_active_job
 
-  api.nvim_create_autocmd("User", {
-    group = group,
-    pattern = M.CANCEL_PATTERN,
-    once = true,
-    callback = function()
-      -- Error: cannot resume dead coroutine
-      if active_job then
-        -- Mark as completed first to prevent error handler from running
-        completed = true
+  -- Build the list of cancel autocmd patterns this request should listen to.
+  -- Always listen on the global CANCEL_PATTERN (broadcast cancel). If the caller
+  -- has supplied a per-request pattern via opts.cancel_pattern, listen on that
+  -- too so only this specific request is killed without disturbing others.
+  local cancel_patterns = { M.CANCEL_PATTERN }
+  if opts.cancel_pattern and opts.cancel_pattern ~= M.CANCEL_PATTERN then
+    table.insert(cancel_patterns, opts.cancel_pattern)
+  end
+  local autocmd_ids = {}
+  local function shutdown_active_job()
+    -- Error: cannot resume dead coroutine
+    if active_job then
+      -- Mark as completed first to prevent error handler from running
+      completed = true
 
-        -- 检查 active_job 的状态
-        local job_is_alive = pcall(function() return active_job:is_closing() == false end)
+      -- Check active_job status
+      local job_is_alive = pcall(function() return active_job:is_closing() == false end)
 
-        -- 只有当 job 仍然活跃时才尝试关闭它
-        if job_is_alive then
-          -- Attempt to shutdown the active job, but ignore any errors
-          xpcall(function() active_job:shutdown() end, function(err)
-            Utils.debug("Ignored error during job shutdown: " .. vim.inspect(err))
-            return err
-          end)
-        else
-          Utils.debug("Job already closed, skipping shutdown")
-        end
-
-        Utils.debug("LLM request cancelled")
-        active_job = nil
-
-        -- Clean up and notify of cancellation
-        cleanup()
-        vim.schedule(function() handler_opts.on_stop({ reason = "cancelled" }) end)
+      -- Only attempt to shut down the job if it is still alive
+      if job_is_alive then
+        -- Attempt to shutdown the active job, but ignore any errors
+        xpcall(function() active_job:shutdown() end, function(err)
+          Utils.debug("Ignored error during job shutdown: " .. vim.inspect(err))
+          return err
+        end)
+      else
+        Utils.debug("Job already closed, skipping shutdown")
       end
-    end,
-  })
+
+      Utils.debug("LLM request cancelled")
+      active_job = nil
+
+      -- Tear down the sibling autocmds so they don't fire a second time.
+      for _, id in ipairs(autocmd_ids) do
+        pcall(api.nvim_del_autocmd, id)
+      end
+      autocmd_ids = {}
+
+      -- Clean up and notify of cancellation
+      cleanup()
+      vim.schedule(function() handler_opts.on_stop({ reason = "cancelled" }) end)
+    end
+  end
+  for _, pattern in ipairs(cancel_patterns) do
+    local id = api.nvim_create_autocmd("User", {
+      group = group,
+      pattern = pattern,
+      once = true,
+      callback = shutdown_active_job,
+    })
+    table.insert(autocmd_ids, id)
+  end
 
   return active_job
 end
@@ -1763,7 +1798,9 @@ end
 
 ---@param opts AvanteLLMStreamOptions
 function M._stream(opts)
-  -- Reset the cancellation flag at the start of a new request
+  -- Reset the legacy global cancellation flag at the start of a new request.
+  -- Per-request cancellation now uses session_ctx.cancel_token (allocated below)
+  -- so that one in-flight request can be cancelled without affecting siblings.
   if LLMToolHelpers then LLMToolHelpers.is_cancelled = false end
 
   local acp_provider = Config.acp_providers[Config.provider]
@@ -1771,6 +1808,23 @@ function M._stream(opts)
 
   local provider = opts.provider or Providers[Config.provider]
   opts.session_ctx = opts.session_ctx or {}
+
+  -- Allocate a per-request id + cancel token on the first call into _stream for
+  -- this logical request. Recursive iterations of the agent loop (handle_next_tool_use
+  -- -> M._stream) reuse the same id/token so all iterations of a single user
+  -- submission share one cancel scope.
+  if not opts.session_ctx.request_id then
+    opts.session_ctx.request_id = M.next_request_id()
+    opts.session_ctx.cancel_pattern = M.CANCEL_PATTERN_PREFIX .. opts.session_ctx.request_id
+    opts.session_ctx.cancel_token = LLMToolHelpers.make_cancel_token(opts.session_ctx.request_id)
+  end
+
+  -- If this request was cancelled between agent-loop iterations, stop here so we
+  -- don't spawn a new curl call on a dead conversation.
+  if LLMToolHelpers.is_token_cancelled(opts.session_ctx.cancel_token) then
+    Utils.debug("M._stream: request " .. tostring(opts.session_ctx.request_id) .. " was cancelled before iteration")
+    return opts.on_stop({ reason = "cancelled" })
+  end
 
   if not opts.session_ctx.on_messages_add then opts.session_ctx.on_messages_add = opts.on_messages_add end
   if not opts.session_ctx.on_state_change then opts.session_ctx.on_state_change = opts.on_state_change end
@@ -1868,6 +1922,18 @@ function M._stream(opts)
         local function handle_tool_result(result, error)
           partial_tool_use_message.is_calling = false
           if opts.on_messages_add then opts.on_messages_add({ partial_tool_use_message }) end
+          -- If this request was soft-cancelled (e.g. the user submitted a new message
+          -- mid-stream), we must NOT recurse back into M._stream. The tool's result
+          -- has already been appended to chat history via the on_messages_add above,
+          -- so the next user-driven request will see it as part of history naturally.
+          if
+            opts.session_ctx
+            and LLMToolHelpers.is_token_cancelled(opts.session_ctx.cancel_token)
+            and error ~= LLMToolHelpers.CANCEL_TOKEN
+          then
+            Utils.debug("handle_tool_result: dropping recursion for cancelled request " .. tostring(opts.session_ctx.request_id))
+            return
+          end
           -- Special handling for cancellation signal from tools
           if error == LLMToolHelpers.CANCEL_TOKEN then
             Utils.debug("Tool execution was cancelled by user")
@@ -1902,6 +1968,7 @@ function M._stream(opts)
           tool_use_id = partial_tool_use.id,
           streaming = partial_tool_use.state == "generating",
           on_complete = function() end,
+          cancel_token = opts.session_ctx and opts.session_ctx.cancel_token or nil,
         }
         if partial_tool_use.state == "generating" then
           if not is_edit_tool_use and not support_streaming then return end
@@ -1920,6 +1987,34 @@ function M._stream(opts)
           set_tool_use_store = opts.set_tool_use_store,
           on_complete = handle_tool_result,
           tool_use_id = partial_tool_use.id,
+          cancel_token = opts.session_ctx and opts.session_ctx.cancel_token or nil,
+          on_orphaned_result = function(tool_use, orphan_result, orphan_err, ctx)
+            -- The originating request was soft-cancelled but this tool was allowed
+            -- to finish. Append the tool_result + a small system note into history so
+            -- the *next* outbound LLM call has both the structurally-required
+            -- tool_result pair AND the surrounding context of where it came from.
+            if not opts.on_messages_add then return end
+            local result_message = History.Message:new("user", {
+              type = "tool_result",
+              tool_use_id = tool_use.id,
+              content = orphan_err ~= nil and orphan_err or orphan_result,
+              is_error = orphan_err ~= nil,
+              is_user_declined = false,
+            })
+            local note_text = string.format(
+              "<system-note>Tool `%s` (id=%s) from a previous, cancelled request finished after the cancellation. Its result is included above so you have full context for the current turn.</system-note>",
+              tool_use.name,
+              tool_use.id
+            )
+            local note_message = History.Message:new("user", note_text, {
+              visible = false,
+              is_context = true,
+            })
+            opts.on_messages_add({ result_message, note_message })
+            if opts.on_orphaned_tool_result then
+              opts.on_orphaned_tool_result(tool_use, orphan_result, orphan_err, ctx)
+            end
+          end,
         })
         if result ~= nil or error ~= nil then return handle_tool_result(result, error) end
       end
@@ -2048,6 +2143,7 @@ function M._stream(opts)
     prompt_opts = prompt_opts,
     handler_opts = handler_opts,
     on_response_headers = function(headers) resp_headers = headers end,
+    cancel_pattern = opts.session_ctx and opts.session_ctx.cancel_pattern or nil,
   })
 end
 
@@ -2139,8 +2235,27 @@ function M._dual_boost_stream(opts, Provider1, Provider2)
   if not success then Utils.error("Failed to start dual_boost streams: " .. tostring(err)) end
 end
 
+---@class avante.LLMStreamHandle
+---@field id string                                       -- unique request id
+---@field is_done fun(): boolean                          -- has the request finished (complete/error/cancelled)?
+---@field cancel fun(cancel_opts?: { abort_tools?: boolean, reason?: string }): nil
+---@field cancel_pattern string                           -- per-request autocmd pattern (advanced use)
+
 ---@param opts AvanteLLMStreamOptions
+---@return avante.LLMStreamHandle
 function M.stream(opts)
+  -- Allocate the request id eagerly so the caller has a handle even before _stream
+  -- has been entered (e.g. for the dual-boost / ACP paths).
+  opts.session_ctx = opts.session_ctx or {}
+  if not opts.session_ctx.request_id then
+    opts.session_ctx.request_id = M.next_request_id()
+    opts.session_ctx.cancel_pattern = M.CANCEL_PATTERN_PREFIX .. opts.session_ctx.request_id
+    opts.session_ctx.cancel_token = LLMToolHelpers.make_cancel_token(opts.session_ctx.request_id)
+  end
+  local request_id = opts.session_ctx.request_id
+  local cancel_pattern = opts.session_ctx.cancel_pattern
+  local cancel_token = opts.session_ctx.cancel_token
+
   local is_completed = false
   if opts.on_tool_log ~= nil then
     local original_on_tool_log = opts.on_tool_log
@@ -2190,8 +2305,35 @@ function M.stream(opts)
   else
     M._stream(opts)
   end
+
+  ---@type avante.LLMStreamHandle
+  return {
+    id = request_id,
+    cancel_pattern = cancel_pattern,
+    is_done = function() return is_completed end,
+    cancel = function(cancel_opts)
+      cancel_opts = cancel_opts or {}
+      -- Mark the per-request token as cancelled. If abort_tools is set, in-flight
+      -- tools will see should_abort_tool() return true and bail out. Otherwise
+      -- (the default soft cancel) they keep running and their results are routed
+      -- via on_orphaned_result so the next outbound payload can fold them in.
+      LLMToolHelpers.cancel_token(cancel_token, {
+        abort_tools = cancel_opts.abort_tools,
+        reason = cancel_opts.reason,
+      })
+      -- Tear down the curl request for this specific id without disturbing any
+      -- other concurrent requests.
+      api.nvim_exec_autocmds("User", { pattern = cancel_pattern })
+      abort_retry_timer = true
+    end,
+  }
 end
 
+---Hard-cancel EVERY in-flight LLM request and abort every running tool.
+---This is the "nuclear option" used by cleanup paths (:AvanteStop, shutdown,
+---buffer-leave). For surgical, per-request cancellation that lets tools finish
+---and queues their results for the next outbound payload, prefer the `cancel()`
+---method on the handle returned by `M.stream()`.
 function M.cancel_inflight_request()
   if LLMToolHelpers.is_cancelled ~= nil then LLMToolHelpers.is_cancelled = true end
   if LLMToolHelpers.confirm_popup ~= nil then

--- a/lua/avante/llm_tools/helpers.lua
+++ b/lua/avante/llm_tools/helpers.lua
@@ -7,10 +7,73 @@ local M = {}
 
 M.CANCEL_TOKEN = "__CANCELLED__"
 
--- Track cancellation state
+-- Track global cancellation state (legacy / hard-cancel via :AvanteStop, shutdown,
+-- buffer-leave, etc). New per-request cancellations should use a per-request
+-- cancel token instead (see make_cancel_token below). This global flag is kept
+-- for back-compat and for cases where we want to abort EVERY in-flight tool at
+-- once.
 M.is_cancelled = false
 ---@type avante.ui.Confirm
 M.confirm_popup = nil
+
+---@class avante.CancelToken
+---@field cancelled boolean              -- has cancellation been requested for this context?
+---@field request_id string|nil          -- the LLM request id this token belongs to
+---@field keep_tools_running boolean     -- if true, soft cancel: tools may keep running and have their results queued
+---@field cancelled_at integer|nil       -- vim.uv.hrtime() when cancelled
+---@field reason string|nil              -- optional human-readable reason
+
+---Create a per-request cancel token.
+---@param request_id string|nil
+---@param opts? { keep_tools_running?: boolean }
+---@return avante.CancelToken
+function M.make_cancel_token(request_id, opts)
+  opts = opts or {}
+  local keep = opts.keep_tools_running
+  if keep == nil then keep = true end
+  return {
+    cancelled = false,
+    request_id = request_id,
+    keep_tools_running = keep,
+    cancelled_at = nil,
+    reason = nil,
+  }
+end
+
+---Mark a cancel token as cancelled.
+---@param token avante.CancelToken|nil
+---@param opts? { abort_tools?: boolean, reason?: string }
+function M.cancel_token(token, opts)
+  if not token then return end
+  opts = opts or {}
+  token.cancelled = true
+  token.cancelled_at = vim.uv.hrtime()
+  if opts.reason then token.reason = opts.reason end
+  if opts.abort_tools then token.keep_tools_running = false end
+end
+
+---Has cancellation been requested for this context?
+---Includes the legacy global flag so that a hard global cancel still wins.
+---@param token avante.CancelToken|nil
+---@return boolean
+function M.is_token_cancelled(token)
+  if M.is_cancelled then return true end
+  if token and token.cancelled then return true end
+  return false
+end
+
+---Should an in-flight tool be aborted right now?
+---Soft (per-request) cancels with keep_tools_running=true do NOT abort tools —
+---they let the tool finish so its result can be queued for the next outbound
+---LLM payload. Only the legacy global flag, or an explicit
+---`cancel({ abort_tools = true })`, will actually abort the tool.
+---@param token avante.CancelToken|nil
+---@return boolean
+function M.should_abort_tool(token)
+  if M.is_cancelled then return true end
+  if token and token.cancelled and not token.keep_tools_running then return true end
+  return false
+end
 
 ---@param rel_path string
 ---@return string

--- a/lua/avante/llm_tools/init.lua
+++ b/lua/avante/llm_tools/init.lua
@@ -1323,6 +1323,10 @@ M.run_python = M.python
 ---@field on_log? fun(tool_id: string, tool_name: string, log: string, state: AvanteLLMToolUseState): nil
 ---@field set_tool_use_store? fun(tool_id: string, key: string, value: any): nil
 ---@field on_complete? fun(result: string | nil, error: string | nil): nil
+---@field cancel_token? avante.CancelToken    -- per-request cancel token; preferred over the global Helpers.is_cancelled
+---@field on_orphaned_result? fun(tool_use: AvanteLLMToolUse, result: string | nil, error: string | nil, ctx: { request_id: string|nil, started_at: integer, finished_at: integer }): nil
+---@field streaming? boolean
+---@field tool_use_id? string
 
 ---@param tools AvanteLLMTool[]
 ---@param tool_use AvanteLLMToolUse
@@ -1331,8 +1335,12 @@ M.run_python = M.python
 function M.process_tool_use(tools, tool_use, opts)
   local on_log = opts.on_log
   local on_complete = opts.on_complete
-  -- Check if execution is already cancelled
-  if Helpers.is_cancelled then
+  local cancel_token = opts.cancel_token
+  local on_orphaned_result = opts.on_orphaned_result
+  local started_at = vim.uv.hrtime()
+  -- Check if execution is already cancelled (hard global cancel only — soft per-request
+  -- cancellations should not block a tool from starting if the user wants its result queued).
+  if Helpers.should_abort_tool(cancel_token) then
     Utils.debug("Tool execution cancelled before starting: " .. tool_use.name)
     if on_complete then
       on_complete(nil, Helpers.CANCEL_TOKEN)
@@ -1356,7 +1364,11 @@ function M.process_tool_use(tools, tool_use, opts)
   if not func then return nil, "Tool not found: " .. tool_use.name end
   if on_log then on_log(tool_use.id, tool_use.name, "running tool", "running") end
 
-  -- Set up a timer to periodically check for cancellation
+  -- Set up a timer to periodically check for HARD cancellation (global flag or
+  -- explicit abort_tools=true on the per-request token). Soft per-request cancels
+  -- with keep_tools_running=true are *not* observed here — the tool is allowed to
+  -- run to completion, and its result will be routed to on_orphaned_result when it
+  -- finishes, so the next outbound LLM payload can include it.
   local cancel_timer
   if on_complete then
     cancel_timer = vim.uv.new_timer()
@@ -1365,12 +1377,15 @@ function M.process_tool_use(tools, tool_use, opts)
         100,
         100,
         vim.schedule_wrap(function()
-          if Helpers.is_cancelled then
-            Utils.debug("Tool execution cancelled during execution: " .. tool_use.name)
+          if Helpers.should_abort_tool(cancel_token) then
+            Utils.debug("Tool execution aborted during execution: " .. tool_use.name)
             if cancel_timer and not cancel_timer:is_closing() then
               cancel_timer:stop()
               cancel_timer:close()
             end
+            -- Reset the legacy global flag so subsequent tools aren't poisoned by
+            -- a stale signal. Per-request tokens are not reset here — they belong
+            -- to the (now-dead) request and should stay cancelled.
             Helpers.is_cancelled = false
             on_complete(nil, Helpers.CANCEL_TOKEN)
           end
@@ -1388,8 +1403,8 @@ function M.process_tool_use(tools, tool_use, opts)
       cancel_timer:close()
     end
 
-    -- Check for cancellation one more time before processing result
-    if Helpers.is_cancelled then
+    -- Check for hard cancellation one more time before processing result
+    if Helpers.should_abort_tool(cancel_token) then
       if on_log then on_log(tool_use.id, tool_use.name, "cancelled during result handling", "failed") end
       return nil, Helpers.CANCEL_TOKEN
     end
@@ -1411,22 +1426,41 @@ function M.process_tool_use(tools, tool_use, opts)
   local result, err = func(input_json, {
     session_ctx = opts.session_ctx or {},
     on_log = function(log)
-      -- Check for cancellation during logging
-      if Helpers.is_cancelled then return end
+      -- Drop log entries for hard-aborted tools, but keep them for soft-cancelled
+      -- ones so the user can see what the orphaned tool was doing.
+      if Helpers.should_abort_tool(cancel_token) then return end
       if on_log then on_log(tool_use.id, tool_use.name, log, "running") end
     end,
     set_store = function(key, value)
       if opts.set_tool_use_store then opts.set_tool_use_store(tool_use.id, key, value) end
     end,
     on_complete = function(result, err)
-      -- Check for cancellation before completing
-      if Helpers.is_cancelled then
+      -- Hard cancel: report cancellation up.
+      if Helpers.should_abort_tool(cancel_token) then
         Helpers.is_cancelled = false
         if on_complete then on_complete(nil, Helpers.CANCEL_TOKEN) end
         return
       end
 
       result, err = handle_result(result, err)
+
+      -- Soft cancel (per-request token tripped while the tool was running):
+      -- the originating request is dead, so we must NOT re-enter its agent loop.
+      -- Route the result to the orphan handler so the surrounding code can fold
+      -- it into the next outbound LLM payload with proper context.
+      if Helpers.is_token_cancelled(cancel_token) then
+        if on_orphaned_result then
+          on_orphaned_result(tool_use, result, err, {
+            request_id = cancel_token and cancel_token.request_id or nil,
+            started_at = started_at,
+            finished_at = vim.uv.hrtime(),
+          })
+        else
+          Utils.debug("orphan tool result for " .. tool_use.name .. " dropped (no handler)")
+        end
+        return
+      end
+
       if on_complete == nil then
         Utils.error("asynchronous tool " .. tool_use.name .. " result not handled")
         return

--- a/lua/avante/sidebar.lua
+++ b/lua/avante/sidebar.lua
@@ -365,6 +365,22 @@ function Sidebar:close(opts)
   self:close_input_hint()
 end
 
+---Cancel only this sidebar's in-flight LLM request (soft cancel by default —
+---in-flight tools are allowed to finish and their results are queued for the
+---next outbound LLM payload). Pass `{ abort_tools = true }` to hard-cancel
+---running tools too. Returns true if there was a request to cancel.
+---@param cancel_opts? { abort_tools?: boolean, reason?: string }
+---@return boolean
+function Sidebar:cancel_request(cancel_opts)
+  if self.current_request and not self.current_request.is_done() then
+    self.current_request.cancel(cancel_opts or {})
+    self.is_generating = false
+    self.current_request = nil
+    return true
+  end
+  return false
+end
+
 function Sidebar:shutdown()
   Llm.cancel_inflight_request()
   self:close()
@@ -2795,9 +2811,24 @@ end
 function Sidebar:handle_submit(request)
   if Config.prompt_logger.enabled then PromptLogger.log_prompt(request) end
 
-  if self.is_generating then
-    self:add_history_messages({ History.Message:new("user", request) })
-    return
+  -- ChatGPT-style interrupt: if a previous request is still in flight, soft-cancel
+  -- it. Soft-cancel kills the LLM stream and drops any partial assistant text, but
+  -- lets in-flight tools keep running. When those tools complete, their results
+  -- are routed via on_orphaned_result (see llm.lua) and appended to chat history
+  -- so the *next* outbound LLM call (the one we're about to start) folds them in
+  -- naturally — without the previous, dead agent loop ever re-entering M._stream.
+  if self.is_generating and self.current_request and not self.current_request.is_done() then
+    Utils.debug(
+      "Sidebar:handle_submit interrupting in-flight request "
+        .. tostring(self.current_request.id)
+        .. " (tools may keep running and have results queued for the next turn)"
+    )
+    self.current_request.cancel({ abort_tools = false, reason = "superseded_by_user_submit" })
+    -- Eagerly clear our local in-flight bookkeeping; on_stop for the cancelled
+    -- request will still fire but it will short-circuit because the request_id
+    -- captured below won't match the new self.current_request.id.
+    self.is_generating = false
+    self.current_request = nil
   end
 
   if request:match("@codebase") and not vim.fn.expand("%:e") then
@@ -2925,9 +2956,24 @@ function Sidebar:handle_submit(request)
     end
   end
 
+  -- captured_request_id is filled in after Llm.stream() returns the handle (below).
+  -- Until then it remains nil; a stop event for a previously-cancelled request will
+  -- not match the new self.current_request.id and will skip the state reset.
+  local captured_request_id = nil
   ---@type AvanteLLMStopCallback
   local function on_stop(stop_opts)
-    self.is_generating = false
+    -- Only reset in-flight state if this stop belongs to the *current* request.
+    -- Stale stops from a superseded request must not clobber the new request's
+    -- state.
+    local is_current = (
+      self.current_request ~= nil
+      and captured_request_id ~= nil
+      and self.current_request.id == captured_request_id
+    )
+    if is_current or captured_request_id == nil then
+      self.is_generating = false
+      self.current_request = nil
+    end
 
     pcall(function()
       ---remove keymaps
@@ -3027,7 +3073,10 @@ function Sidebar:handle_submit(request)
             stream_options.memory = memory.content
           end
           stream_options.history_messages = self:get_history_messages_for_api()
-          Llm.stream(stream_options)
+          local handle = Llm.stream(stream_options)
+          self.current_request = handle
+          captured_request_id = handle and handle.id or nil
+          self.is_generating = true
         end
       )
     end
@@ -3035,7 +3084,10 @@ function Sidebar:handle_submit(request)
     stream_options.on_memory_summarize = on_memory_summarize
 
     if request ~= "" then on_state_change("generating") end
-    Llm.stream(stream_options)
+    self.is_generating = true
+    local handle = Llm.stream(stream_options)
+    self.current_request = handle
+    captured_request_id = handle and handle.id or nil
   end)
 end
 


### PR DESCRIPTION
Previously, when a user submitted a new message or a tool returned while an LLM stream was still in flight, the request flow could "shard" into two parallel agent loops both mutating the same chat_history. The root cause was that avante had no per-request identity and no per-conversation serialization:

- The intended Sidebar.is_generating guard was dead code — set to false, never to true.
- Llm.stream returned nothing; cancellation was module-global via the single AvanteLLMEscape autocmd, with no per-request scope.
- The tool runner polled a single Helpers.is_cancelled boolean every 100ms; if a tool completed *after* the timer fired CANCEL_TOKEN, its later on_complete became an orphan that re-entered the LLM stream.

This change introduces per-request cancellation that preserves future parallelism (parallel tools, parallel dispatches, multiple conversations):

- Helpers.make_cancel_token(request_id) / cancel_token / is_token_cancelled / should_abort_tool form a per-context cancel API. The global Helpers.is_cancelled is kept as a legacy hard-cancel used by :AvanteStop and cleanup paths.
- Llm.stream(opts) now allocates a per-request id, builds a cancel token plus a per-request autocmd pattern (AvanteLLMEscape_<id>), and returns a handle { id, is_done, cancel({ abort_tools? }) }.
- Llm.curl listens on the per-request pattern in addition to the global one, so a per-request cancel kills only its own curl job.
- LLMTools.process_tool_use accepts cancel_token and on_orphaned_result. Soft cancels (abort_tools = false) let tools run to completion; their results are routed to on_orphaned_result instead of re-entering the dead agent loop.
- In M._stream, the orphan handler appends the late tool_result plus a <system-note> describing its origin into chat_history, so the next outbound payload has both the structurally-required tool_result pair and surrounding context for the LLM.
- handle_tool_result short-circuits recursion when its request was soft-cancelled.
- Sidebar:handle_submit now ChatGPT-style interrupts an in-flight request: the previous LLM stream is killed and its partial assistant text dropped, but in-flight tools keep running and their results are queued for the next turn.
- Sidebar.on_stop is keyed by captured request id so a stale stop from a superseded request can't clobber the new request's state.
- Added Sidebar:cancel_request({ abort_tools? }) for explicit per-sidebar cancellation.