### PR TITLE
ci: Push logic on MacOS for renaming .dylib to .so into Makefile

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -93,8 +93,13 @@ jobs:
         with:
           targets: ${{ matrix.config.rust_target }}
           toolchain: "1.85.0"
-      - name: Build all crates
-        if: ${{ matrix.config.container == null }}
+      - name: Build all crates (Linux/MacOS)
+        if: ${{ matrix.config.container == null && matrix.config.os_name != 'windows' }}
+        run: |
+          make ${{ matrix.feature }} BUILD_FROM_SOURCE=true CARGO_TARGET=${{ matrix.config.rust_target }}
+
+      - name: Build all crates (Windows)
+        if: ${{ matrix.config.os_name == 'windows' }}
         run: |
           # TODO leverage AvanteBuild
           cargo build --release --features ${{ matrix.feature }} --target ${{ matrix.config.rust_target }}
@@ -109,30 +114,16 @@ jobs:
             -w /workspace \
             --platform ${{ matrix.config.docker_platform }} \
             ${{ matrix.config.container }} \
-            bash -c "yum install -y perl-IPC-Cmd openssl-devel && curl --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y --profile minimal && . /root/.cargo/env && cargo build --release --features ${{ matrix.feature }}"
+            bash -c "yum install -y perl-IPC-Cmd openssl-devel && curl --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y --profile minimal && . /root/.cargo/env && make ${{ matrix.feature }} BUILD_FROM_SOURCE=true"
 
       - name: Handle binaries (Linux/MacOS)
         if: ${{ matrix.config.os_name != 'windows' }}
         shell: bash
         run: |
           mkdir -p results
-          if [ "${{ matrix.config.os_name }}" == "darwin" ]; then
-            CARGO_EXT="dylib"
-            TARGET_DIR="target/${{ matrix.config.rust_target }}/release"
-          else
-            CARGO_EXT="so"
-            TARGET_DIR="target/release"
-          fi
-
-          # Rename the extension to .so on all Unix platforms
-          EXT="so"
-
-          cp -v $TARGET_DIR/libavante_templates.$CARGO_EXT results/avante_templates.$EXT
-          cp -v $TARGET_DIR/libavante_tokenizers.$CARGO_EXT results/avante_tokenizers.$EXT
-          cp -v $TARGET_DIR/libavante_repo_map.$CARGO_EXT results/avante_repo_map.$EXT
-          cp -v $TARGET_DIR/libavante_html2md.$CARGO_EXT results/avante_html2md.$EXT
+          cp -v lua/avante_*.so results/
           cd results
-          tar zcvf avante_lib-${{ matrix.config.os_name }}-${{ matrix.config.arch }}-${{ matrix.feature }}.tar.gz *.${EXT}
+          tar zcvf avante_lib-${{ matrix.config.os_name }}-${{ matrix.config.arch }}-${{ matrix.feature }}.tar.gz *.so
 
       - name: Handle binaries (Windows)
         if: ${{ matrix.config.os_name == 'windows' }}

--- a/Makefile
+++ b/Makefile
@@ -8,9 +8,14 @@ else ifeq ($(UNAME), Darwin)
 	OS := macOS
 	# looks interchangeable with "dylib", but nvim will find .so automatically in rtp
 	EXT := so
+	CARGO_EXT := dylib
 else
 	$(error Unsupported operating system: $(UNAME))
 endif
+
+CARGO_EXT ?= $(EXT)
+CARGO_TARGET ?=
+TARGET_DIR := target$(if $(CARGO_TARGET),/$(CARGO_TARGET))/release
 
 LUA_VERSIONS := luajit lua51
 
@@ -48,8 +53,8 @@ $(foreach lua_version,$(LUA_VERSIONS),$(eval $(call make_definitions,$(lua_versi
 
 define build_package
 $1-$2:
-	cargo build --release --features=$1 -p avante-$2
-	cp target/release/libavante_$(shell echo $2 | tr - _).$(EXT) $(BUILD_DIR)/avante_$(shell echo $2 | tr - _).$(EXT)
+	cargo build --release --features=$1 -p avante-$2 $(if $(CARGO_TARGET),--target $(CARGO_TARGET))
+	cp $(TARGET_DIR)/libavante_$(shell echo $2 | tr - _).$(CARGO_EXT) $(BUILD_DIR)/avante_$(shell echo $2 | tr - _).$(EXT)
 endef
 
 define build_targets


### PR DESCRIPTION
If MacOS users wish to specify BUILD_FROM_SOURCE,
to build Avante directly, this will now work.

Before, BUILD_FROM_SOURCE was failing, because cargo
builds .dylib files, but the Makefile was trying to copy .so files

Assisted-by: Google Gemini 3.5 Flash
