### PR TITLE
fix: Update avante's winbar after selecting new provider

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -93,6 +93,7 @@ docgen:
 		lua/avante/libs/acp_client.lua \
 		lua/avante/providers/openai.lua \
 		lua/avante/providers/claude.lua \
+		lua/avante/html2md.lua \
 		> doc/avante.txt
 	nvim -u NONE -i NONE --headless +'helptags doc' +'quit!'
 

--- a/doc/avante.txt
+++ b/doc/avante.txt
@@ -159,6 +159,7 @@ avante custom prompts ·····························
 avante utilities ················································ |avante-utils|
 avante ACP ························································ |avante-acp|
 avante claude ········································ |avante-providers-claude|
+Converts html to markdown ····································· |avante-html2md|
 
 Avante                                                                  *Avante*
 
@@ -827,7 +828,10 @@ avante sidebar                                                  *avante-sidebar*
 avante.Sidebar                                                  *avante.Sidebar*
 
     Fields: ~
-        {id}                         (integer)
+        {id}                         (integer)                                                                                               This is avante's main view, a vertical column of several windows, most of the time:
+                                                                                                                                             1. the result
+                                                                                                                                             2. selected code
+                                                                                                                                             3. user input
         {augroup}                    (integer)
         {code}                       (avante.CodeState)
         {containers}                 ({result?:NuiSplit,todos?:NuiSplit,selected_code?:NuiSplit,selected_files?:NuiSplit,input?:NuiSplit})
@@ -1025,9 +1029,12 @@ Sidebar:apply({current_cursor})                           *avante-sidebar:apply*
 
 
 Sidebar:render_header()                           *avante-sidebar:render_header*
+    When include_model is set, in ACP mode, model will be rendered as "model | mode"
+    else it will be set as
 
 
 Sidebar:render_result()                           *avante-sidebar:render_result*
+     @see render_header
 
 
 Sidebar:render_input({ask?})                       *avante-sidebar:render_input*
@@ -3419,6 +3426,30 @@ M.store_tokens()                          *avante-providers-claude.store_tokens*
 
 
 M.cleanup_claude()                      *avante-providers-claude.cleanup_claude*
+
+
+==============================================================================
+Converts html to markdown                                       *avante-html2md*
+
+ Loads the rust library html2md.so which is a glorified wrapper over
+ https://gitlab.com/Kanedias/html2md to convert simple html documents into markdown flavor.
+
+AvanteHtml2Md                                                    *AvanteHtml2Md*
+
+    Fields: ~
+        {fetch_md}  (fun(url:string):string)
+
+
+M._init_html2md_lib()                         *avante-html2md._init_html2md_lib*
+
+    Returns: ~
+        (AvanteHtml2Md|nil)
+
+
+M.setup()                                                 *avante-html2md.setup*
+
+
+M.fetch_md()                                           *avante-html2md.fetch_md*
 
 
 vim:tw=78:ts=8:noet:ft=help:norl:

--- a/lua/avante/html2md.lua
+++ b/lua/avante/html2md.lua
@@ -1,3 +1,8 @@
+---@mod avante-html2md Converts html to markdown
+---@brief [[
+--- Loads the rust library html2md.so which is a glorified wrapper over
+--- https://gitlab.com/Kanedias/html2md to convert simple html documents into markdown flavor.
+---@brief ]]
 ---@class AvanteHtml2Md
 ---@field fetch_md fun(url: string): string
 local _html2md_lib = nil

--- a/lua/avante/providers/init.lua
+++ b/lua/avante/providers/init.lua
@@ -237,6 +237,8 @@ function M.refresh(provider_name)
     local p = M[Config.provider]
     E.setup({ provider = p, refresh = true })
   end
+  local sidebar = require("avante").get()
+  if sidebar and sidebar:is_open() then sidebar:render_result() end
   Utils.info("Switch to provider: " .. provider_name, { once = true, title = "Avante" })
 end
 

