### PR TITLE
fix(openai): only send pending tool outputs with previous_response_id

### DIFF
--- a/lua/avante/providers/openai.lua
+++ b/lua/avante/providers/openai.lua
@@ -290,48 +290,41 @@ function M:parse_messages(opts)
       if #content > 0 then table.insert(messages, { role = self.role_map[msg.role], content = content }) end
       if not provider_conf.disable_tools and not use_ReAct_prompt then
         if #tool_calls > 0 then
-          -- Only skip tool_calls if using Response API with previous_response_id support
-          -- Copilot uses Response API format but doesn't support previous_response_id
-          local should_include_tool_calls = not use_response_api or not provider_conf.support_previous_response_id
+          if use_response_api then
+            -- Keep tool calls in the parsed history. parse_curl_args may send only
+            -- pending tool outputs with previous_response_id, but full-history
+            -- fallback still needs each output paired with its function_call.
+            for _, tool_call in ipairs(tool_calls) do
+              table.insert(messages, {
+                type = "function_call",
+                call_id = tool_call.id,
+                name = tool_call["function"].name,
+                arguments = tool_call["function"].arguments,
+              })
+            end
+          else
+            -- Chat Completions API format
+            local last_message = messages[#messages]
+            if last_message and last_message.role == self.role_map["assistant"] and last_message.tool_calls then
+              last_message.tool_calls = vim.list_extend(last_message.tool_calls, tool_calls)
 
-          if should_include_tool_calls then
-            -- For Response API without previous_response_id support (like Copilot),
-            -- convert tool_calls to function_call items in input
-            if use_response_api then
-              for _, tool_call in ipairs(tool_calls) do
-                table.insert(messages, {
-                  type = "function_call",
-                  call_id = tool_call.id,
-                  name = tool_call["function"].name,
-                  arguments = tool_call["function"].arguments,
-                })
-              end
+              last_message.reasoning_content = pending_reasoning_content or ""
+              pending_reasoning_content = nil
+
+              if not last_message.content then last_message.content = "" end
             else
-              -- Chat Completions API format
-              local last_message = messages[#messages]
-              if last_message and last_message.role == self.role_map["assistant"] and last_message.tool_calls then
-                last_message.tool_calls = vim.list_extend(last_message.tool_calls, tool_calls)
+              local tool_call_message = {
+                role = self.role_map["assistant"],
+                tool_calls = tool_calls,
+                content = "",
+              }
 
-                last_message.reasoning_content = pending_reasoning_content or ""
-                pending_reasoning_content = nil
+              tool_call_message.reasoning_content = pending_reasoning_content or ""
+              pending_reasoning_content = nil
 
-                if not last_message.content then last_message.content = "" end
-              else
-                local tool_call_message = {
-                  role = self.role_map["assistant"],
-                  tool_calls = tool_calls,
-                  content = "",
-                }
-
-                tool_call_message.reasoning_content = pending_reasoning_content or ""
-                pending_reasoning_content = nil
-
-                table.insert(messages, tool_call_message)
-              end
+              table.insert(messages, tool_call_message)
             end
           end
-          -- If support_previous_response_id is true, Response API manages function call history
-          -- So we can skip adding tool_calls to input messages
         end
         if #tool_results > 0 then
           for _, tool_result in ipairs(tool_results) do
@@ -583,6 +576,20 @@ function M.transform_openai_usage(usage)
     -- total_tokens is the sum of both
   }
   return res
+end
+
+---@param messages AvanteOpenAIMessage[]
+---@return AvanteOpenAIMessage[]
+local function get_trailing_function_outputs(messages)
+  local function_outputs = {}
+
+  for idx = #messages, 1, -1 do
+    local msg = messages[idx]
+    if msg.type ~= "function_call_output" then break end
+    table.insert(function_outputs, 1, msg)
+  end
+
+  return function_outputs
 end
 
 --- Parse response
@@ -885,28 +892,24 @@ function M:parse_curl_args(prompt_opts)
 
   -- Response API uses 'input' instead of 'messages'
   if use_response_api then
-    -- Check if we have tool results - if so, use previous_response_id
-    local has_function_outputs = false
-    for _, msg in ipairs(parsed_messages) do
-      if msg.type == "function_call_output" then
-        has_function_outputs = true
-        break
-      end
-    end
+    local pending_function_outputs = get_trailing_function_outputs(parsed_messages)
 
-    if has_function_outputs and self.last_response_id then
+    if
+      #pending_function_outputs > 0
+      and self.last_response_id
+      and provider_conf.support_previous_response_id ~= false
+    then
       -- When sending function outputs, use previous_response_id
       base_body.previous_response_id = self.last_response_id
-      -- Only send the function outputs, not the full history
-      local function_outputs = {}
-      for _, msg in ipairs(parsed_messages) do
-        if msg.type == "function_call_output" then table.insert(function_outputs, msg) end
-      end
-      base_body.input = function_outputs
+      -- Only send outputs for the immediately pending tool calls, not every
+      -- historical tool output in the chat.
+      base_body.input = pending_function_outputs
       -- Clear the stored response_id after using it
       self.last_response_id = nil
     else
-      -- Normal request without tool results
+      -- Normal request, or fallback when previous_response_id is unavailable.
+      -- parse_messages keeps function_call items so full-history tool output
+      -- replay remains valid.
       base_body.input = parsed_messages
     end
 


### PR DESCRIPTION
## Problem

When using the OpenAI **Response API** (`use_response_api = true`), multi-turn tool conversations break in a few related ways:

1. **`parse_curl_args` re-sends the entire tool-output history.** It scanned all `parsed_messages` for `function_call_output` items and sent *every* one alongside `previous_response_id`. But `previous_response_id` already represents the server-side state of the prior turn, so re-sending all historical outputs causes `400` errors (e.g. *"previous response not found"*, #3021) and duplicated outputs.

2. **`support_previous_response_id` was never checked in `parse_curl_args`.** The branch was gated only on `has_function_outputs and self.last_response_id`. Since `last_response_id` is populated on every response regardless of provider, a provider configured with `support_previous_response_id = false` (e.g. Copilot, #2805) would still incorrectly take the `previous_response_id` path.

3. **`parse_messages` dropped `function_call` items** whenever `support_previous_response_id` was truthy. That left the full-history fallback emitting `function_call_output` items with no paired `function_call`, which the API rejects.

## Fix

- Always keep `function_call` items in the parsed Response API history, so the full-history fallback stays valid.
- Add a small `get_trailing_function_outputs` helper that extracts only the **trailing (pending)** outputs for the current turn.
- Take the `previous_response_id` path only when there are pending outputs, a stored `last_response_id`, **and** `support_previous_response_id ~= false`; otherwise send the full history.

Net effect: when continuing a turn statefully, only the pending tool outputs are sent with `previous_response_id`; when a provider can't use it, the full (and now valid) history is sent instead.

## Testing

Manually verified against the OpenAI Response API (`gpt-5.x`, `use_response_api = true`, `support_previous_response_id = true`) — multi-step agentic tool conversations that previously failed with `400` now complete. The `parse_messages` change is a structural simplification (one fewer branch) and the new helper is self-contained.

Refs #3021, #2805