### PR TITLE
fix(acp): follow agent locations on tool_call_update and reduce grace period

### DIFF
--- a/lua/avante/llm.lua
+++ b/lua/avante/llm.lua
@@ -1079,76 +1079,90 @@ function M._stream_acp(opts)
             end
           end
 
-          if update.sessionUpdate == "tool_call" then
-            add_tool_call_message(update)
+          -- Follow agent edit locations: navigate to the file being edited.
+          -- Extracted as a function so it can be called from both tool_call
+          -- and tool_call_update (some ACP adapters send locations in the
+          -- update rather than the initial tool_call).
+          local function try_follow_agent_location(upd)
+            if
+              not Config.behaviour.acp_follow_agent_locations
+              or upd.kind ~= "edit"
+              or not upd.locations
+              or #upd.locations < 1
+            then
+              return
+            end
 
             local sidebar = require("avante").get()
+            if not sidebar or sidebar.is_in_full_view then return end
 
-            if
-              Config.behaviour.acp_follow_agent_locations
-              and sidebar
-              and not sidebar.is_in_full_view -- don't follow when in Zen mode
-              and update.kind == "edit" -- to avoid entering more than once
-              and update.locations
-              and #update.locations > 0
-            then
-              vim.schedule(function()
-                if not sidebar:is_open() then return end
+            vim.schedule(function()
+              if not sidebar:is_open() then return end
 
-                -- Find a valid code window (non-sidebar window)
-                local code_winid = nil
-                if sidebar.code.winid and sidebar.code.winid ~= 0 and api.nvim_win_is_valid(sidebar.code.winid) then
-                  code_winid = sidebar.code.winid
-                else
-                  -- Find first non-sidebar window in the current tab
-                  local all_wins = api.nvim_tabpage_list_wins(0)
-                  for _, winid in ipairs(all_wins) do
-                    if api.nvim_win_is_valid(winid) and not sidebar:is_sidebar_winid(winid) then
-                      code_winid = winid
-                      break
-                    end
+              -- Find a valid code window (non-sidebar window)
+              local code_winid = nil
+              if sidebar.code.winid and sidebar.code.winid ~= 0 and api.nvim_win_is_valid(sidebar.code.winid) then
+                code_winid = sidebar.code.winid
+              else
+                local all_wins = api.nvim_tabpage_list_wins(0)
+                for _, winid in ipairs(all_wins) do
+                  if api.nvim_win_is_valid(winid) and not sidebar:is_sidebar_winid(winid) then
+                    code_winid = winid
+                    break
                   end
                 end
+              end
 
-                if not code_winid then return end
+              if not code_winid then return end
 
-                local now = uv.now()
-                local last_auto_nav = vim.g.avante_last_auto_nav or 0
-                local grace_period = 2000
+              -- Short debounce to prevent double-fires from the same tool call
+              local now = uv.now()
+              local last_auto_nav = vim.g.avante_last_auto_nav or 0
+              if now - last_auto_nav < 200 then return end
 
-                -- Check if user navigated manually recently
-                if now - last_auto_nav < grace_period then return end
+              -- Only follow first location to avoid rapid jumping
+              local location = upd.locations[1]
+              if not location or not location.path then return end
 
-                -- Only follow first location to avoid rapid jumping
-                local location = update.locations[1]
-                if not location or not location.path then return end
+              local abs_path = Utils.is_absolute_path(location.path) and location.path
+                or vim.fs.joinpath(Utils.get_project_root(), location.path)
+              local bufnr = vim.fn.bufnr(abs_path, true)
 
-                local abs_path = Utils.is_absolute_path(location.path) and location.path
-                  or vim.fs.joinpath(Utils.get_project_root(), location.path)
-                local bufnr = vim.fn.bufnr(abs_path, true)
+              if not bufnr or bufnr == -1 then return end
 
-                if not bufnr or bufnr == -1 then return end
+              if not api.nvim_buf_is_loaded(bufnr) then pcall(vim.fn.bufload, bufnr) end
 
-                if not api.nvim_buf_is_loaded(bufnr) then pcall(vim.fn.bufload, bufnr) end
+              local ok = pcall(api.nvim_win_set_buf, code_winid, bufnr)
+              if not ok then return end
 
-                local ok = pcall(api.nvim_win_set_buf, code_winid, bufnr)
-                if not ok then return end
+              local line = location.line or 1
+              local line_count = api.nvim_buf_line_count(bufnr)
+              local target_line = math.min(line, line_count)
 
-                local line = location.line or 1
-                local line_count = api.nvim_buf_line_count(bufnr)
-                local target_line = math.min(line, line_count)
-
-                pcall(api.nvim_win_set_cursor, code_winid, { target_line, 0 })
-                pcall(api.nvim_win_call, code_winid, function()
-                  vim.cmd("normal! zz") -- Center line in viewport
-                end)
-
-                vim.g.avante_last_auto_nav = now
+              pcall(api.nvim_win_set_cursor, code_winid, { target_line, 0 })
+              pcall(api.nvim_win_call, code_winid, function()
+                vim.cmd("normal! zz")
               end)
-            end
+
+              vim.g.avante_last_auto_nav = now
+            end)
+          end
+
+          if update.sessionUpdate == "tool_call" then
+            add_tool_call_message(update)
+            try_follow_agent_location(update)
           end
 
           if update.sessionUpdate == "tool_call_update" then
+            -- Also try follow here: some ACP adapters (e.g. claude-agent-acp)
+            -- send locations in tool_call_update rather than the initial tool_call
+            local merged = tool_call_messages[update.toolCallId]
+              and tool_call_messages[update.toolCallId].acp_tool_call
+            if merged then
+              try_follow_agent_location(vim.tbl_deep_extend("force", merged, update))
+            else
+              try_follow_agent_location(update)
+            end
             local tool_call_message = tool_call_messages[update.toolCallId]
             if not tool_call_message then
               tool_call_message = History.Message:new("assistant", {

--- a/lua/avante/llm.lua
+++ b/lua/avante/llm.lua
@@ -1140,9 +1140,7 @@ function M._stream_acp(opts)
               local target_line = math.min(line, line_count)
 
               pcall(api.nvim_win_set_cursor, code_winid, { target_line, 0 })
-              pcall(api.nvim_win_call, code_winid, function()
-                vim.cmd("normal! zz")
-              end)
+              pcall(api.nvim_win_call, code_winid, function() vim.cmd("normal! zz") end)
 
               vim.g.avante_last_auto_nav = now
             end)


### PR DESCRIPTION
## Summary

Two bugs prevented `acp_follow_agent_locations` from working reliably with ACP adapters like `claude-agent-acp`:

- **Locations arrive in `tool_call_update`, not `tool_call`**: Some ACP adapters (e.g. `@agentclientprotocol/claude-agent-acp`) send an empty `locations` array in the initial `tool_call` session update, then populate it in a subsequent `tool_call_update`. The follow logic only ran on `tool_call`, so it never saw the locations and the editor never navigated.

- **2000ms grace period is too aggressive for agentic mode**: In agentic mode, the agent frequently edits multiple files in rapid succession (often < 2s apart). The 2-second grace period caused all but the first follow to be silently skipped. Reduced to 200ms, which still prevents double-fires from the same tool call being reported twice.

## Changes

- Extract the follow logic into a reusable `try_follow_agent_location()` function
- Call it from both the `tool_call` and `tool_call_update` handlers
- For `tool_call_update`, merge with stored tool call data to recover the `kind` field when the update doesn't include it
- Reduce grace period from 2000ms to 200ms

## Test plan

- [x] Tested with `claude-agent-acp@0.44` as ACP provider — follow now navigates to edited files
- [x] Verified follow works when adapter sends locations in `tool_call_update`
- [x] Verified rapid successive edits (< 2s apart) are followed correctly
- [x] Verified 200ms debounce still prevents double-fire from same tool call
- [x] Verified non-edit tool calls (read, execute, search) do not trigger follow
- [x] Verified zen mode still suppresses follow