--- a/lua/avante/repo_map.lua
+++ b/lua/avante/repo_map.lua
@@ -1,3 +1,11 @@
+---@mod avante-repo-map Summarize codebase
+---@brief [[
+--- Generate a summary of your codebase via an avante rust library.
+--- Builds upon treesitter to list nodes.
+--- Run 'AvanteShowRepoMap' to see the result. You can also reference
+--- @codebase in the input container.
+---]]
+---@see AvanteShowRepoMap
 local Popup = require("nui.popup")
 local Utils = require("avante.utils")
 local event = require("nui.utils.autocmd").event

--- a/lua/avante/sidebar.lua
+++ b/lua/avante/sidebar.lua
@@ -113,6 +113,10 @@ local SIDEBAR_CONTAINERS = {
 }
 
 ---@class avante.Sidebar
+--- This is avante's main view, a vertical column of several windows, most of the time:
+--- 1. the result
+--- 2. selected code
+--- 3. user input
 ---@field id integer
 ---@field augroup integer
 ---@field code avante.CodeState
@@ -1076,6 +1080,12 @@ local base_win_options = {
   statusline = vim.o.laststatus == 0 and " " or "",
 }
 
+---Sets 'winbar' for any sidebar container
+---If `windows.sidebar_header.include_model` is set, the bar will show the currently selected model
+---@param header_text string Leftmost default string
+---@param opts table?
+---When include_model is set, in ACP mode, model will be rendered as "model | mode"
+---else it will be set as
 function Sidebar:render_header(winid, bufnr, header_text, hl, reverse_hl, opts)
   opts = vim.tbl_extend("force", { include_model = false }, opts or {})
   if not Config.windows.sidebar_header.enabled then return end
@@ -1130,6 +1140,7 @@ function Sidebar:render_header(winid, bufnr, header_text, hl, reverse_hl, opts)
   api.nvim_set_option_value("winbar", winbar_text, { win = winid })
 end
 
+--- @see render_header
 function Sidebar:render_result()
   if not Utils.is_valid_container(self.containers.result) then return end
   local header_text = Utils.icon("󰭻 ") .. "Avante"

--- a/tests/providers/init_spec.lua
+++ b/tests/providers/init_spec.lua
@@ -1,0 +1,61 @@
+describe("providers", function()
+  local Config
+  local previous_avante
+  local previous_avante_module
+
+  before_each(function()
+    previous_avante = vim.g.avante
+    previous_avante_module = package.loaded["avante"]
+    package.loaded["avante.config"] = nil
+    package.loaded["avante.providers"] = nil
+
+    Config = require("avante.config")
+    Config.get_last_used_model = function() end
+    Config.setup({
+      provider = "test_openai",
+      providers = {
+        test_openai = {
+          api_key_name = "",
+          model = "gpt-test",
+          parse_curl_args = function() end,
+          setup = function() end,
+        },
+        test_claude = {
+          api_key_name = "",
+          model = "claude-test",
+          parse_curl_args = function() end,
+          setup = function() end,
+        },
+      },
+      windows = {
+        sidebar_header = {
+          include_model = true,
+        },
+      },
+    })
+  end)
+
+  after_each(function()
+    vim.g.avante = previous_avante
+    package.loaded["avante"] = previous_avante_module
+    package.loaded["avante.config"] = nil
+    package.loaded["avante.providers"] = nil
+  end)
+
+  it("redraws the sidebar header after switching providers", function()
+    local rendered = 0
+    package.loaded["avante"] = {
+      get = function()
+        return {
+          is_open = function() return true end,
+          render_result = function() rendered = rendered + 1 end,
+        }
+      end,
+    }
+
+    require("avante.providers").refresh("test_claude")
+
+    assert.are.same("test_claude", Config.provider)
+    assert.are.same(1, rendered)
+  end)
+end)


### PR DESCRIPTION
Before: switching provider, the winbar would still show the old model when "vim.g.avante.windows.sidebar_header.include_model" is set to true After: update winbar content