### PR TITLE
Add Pack config example

### DIFF
--- a/README.md
+++ b/README.md
@@ -260,14 +260,13 @@ vim.pack.add({
   -- Deps
   'https://github.com/nvim-lua/plenary.nvim',
   'https://github.com/MunifTanjim/nui.nvim',
-  'https://github.com/MeanderingProgrammer/render-markdown.nvim',
 
   -- Optional deps
+  'https://github.com/MeanderingProgrammer/render-markdown.nvim',
   'https://github.com/hrsh7th/nvim-cmp',
   'https://github.com/nvim-tree/nvim-web-devicons', -- or 'echasnovski/mini.icons'
   'https://github.com/HakonHarnes/img-clip.nvim',
   'https://github.com/zbirenbaum/copilot.lua',
-  'https://github.com/stevearc/dressing.nvim', -- for enhanced input UI
   'https://github.com/folke/snacks.nvim', -- for modern input UI
 })
 

--- a/README.md
+++ b/README.md
@@ -238,42 +238,43 @@ For building binary if you wish to build from source, then `cargo` is required. 
 Pack is an out-of-the-box plugin manager since Neovim v0.12.
 
 ```lua
-local avante_hook = function(ev)
-  local name, kind = ev.data.spec.name, ev.data.kind
-  if name == 'avante.nvim' and (kind == 'install' or kind == 'update') then
-    -- Use `make BUILD_FROM_SOURCE=true` to build from source
-    vim.system({ 'make' }, { cwd = ev.data.path }):wait()
-  end
-end
-
-vim.api.nvim_create_autocmd('PackChanged', { callback = avante_hook })
-
-local gh = function(x) return 'https://github.com/' .. x end
+vim.api.nvim_create_autocmd(
+  'PackChanged',
+  {
+    callback = function(ev)
+      local name, kind = ev.data.spec.name, ev.data.kind
+      if name == 'avante.nvim' and (kind == 'install' or kind == 'update') then
+        -- Use `make BUILD_FROM_SOURCE=true` to build from source
+        vim.system({ 'make' }, { cwd = ev.data.path }):wait()
+      end
+    end
+  }
+)
 
 vim.pack.add({
   {
-    src=gh('yetone/avante.nvim'),
+    src='https://github.com/yetone/avante.nvim',
     version='main'  -- default
   },
 
   -- Deps
-  gh('nvim-lua/plenary.nvim'),
-  gh('MunifTanjim/nui.nvim'),
-  gh('MeanderingProgrammer/render-markdown.nvim'),
+  'https://github.com/nvim-lua/plenary.nvim',
+  'https://github.com/MunifTanjim/nui.nvim',
+  'https://github.com/MeanderingProgrammer/render-markdown.nvim',
 
   -- Optional deps
-  gh('hrsh7th/nvim-cmp'),
-  gh('nvim-tree/nvim-web-devicons'), -- or 'echasnovski/mini.icons'
-  gh('HakonHarnes/img-clip.nvim'),
-  gh('zbirenbaum/copilot.lua'),
-  gh('stevearc/dressing.nvim'), -- for enhanced input UI
-  gh('folke/snacks.nvim'), -- for modern input UI
+  'https://github.com/hrsh7th/nvim-cmp',
+  'https://github.com/nvim-tree/nvim-web-devicons', -- or 'echasnovski/mini.icons'
+  'https://github.com/HakonHarnes/img-clip.nvim',
+  'https://github.com/zbirenbaum/copilot.lua',
+  'https://github.com/stevearc/dressing.nvim', -- for enhanced input UI
+  'https://github.com/folke/snacks.nvim', -- for modern input UI
 })
 
 -- Config customizations
 require('avante').setup({})
 ```
-  
+
 </details>
 
 <details>

--- a/README.md
+++ b/README.md
@@ -233,6 +233,51 @@ For building binary if you wish to build from source, then `cargo` is required. 
 
 <details>
 
+  <summary><a href="https://neovim.io/doc/user/pack/">Pack</a></summary>
+
+Pack is an out-of-the-box plugin manager since Neovim v0.12.
+
+```lua
+local avante_hook = function(ev)
+  local name, kind = ev.data.spec.name, ev.data.kind
+  if name == 'avante.nvim' and (kind == 'install' or kind == 'update') then
+    -- Use `make BUILD_FROM_SOURCE=true` to build from source
+    vim.system({ 'make' }, { cwd = ev.data.path }):wait()
+  end
+end
+
+vim.api.nvim_create_autocmd('PackChanged', { callback = avante_hook })
+
+local gh = function(x) return 'https://github.com/' .. x end
+
+vim.pack.add({
+  {
+    src=gh('yetone/avante.nvim'),
+    version='main'  -- default
+  },
+
+  -- Deps
+  gh('nvim-lua/plenary.nvim'),
+  gh('MunifTanjim/nui.nvim'),
+  gh('MeanderingProgrammer/render-markdown.nvim'),
+
+  -- Optional deps
+  gh('hrsh7th/nvim-cmp'),
+  gh('nvim-tree/nvim-web-devicons'), -- or 'echasnovski/mini.icons'
+  gh('HakonHarnes/img-clip.nvim'),
+  gh('zbirenbaum/copilot.lua'),
+  gh('stevearc/dressing.nvim'), -- for enhanced input UI
+  gh('folke/snacks.nvim'), -- for modern input UI
+})
+
+-- Config customizations
+require('avante').setup({})
+```
+  
+</details>
+
+<details>
+
   <summary><a href="https://github.com/lumen-oss/rocks.nvim">rocks.nvim</a></summary>
 
 Run `:Rocks install avante.nvim` then add to your init.lua:


### PR DESCRIPTION
Satisfies #3091. Config example for Pack — the brand new official plugin manager. Only English `README.md` patch.