### PR TITLE
fix(acp): terminate launcher process trees

### DIFF
--- a/lua/avante/libs/acp_client.lua
+++ b/lua/avante/libs/acp_client.lua
@@ -368,6 +368,8 @@ function ACPClient:_create_stdio_transport()
     stdout = nil,
     --- @type uv.uv_process_t|nil
     process = nil,
+    --- @type integer|nil
+    pid = nil,
   }
 
   --- @param transport_self avante.acp.ACPTransportInstance
@@ -412,6 +414,9 @@ function ACPClient:_create_stdio_transport()
     ---@diagnostic disable-next-line: missing-fields
     local handle, pid = uv.spawn(self.config.command, {
       args = args,
+      -- A separate process group lets us clean up ACP launchers and every
+      -- subprocess they create. Windows keeps the existing direct-child path.
+      detached = vim.fn.has("win32") == 0,
       env = final_env,
       stdio = { stdin, stdout, stderr },
     }, function(code, signal)
@@ -422,6 +427,7 @@ function ACPClient:_create_stdio_transport()
         transport_self.process:close()
         transport_self.process = nil
       end
+      transport_self.pid = nil
 
       -- Handle auto-reconnect
       if self.config.reconnect and self.reconnect_count < (self.config.max_reconnect_attempts or 3) then
@@ -440,6 +446,7 @@ function ACPClient:_create_stdio_transport()
     end
 
     transport_self.process = handle
+    transport_self.pid = pid
     transport_self.stdin = stdin
     transport_self.stdout = stdout
 
@@ -492,14 +499,22 @@ function ACPClient:_create_stdio_transport()
   function transport.stop(transport_self)
     if transport_self.process and not transport_self.process:is_closing() then
       local process = transport_self.process
+      local pid = transport_self.pid
       transport_self.process = nil
+      transport_self.pid = nil
 
       if not process then return end
 
-      -- Try to terminate gracefully
-      pcall(function() process:kill(15) end)
-      -- then force kill, it'll fail harmlessly if already exited
-      pcall(function() process:kill(9) end)
+      if vim.fn.has("win32") == 0 and pid then
+        -- The ACP command is a process-group leader on POSIX. Kill the group
+        -- so package-manager launchers cannot leave their native child behind.
+        pcall(function() uv.kill(-pid, 15) end)
+        pcall(function() uv.kill(-pid, 9) end)
+      else
+        -- Windows does not support POSIX process-group signals.
+        pcall(function() process:kill(15) end)
+        pcall(function() process:kill(9) end)
+      end
       process:close()
     end
     if transport_self.stdin then

--- a/tests/libs/acp_client_spec.lua
+++ b/tests/libs/acp_client_spec.lua
@@ -370,4 +370,59 @@ describe("ACPClient", function()
       assert.same({}, sent_params.mcpServers)
     end)
   end)
+
+  describe("stdio process lifecycle", function()
+    local uv = vim.uv or vim.loop
+    local temp_dir
+    local child_pid
+    local transport
+
+    after_each(function()
+      if transport then pcall(function() transport:stop() end) end
+      if child_pid and uv.kill(child_pid, 0) == 0 then pcall(function() uv.kill(child_pid, 9) end) end
+      if temp_dir then vim.fs.rm(temp_dir, { recursive = true, force = true }) end
+    end)
+
+    it("stops subprocesses created by an ACP launcher", function()
+      if vim.fn.has("win32") == 1 then return end
+
+      temp_dir = vim.fn.tempname()
+      local launcher = vim.fs.joinpath(temp_dir, "acp-launcher.sh")
+      local child_pid_file = vim.fs.joinpath(temp_dir, "child.pid")
+
+      vim.fn.mkdir(temp_dir, "p")
+      vim.fn.writefile({
+        "#!/bin/sh",
+        "sleep 60 &",
+        'printf "%s\\n" "$!" > "$1"',
+        'wait "$!"',
+      }, launcher)
+      assert.equals(true, uv.fs_chmod(launcher, 493))
+
+      local client = ACPClient:new({
+        transport_type = "stdio",
+        command = launcher,
+        args = { child_pid_file },
+      })
+      transport = client:_create_stdio_transport()
+      transport:start(function() end)
+
+      assert.equals(
+        true,
+        vim.wait(2000, function() return uv.fs_stat(child_pid_file) ~= nil end, 20),
+        "ACP launcher did not report its child PID"
+      )
+      child_pid = tonumber(vim.fn.readfile(child_pid_file)[1])
+      assert.is_not_nil(child_pid)
+      assert.equals(0, uv.kill(child_pid, 0))
+
+      transport:stop()
+
+      assert.equals(
+        true,
+        vim.wait(2000, function() return uv.kill(child_pid, 0) == nil end, 20),
+        "ACP launcher child survived transport shutdown"
+      )
+    end)
+  end)
 end)


### PR DESCRIPTION
## What changed

- Spawn POSIX stdio ACP commands as process-group leaders.
- Track the spawned PID alongside the libuv process handle.
- Signal the complete process group during `transport.stop()` on Linux/macOS.
- Preserve the existing direct-child shutdown behavior on Windows.
- Add a regression test whose ACP launcher creates a child process and assert that the child does not survive shutdown.

## Why

Avante currently stops only the direct process returned by `uv.spawn`. Package-manager and JavaScript launchers can create a native child process, so stopping Avante or exiting Neovim may kill the launcher while leaving its child alive and reparented to PID 1.

A concrete example is `@zed-industries/codex-acp@0.16.0`: its JavaScript launcher uses `spawnSync` to execute the platform-native `codex-acp` binary. Repeated Avante sessions can therefore accumulate native processes even though the existing `VimLeavePre` cleanup runs.

This extends the cleanup introduced for #2749 from direct-child cleanup to process-tree cleanup on POSIX.

Closes #3168.

## User impact

Closing an ACP client or exiting Neovim no longer leaves subprocesses created by ACP launchers running in the background on Linux/macOS.

## Validation

- `make luastylecheck`
- `./scripts/run-luatest.sh tests/libs/acp_client_spec.lua` — 13 successes, 0 failures
- Full Lua test run — 230 successes, 0 failures; the local environment emitted unrelated Docker-unavailable callback warnings
- Reproduced originally on Linux ARM64 with Neovim 0.11 and `@zed-industries/codex-acp@0.16.0`
